### PR TITLE
Generic subtract

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
@@ -669,10 +669,24 @@ public class DoubleColumn extends AbstractColumn implements DoubleIterable, Nume
     }
 
     @Override
-    public float getFloat(int index) {
-        return (float) data.getDouble(index);
+    public int getInt(int index) {
+        double value = data.getDouble(index);
+        return Double.isNaN(value) ? IntColumn.MISSING_VALUE : (int) value;
     }
 
+    @Override
+    public long getLong(int index) {
+        double value = data.getDouble(index);
+        return Double.isNaN(value) ? LongColumn.MISSING_VALUE : (long) value;
+    }
+
+    @Override
+    public float getFloat(int index) {
+        double value = data.getDouble(index);
+        return Double.isNaN(value) ? FloatColumn.MISSING_VALUE : (float) value;
+    }
+
+    @Override
     public double getDouble(int index) {
         return data.getDouble(index);
     }

--- a/core/src/main/java/tech/tablesaw/api/FloatColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/FloatColumn.java
@@ -667,8 +667,26 @@ public class FloatColumn extends AbstractColumn implements FloatIterable, Numeri
     }
 
     @Override
+    public int getInt(int index) {
+        float value = data.getFloat(index);
+        return Float.isNaN(value) ? IntColumn.MISSING_VALUE : (int) value;
+    }
+
+    @Override
+    public long getLong(int index) {
+        float value = data.getFloat(index);
+        return Float.isNaN(value) ? LongColumn.MISSING_VALUE : (long) value;
+    }
+
+    @Override
     public float getFloat(int index) {
         return data.getFloat(index);
+    }
+
+    @Override
+    public double getDouble(int index) {
+        float value = data.getFloat(index);
+        return Float.isNaN(value) ? DoubleColumn.MISSING_VALUE : value;
     }
 
     public void set(int r, float value) {

--- a/core/src/main/java/tech/tablesaw/api/IntColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/IntColumn.java
@@ -328,19 +328,19 @@ public class IntColumn extends AbstractColumn implements IntMapUtils, NumericCol
     @Override
     public float getFloat(int index) {
         int value = data.getInt(index);
-        return value == IntColumn.MISSING_VALUE ? FloatColumn.MISSING_VALUE : (float) value;
+        return value == MISSING_VALUE ? FloatColumn.MISSING_VALUE : (float) value;
     }
 
     @Override
     public long getLong(int index) {
         int value = data.getInt(index);
-        return value == IntColumn.MISSING_VALUE ? LongColumn.MISSING_VALUE : value;
+        return value == MISSING_VALUE ? LongColumn.MISSING_VALUE : value;
     }
 
     @Override
     public double getDouble(int index) {
         int value = data.getInt(index);
-        return value == IntColumn.MISSING_VALUE ? DoubleColumn.MISSING_VALUE : (float) value;
+        return value == MISSING_VALUE ? DoubleColumn.MISSING_VALUE : (float) value;
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/api/IntColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/IntColumn.java
@@ -321,8 +321,26 @@ public class IntColumn extends AbstractColumn implements IntMapUtils, NumericCol
     }
 
     @Override
+    public int getInt(int index) {
+        return data.getInt(index);
+    }
+
+    @Override
     public float getFloat(int index) {
-        return (float) data.getInt(index);
+        int value = data.getInt(index);
+        return value == IntColumn.MISSING_VALUE ? FloatColumn.MISSING_VALUE : (float) value;
+    }
+
+    @Override
+    public long getLong(int index) {
+        int value = data.getInt(index);
+        return value == IntColumn.MISSING_VALUE ? LongColumn.MISSING_VALUE : value;
+    }
+
+    @Override
+    public double getDouble(int index) {
+        int value = data.getInt(index);
+        return value == IntColumn.MISSING_VALUE ? DoubleColumn.MISSING_VALUE : (float) value;
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/api/LongColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/LongColumn.java
@@ -244,10 +244,10 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
         return result;
     }
 
-    public LongColumn subtract(LongColumn column2) {
+    public LongColumn subtract(NumericColumn column2) {
         LongColumn result = new LongColumn(name() + " - " + column2.name(), size());
-        for (int r = 0; r < size(); r++) {
-            result.append(subtract(get(r), column2.get(r)));
+        for (int r = 0; r < size() && r < column2.size(); r++) {
+            result.append(subtract(get(r), column2.getLong(r)));
         }
         return result;
     }

--- a/core/src/main/java/tech/tablesaw/api/LongColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/LongColumn.java
@@ -412,13 +412,13 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
     @Override
     public int getInt(int index) {
         double value = data.getLong(index);
-        return value == LongColumn.MISSING_VALUE ? IntColumn.MISSING_VALUE : (int) value;
+        return value == MISSING_VALUE ? IntColumn.MISSING_VALUE : (int) value;
     }
 
     @Override
     public float getFloat(int index) {
         double value = data.getLong(index);
-        return value == LongColumn.MISSING_VALUE ? FloatColumn.MISSING_VALUE : (float) value;
+        return value == MISSING_VALUE ? FloatColumn.MISSING_VALUE : (float) value;
     }
 
     @Override
@@ -429,7 +429,7 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
     @Override
     public double getDouble(int index) {
         double value = data.getLong(index);
-        return value == LongColumn.MISSING_VALUE ? DoubleColumn.MISSING_VALUE : (float) value;
+        return value == MISSING_VALUE ? DoubleColumn.MISSING_VALUE : (float) value;
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/api/LongColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/LongColumn.java
@@ -410,8 +410,26 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
     }
 
     @Override
+    public int getInt(int index) {
+        double value = data.getLong(index);
+        return value == LongColumn.MISSING_VALUE ? IntColumn.MISSING_VALUE : (int) value;
+    }
+
+    @Override
     public float getFloat(int index) {
-        return (float) data.getLong(index);
+        double value = data.getLong(index);
+        return value == LongColumn.MISSING_VALUE ? FloatColumn.MISSING_VALUE : (float) value;
+    }
+
+    @Override
+    public long getLong(int index) {
+        return data.getLong(index);
+    }
+
+    @Override
+    public double getDouble(int index) {
+        double value = data.getLong(index);
+        return value == LongColumn.MISSING_VALUE ? DoubleColumn.MISSING_VALUE : (float) value;
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/api/NumericColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/NumericColumn.java
@@ -23,7 +23,21 @@ public interface NumericColumn extends Column {
 
     double[] toDoubleArray();
 
-    float getFloat(int index);
+    default int getInt(int index) {
+        throw new UnsupportedOperationException("getInt() method not supported for all data types");
+    }
+
+    default float getFloat(int index) {
+        throw new UnsupportedOperationException("getFloat() method not supported for all data types");
+    }
+
+    default long getLong(int index) {
+        throw new UnsupportedOperationException("getLong() method not supported for all data types");
+    }
+
+    default double getDouble(int index) {
+        throw new UnsupportedOperationException("getDouble() method not supported for all data types");
+    }
 
     double max();
 

--- a/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
@@ -460,7 +460,7 @@ public class DoubleColumnTest {
 
     @Test
     public void getLong() {
-        DoubleColumn column = createDoubleColumn(new double[]{20.2, 32452345.3, DoubleColumn.MISSING_VALUE, 234});
+        DoubleColumn column = createDoubleColumn(new double[]{20.2, 32452345.3, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20L, column.getLong(0));
         assertEquals("Primitive type conversion error", 32452345L, column.getLong(1));
         assertEquals("Primitive type conversion error", LongColumn.MISSING_VALUE, column.getLong(2));
@@ -469,7 +469,7 @@ public class DoubleColumnTest {
 
     @Test
     public void getInt() {
-        DoubleColumn column = createDoubleColumn(new double[]{20.2, 32452345.3, DoubleColumn.MISSING_VALUE, 234});
+        DoubleColumn column = createDoubleColumn(new double[]{20.2, 32452345.3, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20, column.getInt(0));
         assertEquals("Primitive type conversion error", 32452345, column.getInt(1));
         assertEquals("Primitive type conversion error", IntColumn.MISSING_VALUE, column.getInt(2));
@@ -478,7 +478,7 @@ public class DoubleColumnTest {
 
     @Test
     public void getFloat() {
-        DoubleColumn column = createDoubleColumn(new double[]{20.2, 32452345.3, DoubleColumn.MISSING_VALUE, 234});
+        DoubleColumn column = createDoubleColumn(new double[]{20.2, 32452345.3, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20.2, column.getFloat(0), 0.1);
         assertEquals("Primitive type conversion error", 32452345.3, column.getFloat(1), 1);
         assertTrue("Primitive type conversion error", Float.isNaN(column.getFloat(2)));

--- a/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
@@ -432,17 +432,14 @@ public class DoubleColumnTest {
     }
 
     @Test
-    public void testMissingValuesInColumn() {
+    public void testDifferenceMissingValuesInColumn() {
         double[] originalValues = new double[]{32, 42, MISSING_VALUE, 57, 52};
         double[] expectedValues = new double[]{MISSING_VALUE, 10, MISSING_VALUE, MISSING_VALUE, -5};
         assertTrue(computeAndValidateDifference(originalValues, expectedValues));
     }
 
     private boolean computeAndValidateDifference(double[] originalValues, double[] expectedValues) {
-        DoubleColumn initial = new DoubleColumn("Test", originalValues.length);
-        for (double value : originalValues) {
-            initial.append(value);
-        }
+        DoubleColumn initial = createDoubleColumn(originalValues);
 
         DoubleColumn difference = initial.difference();
         assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
@@ -459,5 +456,40 @@ public class DoubleColumnTest {
         DoubleColumn initial = new DoubleColumn("Test");
         DoubleColumn difference = initial.difference();
         assertEquals("Expecting empty data set.", 0, difference.size());
+    }
+
+    @Test
+    public void getLong() {
+        DoubleColumn column = createDoubleColumn(new double[]{20.2, 32452345.3, DoubleColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20L, column.getLong(0));
+        assertEquals("Primitive type conversion error", 32452345L, column.getLong(1));
+        assertEquals("Primitive type conversion error", LongColumn.MISSING_VALUE, column.getLong(2));
+        assertEquals("Primitive type conversion error", 234, column.getLong(3));
+    }
+
+    @Test
+    public void getInt() {
+        DoubleColumn column = createDoubleColumn(new double[]{20.2, 32452345.3, DoubleColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20, column.getInt(0));
+        assertEquals("Primitive type conversion error", 32452345, column.getInt(1));
+        assertEquals("Primitive type conversion error", IntColumn.MISSING_VALUE, column.getInt(2));
+        assertEquals("Primitive type conversion error", 234, column.getInt(3));
+    }
+
+    @Test
+    public void getFloat() {
+        DoubleColumn column = createDoubleColumn(new double[]{20.2, 32452345.3, DoubleColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.2, column.getFloat(0), 0.1);
+        assertEquals("Primitive type conversion error", 32452345.3, column.getFloat(1), 1);
+        assertTrue("Primitive type conversion error", Float.isNaN(column.getFloat(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getFloat(3), 0.1);
+    }
+
+    private DoubleColumn createDoubleColumn(double[] originalValues) {
+        DoubleColumn initial = new DoubleColumn("Test", originalValues.length);
+        for (double value : originalValues) {
+            initial.append(value);
+        }
+        return initial;
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
@@ -623,12 +623,9 @@ public class FloatColumnTest {
     }
 
     private boolean computeAndValidateDifference(float[] originalValues, float[] expectedValues) {
-        FloatColumn initial = new FloatColumn("Test", originalValues.length);
-        for (float value : originalValues) {
-            initial.append(value);
-        }
-
+        FloatColumn initial = createFloatColumn(originalValues);
         FloatColumn difference = initial.difference();
+
         assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
         for (int index = 0; index < difference.size(); index++) {
             float actual = difference.get(index);
@@ -643,5 +640,40 @@ public class FloatColumnTest {
         FloatColumn initial = new FloatColumn("Test");
         FloatColumn difference = initial.difference();
         assertEquals("Expecting empty data set.", 0, difference.size());
+    }
+
+    @Test
+    public void getInt() {
+        FloatColumn column = createFloatColumn(new float[]{20.2f, 3245234.3f, FloatColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20, column.getInt(0));
+        assertEquals("Primitive type conversion error", 3245234, column.getInt(1));
+        assertEquals("Primitive type conversion error", IntColumn.MISSING_VALUE, column.getInt(2));
+        assertEquals("Primitive type conversion error", 234, column.getInt(3));
+    }
+
+    @Test
+    public void getLong() {
+        FloatColumn column = createFloatColumn(new float[]{20.2f, 3245234.3f, FloatColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20L, column.getLong(0));
+        assertEquals("Primitive type conversion error", 3245234L, column.getLong(1));
+        assertEquals("Primitive type conversion error", LongColumn.MISSING_VALUE, column.getLong(2));
+        assertEquals("Primitive type conversion error", 234, column.getLong(3));
+    }
+
+    @Test
+    public void getFloat() {
+        FloatColumn column = createFloatColumn(new float[]{20.2f, 3245234.3f, FloatColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.2, column.getDouble(0), 0.1);
+        assertEquals("Primitive type conversion error", 3245234.3, column.getDouble(1), 1);
+        assertTrue("Primitive type conversion error", Double.isNaN(column.getDouble(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getDouble(3), 0.1);
+    }
+
+    private FloatColumn createFloatColumn(float[] originalValues) {
+        FloatColumn initial = new FloatColumn("Test", originalValues.length);
+        for (float value : originalValues) {
+            initial.append(value);
+        }
+        return initial;
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
@@ -644,7 +644,7 @@ public class FloatColumnTest {
 
     @Test
     public void getInt() {
-        FloatColumn column = createFloatColumn(new float[]{20.2f, 3245234.3f, FloatColumn.MISSING_VALUE, 234});
+        FloatColumn column = createFloatColumn(new float[]{20.2f, 3245234.3f, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20, column.getInt(0));
         assertEquals("Primitive type conversion error", 3245234, column.getInt(1));
         assertEquals("Primitive type conversion error", IntColumn.MISSING_VALUE, column.getInt(2));
@@ -653,7 +653,7 @@ public class FloatColumnTest {
 
     @Test
     public void getLong() {
-        FloatColumn column = createFloatColumn(new float[]{20.2f, 3245234.3f, FloatColumn.MISSING_VALUE, 234});
+        FloatColumn column = createFloatColumn(new float[]{20.2f, 3245234.3f, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20L, column.getLong(0));
         assertEquals("Primitive type conversion error", 3245234L, column.getLong(1));
         assertEquals("Primitive type conversion error", LongColumn.MISSING_VALUE, column.getLong(2));
@@ -662,7 +662,7 @@ public class FloatColumnTest {
 
     @Test
     public void getFloat() {
-        FloatColumn column = createFloatColumn(new float[]{20.2f, 3245234.3f, FloatColumn.MISSING_VALUE, 234});
+        FloatColumn column = createFloatColumn(new float[]{20.2f, 3245234.3f, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20.2, column.getDouble(0), 0.1);
         assertEquals("Primitive type conversion error", 3245234.3, column.getDouble(1), 1);
         assertTrue("Primitive type conversion error", Double.isNaN(column.getDouble(2)));

--- a/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
@@ -21,6 +21,8 @@ import tech.tablesaw.filtering.IntPredicate;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.*;
 import static tech.tablesaw.api.IntColumn.MISSING_VALUE;
 import static tech.tablesaw.api.QueryHelper.column;
@@ -163,10 +165,8 @@ public class IntColumnTest {
     }
 
     private boolean computeAndValidateDifference(int[] originalValues, int[] expectedValues) {
-        IntColumn initial = new IntColumn("Test", originalValues.length);
-        for (int value : originalValues) {
-            initial.append(value);
-        }
+        IntColumn initial = createIntColumn(originalValues);
+
         IntColumn difference = initial.difference();
         assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
         for (int index = 0; index < difference.size(); index++) {
@@ -216,5 +216,38 @@ public class IntColumnTest {
         IntColumn originals = new IntColumn("Originals", new IntArrayList(originalValues));
         FloatColumn divided = originals.divide(3.3);
         assertEquals(originals.size(), divided.size());
+    }
+
+    @Test
+    public void testGetLong() {
+        IntColumn column = createIntColumn(new int[]{20, 32452345, IntColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20, column.getLong(0));
+        assertEquals("Primitive type conversion error", 32452345, column.getLong(1));
+        assertEquals("Primitive type conversion error", LongColumn.MISSING_VALUE, column.getLong(2));
+        assertEquals("Primitive type conversion error", 234, column.getLong(3));
+    }
+
+    @Test
+    public void testGetFloat() {
+        IntColumn column = createIntColumn(new int[]{20, 32452345, IntColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.0, column.getFloat(0), 0.1);
+        assertEquals("Primitive type conversion error", 32452345.0, column.getFloat(1), 1);
+        assertTrue("Primitive type conversion error", Float.isNaN(column.getFloat(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getFloat(3), 0.1);
+    }
+
+    @Test
+    public void testGetDouble() {
+        IntColumn column = createIntColumn(new int[]{20, 32452345, IntColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.0, column.getDouble(0), 0.1);
+        assertEquals("Primitive type conversion error", 32452345.0, column.getDouble(1), 1);
+        assertTrue("Primitive type conversion error", Double.isNaN(column.getDouble(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getDouble(3), 0.1);
+    }
+
+    private IntColumn createIntColumn(int[] values) {
+        IntColumn column = new IntColumn("Test", values.length);
+        Arrays.stream(values).forEach(column::append);
+        return column;
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
@@ -220,7 +220,7 @@ public class IntColumnTest {
 
     @Test
     public void testGetLong() {
-        IntColumn column = createIntColumn(new int[]{20, 32452345, IntColumn.MISSING_VALUE, 234});
+        IntColumn column = createIntColumn(new int[]{20, 32452345, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20, column.getLong(0));
         assertEquals("Primitive type conversion error", 32452345, column.getLong(1));
         assertEquals("Primitive type conversion error", LongColumn.MISSING_VALUE, column.getLong(2));
@@ -229,7 +229,7 @@ public class IntColumnTest {
 
     @Test
     public void testGetFloat() {
-        IntColumn column = createIntColumn(new int[]{20, 32452345, IntColumn.MISSING_VALUE, 234});
+        IntColumn column = createIntColumn(new int[]{20, 32452345, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20.0, column.getFloat(0), 0.1);
         assertEquals("Primitive type conversion error", 32452345.0, column.getFloat(1), 1);
         assertTrue("Primitive type conversion error", Float.isNaN(column.getFloat(2)));
@@ -238,7 +238,7 @@ public class IntColumnTest {
 
     @Test
     public void testGetDouble() {
-        IntColumn column = createIntColumn(new int[]{20, 32452345, IntColumn.MISSING_VALUE, 234});
+        IntColumn column = createIntColumn(new int[]{20, 32452345, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20.0, column.getDouble(0), 0.1);
         assertEquals("Primitive type conversion error", 32452345.0, column.getDouble(1), 1);
         assertTrue("Primitive type conversion error", Double.isNaN(column.getDouble(2)));

--- a/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
@@ -90,6 +90,54 @@ public class LongColumnTest {
         }
     }
 
+    @Test
+    public void testSubtractSmallerDoubleCol() {
+        long[] thisColValues = new long[]{32, 42, 40, 57, 52};
+        double[] thatColumnValues = new double[]{42, 32, 40};
+        long[] expectedValues = new long[]{-10, 10, 0};
+
+        LongColumn thisColumn = createLongColumn(thisColValues);
+        DoubleColumn thatColumn = createDoubleColumn(thatColumnValues);
+        LongColumn difference = thisColumn.subtract(thatColumn);
+
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
+        validateDifferenceColumn(expectedValues, difference);
+    }
+
+    @Test
+    public void testSubtractBiggerDoubleCol() {
+        long[] thisColValues = new long[]{32, 42, 40, 57, 52};
+        double[] thatColumnValues = new double[]{42, 32, 40, 91, 52, 98, 23};
+        long[] expectedValues = new long[]{-10, 10, 0, -34, 0};
+
+        LongColumn thisColumn = createLongColumn(thisColValues);
+        DoubleColumn thatColumn = createDoubleColumn(thatColumnValues);
+        LongColumn difference = thisColumn.subtract(thatColumn);
+
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
+        validateDifferenceColumn(expectedValues, difference);
+    }
+
+    @Test
+    public void testSubtractMissingValues() {
+        long[] thisColValues = new long[]{32, LongColumn.MISSING_VALUE, 40, 57, 52};
+        double[] thatColumnValues = new double[]{42, 32, 40, 91, 52, 98, 23};
+        long[] expectedValues = new long[]{-10, LongColumn.MISSING_VALUE, 0, -34, 0};
+
+        LongColumn thisColumn = createLongColumn(thisColValues);
+        DoubleColumn thatColumn = createDoubleColumn(thatColumnValues);
+        LongColumn difference = thisColumn.subtract(thatColumn);
+
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
+        validateDifferenceColumn(expectedValues, difference);
+    }
+
+    private DoubleColumn createDoubleColumn(double[] values) {
+        DoubleColumn column = new DoubleColumn("Test", values.length);
+        Arrays.stream(values).forEach(column::append);
+        return column;
+    }
+
     private LongColumn createLongColumn(long[] values) {
         LongColumn column = new LongColumn("Test", values.length);
         Arrays.stream(values).forEach(column::append);

--- a/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
@@ -41,17 +41,11 @@ public class LongColumnTest {
     }
 
     private boolean computeAndValidateDifference(long[] originalValues, long[] expectedValues) {
-        LongColumn initial = new LongColumn("Test", originalValues.length);
-        Arrays.stream(originalValues).forEach(initial::append);
-
+        LongColumn initial = createLongColumn(originalValues);
         LongColumn difference = initial.difference();
+
         assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
-
-        for (int index = 0; index < difference.size(); index++) {
-            long actual = difference.get(index);
-            assertEquals("difference operation at index:" + index + " failed", expectedValues[index], actual);
-        }
-
+        validateDifferenceColumn(expectedValues, difference);
         return true;
     }
 
@@ -60,5 +54,45 @@ public class LongColumnTest {
         LongColumn initial = new LongColumn("Test");
         LongColumn difference = initial.difference();
         assertEquals("Expecting empty data set.", 0, difference.size());
+    }
+
+    @Test
+    public void testGetInt() {
+        LongColumn column = createLongColumn(new long[]{20L, 32452345, LongColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20, column.getInt(0));
+        assertEquals("Primitive type conversion error", 32452345, column.getInt(1));
+        assertEquals("Primitive type conversion error", IntColumn.MISSING_VALUE, column.getInt(2));
+        assertEquals("Primitive type conversion error", 234, column.getInt(3));
+    }
+
+    @Test
+    public void testGetFloat() {
+        LongColumn column = createLongColumn(new long[]{20L, 32452345, LongColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.0, column.getFloat(0), 0.1);
+        assertEquals("Primitive type conversion error", 32452345.0, column.getFloat(1), 1);
+        assertTrue("Primitive type conversion error", Float.isNaN(column.getFloat(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getFloat(3), 0.1);
+    }
+
+    @Test
+    public void testGetDouble() {
+        LongColumn column = createLongColumn(new long[]{20L, 32452345, LongColumn.MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.0, column.getDouble(0), 0.1);
+        assertEquals("Primitive type conversion error", 32452345.0, column.getDouble(1), 1);
+        assertTrue("Primitive type conversion error", Double.isNaN(column.getDouble(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getDouble(3), 0.1);
+    }
+
+    private void validateDifferenceColumn(long[] expectedValues, LongColumn difference) {
+        for (int index = 0; index < difference.size(); index++) {
+            long actual = difference.get(index);
+            assertEquals("difference operation at index:" + index + " failed", expectedValues[index], actual);
+        }
+    }
+
+    private LongColumn createLongColumn(long[] values) {
+        LongColumn column = new LongColumn("Test", values.length);
+        Arrays.stream(values).forEach(column::append);
+        return column;
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
@@ -58,7 +58,7 @@ public class LongColumnTest {
 
     @Test
     public void testGetInt() {
-        LongColumn column = createLongColumn(new long[]{20L, 32452345, LongColumn.MISSING_VALUE, 234});
+        LongColumn column = createLongColumn(new long[]{20L, 32452345, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20, column.getInt(0));
         assertEquals("Primitive type conversion error", 32452345, column.getInt(1));
         assertEquals("Primitive type conversion error", IntColumn.MISSING_VALUE, column.getInt(2));
@@ -67,7 +67,7 @@ public class LongColumnTest {
 
     @Test
     public void testGetFloat() {
-        LongColumn column = createLongColumn(new long[]{20L, 32452345, LongColumn.MISSING_VALUE, 234});
+        LongColumn column = createLongColumn(new long[]{20L, 32452345, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20.0, column.getFloat(0), 0.1);
         assertEquals("Primitive type conversion error", 32452345.0, column.getFloat(1), 1);
         assertTrue("Primitive type conversion error", Float.isNaN(column.getFloat(2)));
@@ -76,7 +76,7 @@ public class LongColumnTest {
 
     @Test
     public void testGetDouble() {
-        LongColumn column = createLongColumn(new long[]{20L, 32452345, LongColumn.MISSING_VALUE, 234});
+        LongColumn column = createLongColumn(new long[]{20L, 32452345, MISSING_VALUE, 234});
         assertEquals("Primitive type conversion error", 20.0, column.getDouble(0), 0.1);
         assertEquals("Primitive type conversion error", 32452345.0, column.getDouble(1), 1);
         assertTrue("Primitive type conversion error", Double.isNaN(column.getDouble(2)));
@@ -120,9 +120,9 @@ public class LongColumnTest {
 
     @Test
     public void testSubtractMissingValues() {
-        long[] thisColValues = new long[]{32, LongColumn.MISSING_VALUE, 40, 57, 52};
+        long[] thisColValues = new long[]{32, MISSING_VALUE, 40, 57, 52};
         double[] thatColumnValues = new double[]{42, 32, 40, 91, 52, 98, 23};
-        long[] expectedValues = new long[]{-10, LongColumn.MISSING_VALUE, 0, -34, 0};
+        long[] expectedValues = new long[]{-10, MISSING_VALUE, 0, -34, 0};
 
         LongColumn thisColumn = createLongColumn(thisColValues);
         DoubleColumn thatColumn = createDoubleColumn(thatColumnValues);


### PR DESCRIPTION
Currently a `LongColumn` can be subtracted from a `LongColumn`. The current api does not allow subtracting a `IntColumn` or a `DoubleColumn`. This limitation can result in additional steps. For e.g. To compute difference between `Salary (long)` and `Median-Salary`, one might do this:  
```
NumericSummaryTable medians = table.median("Salary").by("ZipCode", "Sex") 
```
medians is a `DoubleColumn` of median, which cannot be directly subtracted from `LongColumn (Salary)`. One has to convert `Salary` to `Double` or `Median` to `Long`.

This PR makes `LongColumn.subtract` operation generic and compatible with other numeric types. It can operate on any `NumericColumn`. 

If this change seems meaningful, I can apply it to other `NumericColumns` too as part of this PR. And to other operation in future in different PRs.

Thanks !

