### PR TITLE
Add up-conversion methods in numeric columns

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
@@ -669,10 +669,6 @@ public class DoubleColumn extends AbstractColumn implements DoubleIterable, Nume
     }
 
     @Override
-    public float getFloat(int index) {
-        return (float) data.getDouble(index);
-    }
-
     public double getDouble(int index) {
         return data.getDouble(index);
     }

--- a/core/src/main/java/tech/tablesaw/api/FloatColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/FloatColumn.java
@@ -671,6 +671,12 @@ public class FloatColumn extends AbstractColumn implements FloatIterable, Numeri
         return data.getFloat(index);
     }
 
+    @Override
+    public double getDouble(int index) {
+        float value = data.getFloat(index);
+        return Float.isNaN(value) ? DoubleColumn.MISSING_VALUE : value;
+    }
+
     public void set(int r, float value) {
         data.set(r, value);
     }

--- a/core/src/main/java/tech/tablesaw/api/IntColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/IntColumn.java
@@ -321,8 +321,26 @@ public class IntColumn extends AbstractColumn implements IntMapUtils, NumericCol
     }
 
     @Override
+    public int getInt(int index) {
+        return data.getInt(index);
+    }
+
+    @Override
+    public long getLong(int index) {
+        int value = data.getInt(index);
+        return value == MISSING_VALUE ? LongColumn.MISSING_VALUE : value;
+    }
+
+    @Override
     public float getFloat(int index) {
-        return (float) data.getInt(index);
+        int value = data.getInt(index);
+        return value == MISSING_VALUE ? FloatColumn.MISSING_VALUE : (float) value;
+    }
+
+    @Override
+    public double getDouble(int index) {
+        int value = data.getInt(index);
+        return value == MISSING_VALUE ? DoubleColumn.MISSING_VALUE : (double) value;
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/api/LongColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/LongColumn.java
@@ -410,8 +410,14 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
     }
 
     @Override
