### PR TITLE
Fix bug in min of DateColumn

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/DateColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateColumn.java
@@ -235,12 +235,18 @@ public class DateColumn extends AbstractColumn implements DateMapUtils {
             return null;
         }
 
-        int max = getIntInternal(0);
+        Integer max = null;
         for (int aData : data) {
-            max = (max > aData) ? max : aData;
+            if (DateColumn.MISSING_VALUE != aData) {
+                if (max == null) {
+                    max = aData;
+                } else {
+                    max = (max > aData) ? max : aData;
+                }
+            }
         }
 
-        if (DateColumn.MISSING_VALUE == max) {
+        if (max == null) {
             return null;
         }
         return PackedLocalDate.asLocalDate(max);
@@ -251,11 +257,17 @@ public class DateColumn extends AbstractColumn implements DateMapUtils {
             return null;
         }
 
-        int min = getIntInternal(0);
+        Integer min = null;
         for (int aData : data) {
-            min = (min < aData) ? min : aData;
+            if (DateColumn.MISSING_VALUE != aData) {
+                if (min == null) {
+                    min = aData;
+                } else {
+                    min = (min < aData) ? min : aData;
+                }
+            }
         }
-        if (DateColumn.MISSING_VALUE == min) {
+        if (min == null) {
             return null;
         }
         return PackedLocalDate.asLocalDate(min);

--- a/core/src/test/java/tech/tablesaw/api/DateColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DateColumnTest.java
@@ -16,6 +16,7 @@ package tech.tablesaw.api;
 
 import org.junit.Before;
 import org.junit.Test;
+import tech.tablesaw.columns.packeddata.PackedLocalDate;
 
 import java.time.LocalDate;
 import java.util.Locale;
@@ -96,5 +97,15 @@ public class DateColumnTest {
         assertEquals(2, summary.columnCount());
         assertEquals("Measure", summary.column(0).name());
         assertEquals("Value", summary.column(1).name());
+    }
+
+    @Test
+    public void testMin() {
+        column1.appendInternal(DateColumn.MISSING_VALUE);
+        column1.appendCell("2013-10-23");
+
+        LocalDate actual = column1.min();
+
+        assertEquals(PackedLocalDate.asLocalDate(column1.convert("2013-10-23")), actual);
     }
 }


### PR DESCRIPTION
I realised that code I "refactored"  yesterday had a bug. Actually, I changed the logic so now it occurs more frequently. Because missing value for DateColumn is set to Integer.MIN_VALUE whenever there is such value in a column "min" method is returning it. Before it was doing so only when the first value was missing.

Now I've fixed it and added test for it.