-    public float getFloat(int index) {
-        return (float) data.getLong(index);
+    public long getLong(int index) {
+        return data.getLong(index);
+    }
+
+    @Override
+    public double getDouble(int index) {
+        double value = data.getLong(index);
+        return value == MISSING_VALUE ? DoubleColumn.MISSING_VALUE : (float) value;
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/api/NumericColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/NumericColumn.java
@@ -23,7 +23,45 @@ public interface NumericColumn extends Column {
 
     double[] toDoubleArray();
 
-    float getFloat(int index);
+    /**
+     * Returns int value at <code>index</code> position in the column. A conversion, if needed, could result
+     * in data or accuracy loss.
+     * @param index position in column
+     * @return int value at position
+     */
+    default int getInt(int index) {
+        throw new UnsupportedOperationException("getInt() method not supported for all data types");
+    }
+
+    /**
+     * Returns long value at <code>index</code> position in the column. A conversion, if needed, could result
+     * in data or accuracy loss.
+     * @param index position in column
+     * @return long value at position
+     */
+    default long getLong(int index) {
+        throw new UnsupportedOperationException("getLong() method not supported for all data types");
+    }
+
+    /**
+     * Returns float value at <code>index</code> position in the column. A conversion, if needed, could result
+     * in data or accuracy loss.
+     * @param index position in column
+     * @return float value at position
+     */
+    default float getFloat(int index) {
+        throw new UnsupportedOperationException("getFloat() method not supported for all data types");
+    }
+
+    /**
+     * Returns double value at <code>index</code> position in the column. A conversion, if needed, could result
+     * in data or accuracy loss.
+     * @param index position in column
+     * @return double value at position
+     */
+    default double getDouble(int index) {
+        throw new UnsupportedOperationException("getDouble() method not supported for all data types");
+    }
 
     double max();
 

--- a/core/src/main/java/tech/tablesaw/api/ShortColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/ShortColumn.java
@@ -331,8 +331,27 @@ public class ShortColumn extends AbstractColumn implements ShortMapUtils, Numeri
     }
 
     @Override
+    public int getInt(int index) {
+        int value = data.getShort(index);
+        return value == MISSING_VALUE ? IntColumn.MISSING_VALUE : value;
+    }
+
+    @Override
+    public long getLong(int index) {
+        int value = data.getShort(index);
+        return value == MISSING_VALUE ? LongColumn.MISSING_VALUE : value;
+    }
+
+    @Override
     public float getFloat(int index) {
-        return (float) data.getShort(index);
+        int value = data.getShort(index);
+        return value == MISSING_VALUE ? FloatColumn.MISSING_VALUE : (float) value;
+    }
+
+    @Override
+    public double getDouble(int index) {
+        int value = data.getShort(index);
+        return value == MISSING_VALUE ? DoubleColumn.MISSING_VALUE : (double) value;
     }
 
     @Override

--- a/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
@@ -432,17 +432,14 @@ public class DoubleColumnTest {
     }
 
     @Test
-    public void testMissingValuesInColumn() {
+    public void testDifferenceMissingValuesInColumn() {
         double[] originalValues = new double[]{32, 42, MISSING_VALUE, 57, 52};
         double[] expectedValues = new double[]{MISSING_VALUE, 10, MISSING_VALUE, MISSING_VALUE, -5};
         assertTrue(computeAndValidateDifference(originalValues, expectedValues));
     }
 
     private boolean computeAndValidateDifference(double[] originalValues, double[] expectedValues) {
-        DoubleColumn initial = new DoubleColumn("Test", originalValues.length);
-        for (double value : originalValues) {
-            initial.append(value);
-        }
+        DoubleColumn initial = createDoubleColumn(originalValues);
 
         DoubleColumn difference = initial.difference();
         assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
@@ -459,5 +456,13 @@ public class DoubleColumnTest {
         DoubleColumn initial = new DoubleColumn("Test");
         DoubleColumn difference = initial.difference();
         assertEquals("Expecting empty data set.", 0, difference.size());
+    }
+
+    private DoubleColumn createDoubleColumn(double[] originalValues) {
+        DoubleColumn initial = new DoubleColumn("Test", originalValues.length);
+        for (double value : originalValues) {
+            initial.append(value);
+        }
+        return initial;
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
@@ -623,12 +623,9 @@ public class FloatColumnTest {
     }
 
     private boolean computeAndValidateDifference(float[] originalValues, float[] expectedValues) {
-        FloatColumn initial = new FloatColumn("Test", originalValues.length);
-        for (float value : originalValues) {
-            initial.append(value);
-        }
-
+        FloatColumn initial = createFloatColumn(originalValues);
         FloatColumn difference = initial.difference();
+
         assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
         for (int index = 0; index < difference.size(); index++) {
             float actual = difference.get(index);
@@ -643,5 +640,22 @@ public class FloatColumnTest {
         FloatColumn initial = new FloatColumn("Test");
         FloatColumn difference = initial.difference();
         assertEquals("Expecting empty data set.", 0, difference.size());
+    }
+
+    @Test
+    public void testGetDouble() {
+        FloatColumn column = createFloatColumn(new float[]{20.2f, 3245234.3f, MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.2, column.getDouble(0), 0.1);
+        assertEquals("Primitive type conversion error", 3245234.3, column.getDouble(1), 1);
+        assertTrue("Primitive type conversion error", Double.isNaN(column.getDouble(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getDouble(3), 0.1);
+    }
+
+    private FloatColumn createFloatColumn(float[] originalValues) {
+        FloatColumn initial = new FloatColumn("Test", originalValues.length);
+        for (float value : originalValues) {
+            initial.append(value);
+        }
+        return initial;
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
@@ -21,6 +21,8 @@ import tech.tablesaw.filtering.IntPredicate;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.*;
 import static tech.tablesaw.api.IntColumn.MISSING_VALUE;
 import static tech.tablesaw.api.QueryHelper.column;
@@ -163,10 +165,8 @@ public class IntColumnTest {
     }
 
     private boolean computeAndValidateDifference(int[] originalValues, int[] expectedValues) {
-        IntColumn initial = new IntColumn("Test", originalValues.length);
-        for (int value : originalValues) {
-            initial.append(value);
-        }
+        IntColumn initial = createIntColumn(originalValues);
+
         IntColumn difference = initial.difference();
         assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
         for (int index = 0; index < difference.size(); index++) {
@@ -216,5 +216,38 @@ public class IntColumnTest {
         IntColumn originals = new IntColumn("Originals", new IntArrayList(originalValues));
         FloatColumn divided = originals.divide(3.3);
         assertEquals(originals.size(), divided.size());
+    }
+
+    @Test
+    public void testGetLong() {
+        IntColumn column = createIntColumn(new int[]{20, 32452345, MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20, column.getLong(0));
+        assertEquals("Primitive type conversion error", 32452345, column.getLong(1));
+        assertEquals("Primitive type conversion error", LongColumn.MISSING_VALUE, column.getLong(2));
+        assertEquals("Primitive type conversion error", 234, column.getLong(3));
+    }
+
+    @Test
+    public void testGetFloat() {
+        IntColumn column = createIntColumn(new int[]{20, 32452345, MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.0, column.getFloat(0), 0.1);
+        assertEquals("Primitive type conversion error", 32452345.0, column.getFloat(1), 1);
+        assertTrue("Primitive type conversion error", Float.isNaN(column.getFloat(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getFloat(3), 0.1);
+    }
+
+    @Test
+    public void testGetDouble() {
+        IntColumn column = createIntColumn(new int[]{20, 32452345, MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.0, column.getDouble(0), 0.1);
+        assertEquals("Primitive type conversion error", 32452345.0, column.getDouble(1), 1);
+        assertTrue("Primitive type conversion error", Double.isNaN(column.getDouble(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getDouble(3), 0.1);
+    }
+
+    private IntColumn createIntColumn(int[] values) {
+        IntColumn column = new IntColumn("Test", values.length);
+        Arrays.stream(values).forEach(column::append);
+        return column;
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
@@ -41,17 +41,11 @@ public class LongColumnTest {
     }
 
     private boolean computeAndValidateDifference(long[] originalValues, long[] expectedValues) {
-        LongColumn initial = new LongColumn("Test", originalValues.length);
-        Arrays.stream(originalValues).forEach(initial::append);
-
+        LongColumn initial = createLongColumn(originalValues);
         LongColumn difference = initial.difference();
+
         assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
-
-        for (int index = 0; index < difference.size(); index++) {
-            long actual = difference.get(index);
-            assertEquals("difference operation at index:" + index + " failed", expectedValues[index], actual);
-        }
-
+        validateDifferenceColumn(expectedValues, difference);
         return true;
     }
 
@@ -60,5 +54,27 @@ public class LongColumnTest {
         LongColumn initial = new LongColumn("Test");
         LongColumn difference = initial.difference();
         assertEquals("Expecting empty data set.", 0, difference.size());
+    }
+
+    @Test
+    public void testGetDouble() {
+        LongColumn column = createLongColumn(new long[]{20L, 32452345, MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.0, column.getDouble(0), 0.1);
+        assertEquals("Primitive type conversion error", 32452345.0, column.getDouble(1), 1);
+        assertTrue("Primitive type conversion error", Double.isNaN(column.getDouble(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getDouble(3), 0.1);
+    }
+
+    private void validateDifferenceColumn(long[] expectedValues, LongColumn difference) {
+        for (int index = 0; index < difference.size(); index++) {
+            long actual = difference.get(index);
+            assertEquals("difference operation at index:" + index + " failed", expectedValues[index], actual);
+        }
+    }
+
+    private LongColumn createLongColumn(long[] values) {
+        LongColumn column = new LongColumn("Test", values.length);
+        Arrays.stream(values).forEach(column::append);
+        return column;
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/ShortColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/ShortColumnTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.tablesaw.api;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static tech.tablesaw.api.ShortColumn.MISSING_VALUE;
+
+/**
+ * Tests for Short columns
+ */
+public class ShortColumnTest {
+    @Test
+    public void testGetInt() {
+        ShortColumn column = createShortColumn(new short[]{20, 3245, MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20, column.getInt(0));
+        assertEquals("Primitive type conversion error", 3245, column.getInt(1));
+        assertEquals("Primitive type conversion error", IntColumn.MISSING_VALUE, column.getInt(2));
+        assertEquals("Primitive type conversion error", 234, column.getInt(3));
+    }
+
+    @Test
+    public void testGetLong() {
+        ShortColumn column = createShortColumn(new short[]{20, 3245, MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20L, column.getLong(0));
+        assertEquals("Primitive type conversion error", 3245L, column.getLong(1));
+        assertEquals("Primitive type conversion error", LongColumn.MISSING_VALUE, column.getLong(2));
+        assertEquals("Primitive type conversion error", 234L, column.getLong(3));
+    }
+
+    @Test
+    public void testGetFloat() {
+        ShortColumn column = createShortColumn(new short[]{20, 3245, MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.0, column.getFloat(0), 0.1);
+        assertEquals("Primitive type conversion error", 3245.0, column.getFloat(1), 1);
+        assertTrue("Primitive type conversion error", Float.isNaN(column.getFloat(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getFloat(3), 0.1);
+    }
+
+    @Test
+    public void testGetDouble() {
+        ShortColumn column = createShortColumn(new short[]{20, 3245, MISSING_VALUE, 234});
+        assertEquals("Primitive type conversion error", 20.0, column.getDouble(0), 0.1);
+        assertEquals("Primitive type conversion error", 3245.0, column.getDouble(1), 1);
+        assertTrue("Primitive type conversion error", Double.isNaN(column.getDouble(2)));
+        assertEquals("Primitive type conversion error", 234.0, column.getDouble(3), 0.1);
+    }
+
+    private ShortColumn createShortColumn(short[] values) {
+        ShortColumn column = new ShortColumn("Test", values.length);
+        for (short value: values) {
+            column.append(value);
+        }
+        return column;
+    }
+}


### PR DESCRIPTION
This PR addresses part-1 of #237, `up-conversion`.

Up-sizing, for e.g. int to long,  will be used to enable operations between numeric types. The inverse operation, for e.g. long to int, is expected to be significantly lossy and is not implemented as part of this PR. 

See discussion in #236 for more details.

The following will be supported:
1. `ShortColumn`
   1. `getInt()`
   1. `getLong()`
   1. `getFloat()`
   1. `getDouble()`
1. `IntColumn`
   1. `getLong()`
   1. `getFloat()`
   1. `getDouble()`
1. `LongColumn`
   1. `getDouble()`
1. `FloatColumn`
   1. `getDouble()`
