### PR TITLE
Allow subtract operation between all numeric types

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
@@ -570,10 +570,18 @@ public class DoubleColumn extends AbstractColumn implements DoubleIterable, Nume
         return result;
     }
 
-    public DoubleColumn subtract(DoubleColumn column2) {
-        DoubleColumn result = new DoubleColumn(name() + " - " + column2.name(), size());
-        for (int r = 0; r < size(); r++) {
-            result.append(subtract(get(r), column2.get(r)));
+    public NumericColumn subtract(NumericColumn column2) {
+        return DoubleColumn.subtractDouble(this, column2);
+    }
+
+    public static DoubleColumn subtractDouble(NumericColumn column1, NumericColumn column2) {
+        int col1Size = column1.size();
+        int col2Size = column2.size();
+        int resultSize = col1Size < col2Size ? col1Size : col2Size;
+
+        DoubleColumn result = new DoubleColumn(column1.name() + " - " + column2.name(), resultSize);
+        for (int r = 0; r < resultSize; r++) {
+            result.append(subtract(column1.getDouble(r), column2.getDouble(r)));
         }
         return result;
     }
@@ -835,7 +843,7 @@ public class DoubleColumn extends AbstractColumn implements DoubleIterable, Nume
         return val1 + val2;
     }
 
-    private double subtract(double val1, double val2) {
+    private static double subtract(double val1, double val2) {
         if (isMissing(val1) || isMissing(val2)) {
             return MISSING_VALUE;
         }

--- a/core/src/main/java/tech/tablesaw/api/LongColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/LongColumn.java
@@ -244,10 +244,23 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
         return result;
     }
 
-    public LongColumn subtract(LongColumn column2) {
-        LongColumn result = new LongColumn(name() + " - " + column2.name(), size());
-        for (int r = 0; r < size(); r++) {
-            result.append(subtract(get(r), column2.get(r)));
+    public NumericColumn subtract(NumericColumn column2) {
+        if (column2 instanceof ShortColumn || column2 instanceof IntColumn || column2 instanceof LongColumn) {
+            return subtractLong(this, column2);
+        } else if (column2 instanceof FloatColumn || column2 instanceof DoubleColumn) {
+            return DoubleColumn.subtractDouble(this, column2);
+        } else {
+            throw new UnsupportedOperationException("LongColumn.subtract() method not supported for " +
+                                                        column2.getClass().getName() + " type");
+        }
+    }
+
+    static LongColumn subtractLong(NumericColumn column1, NumericColumn column2) {
+        int col1Size = column1.size();
+        int col2Size = column2.size();
+        LongColumn result = new LongColumn(column1.name() + " - " + column2.name(), col1Size);
+        for (int r = 0; r < col1Size && r < col2Size; r++) {
+            result.append(subtract(column1.getLong(r), column2.getLong(r)));
         }
         return result;
     }
@@ -715,7 +728,7 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
         return val1 + val2;
     }
 
-    private long subtract(long val1, long val2) {
+    private static long subtract(long val1, long val2) {
         if (val1 == MISSING_VALUE || val2 == MISSING_VALUE) {
             return MISSING_VALUE;
         }

--- a/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
@@ -465,7 +465,7 @@ public class DoubleColumnTest {
         NumericColumn difference = col2.subtract(col1);
         assertTrue("Expecting DoubleColumn type result", difference instanceof DoubleColumn);
         DoubleColumn diffDoubleCol = (DoubleColumn) difference;
-        validateEquality(expected, diffDoubleCol);
+        assertTrue(validateEquality(expected, diffDoubleCol));
     }
 
     @Test
@@ -478,12 +478,12 @@ public class DoubleColumnTest {
         DoubleColumn col2 = createDoubleColumn(col2Values);
 
         DoubleColumn difference = DoubleColumn.subtractDouble(col1, col2);
-        validateEquality(expected, difference);
+        assertTrue(validateEquality(expected, difference));
 
         // change order to verify size of returned column
         difference = DoubleColumn.subtractDouble(col2, col1);
         expected = new double[]{-0.5, MISSING_VALUE, -3.33, MISSING_VALUE, .01};
-        validateEquality(expected, difference);
+        assertTrue(validateEquality(expected, difference));
     }
 
     private DoubleColumn createDoubleColumn(double[] originalValues) {

--- a/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
@@ -45,8 +45,7 @@ public class LongColumnTest {
         LongColumn difference = initial.difference();
 
         assertEquals("Both sets of data should be the same size.", expectedValues.length, difference.size());
-        validateDifferenceColumn(expectedValues, difference);
-        return true;
+        return validateDifferenceColumn(expectedValues, difference);
     }
 
     @Test
@@ -65,16 +64,18 @@ public class LongColumnTest {
         assertEquals("Primitive type conversion error", 234.0, column.getDouble(3), 0.1);
     }
 
-    private void validateDifferenceColumn(long[] expectedValues, LongColumn difference) {
+    private boolean validateDifferenceColumn(long[] expectedValues, LongColumn difference) {
         for (int index = 0; index < difference.size(); index++) {
             long actual = difference.get(index);
             assertEquals("difference operation at index:" + index + " failed", expectedValues[index], actual);
         }
+
+        return true;
     }
 
     @Test
     public void testSubtractDoubleColumn() {
-        long[] col1Values = new long[]{32, LongColumn.MISSING_VALUE, 42, 57, 52};
+        long[] col1Values = new long[]{32, MISSING_VALUE, 42, 57, 52};
         double[] col2Values = new double[]{31.5, 42, 38.67, DoubleColumn.MISSING_VALUE, 52.01, 102};
         double[] expected = new double[]{0.5, DoubleColumn.MISSING_VALUE, 3.33, DoubleColumn.MISSING_VALUE, -.01};
 
@@ -106,7 +107,7 @@ public class LongColumnTest {
         NumericColumn difference = col1.subtract(col2);
         assertTrue("Expecting LongColumn type result", difference instanceof LongColumn);
         LongColumn diffLongCol = (LongColumn) difference;
-        validateDifferenceColumn(expected, diffLongCol);
+        assertTrue(validateDifferenceColumn(expected, diffLongCol));
     }
 
     @Test
@@ -119,12 +120,12 @@ public class LongColumnTest {
         LongColumn col2 = createLongColumn(col2Values);
 
         LongColumn difference = LongColumn.subtractLong(col1, col2);
-        validateDifferenceColumn(expected, difference);
+        assertTrue(validateDifferenceColumn(expected, difference));
 
         // change order to verify size of returned column
         difference = LongColumn.subtractLong(col2, col1);
         expected = new long[]{0, MISSING_VALUE, -4, MISSING_VALUE, 0};
-        validateDifferenceColumn(expected, difference);
+        assertTrue(validateDifferenceColumn(expected, difference));
     }
 
     private LongColumn createLongColumn(long[] values) {

--- a/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
@@ -72,6 +72,61 @@ public class LongColumnTest {
         }
     }
 
+    @Test
+    public void testSubtractDoubleColumn() {
+        long[] col1Values = new long[]{32, LongColumn.MISSING_VALUE, 42, 57, 52};
+        double[] col2Values = new double[]{31.5, 42, 38.67, DoubleColumn.MISSING_VALUE, 52.01, 102};
+        double[] expected = new double[]{0.5, DoubleColumn.MISSING_VALUE, 3.33, DoubleColumn.MISSING_VALUE, -.01};
+
+        LongColumn col1 = createLongColumn(col1Values);
+        DoubleColumn col2 = new DoubleColumn("Test", col2Values.length);
+        Arrays.stream(col2Values).forEach(col2::append);
+
+        NumericColumn difference = col1.subtract(col2);
+        assertTrue("Expecting DoubleColumn type result", difference instanceof DoubleColumn);
+
+        DoubleColumn diffDoubleCol = (DoubleColumn) difference;
+        assertEquals("Both sets of data should be the same size.", expected.length, diffDoubleCol.size());
+        for (int index = 0; index < expected.length; index++) {
+            double actual = diffDoubleCol.get(index);
+            assertEquals("value mismatch at index:" + index, expected[index], actual, 0.01);
+        }
+    }
+
+    @Test
+    public void testSubtractIntColumn() {
+        long[] col1Values = new long[]{32, MISSING_VALUE, 38, 57, 52};
+        int[] col2Values = new int[]{31, 42, 42, IntColumn.MISSING_VALUE, 51, 102};
+        long[] expected = new long[]{1, MISSING_VALUE, -4, MISSING_VALUE, 1};
+
+        LongColumn col1 = createLongColumn(col1Values);
+        IntColumn col2 = new IntColumn("Test", col1Values.length);
+        Arrays.stream(col2Values).forEach(col2::append);
+
+        NumericColumn difference = col1.subtract(col2);
+        assertTrue("Expecting LongColumn type result", difference instanceof LongColumn);
+        LongColumn diffLongCol = (LongColumn) difference;
+        validateDifferenceColumn(expected, diffLongCol);
+    }
+
+    @Test
+    public void testSubtract2Columns() {
+        long[] col1Values = new long[]{32, MISSING_VALUE, 42, 57, 52};
+        long[] col2Values = new long[]{32, 42, 38, MISSING_VALUE, 52, 102};
+        long[] expected = new long[]{0, MISSING_VALUE, 4, MISSING_VALUE, 0};
+
+        LongColumn col1 = createLongColumn(col1Values);
+        LongColumn col2 = createLongColumn(col2Values);
+
+        LongColumn difference = LongColumn.subtractLong(col1, col2);
+        validateDifferenceColumn(expected, difference);
+
+        // change order to verify size of returned column
+        difference = LongColumn.subtractLong(col2, col1);
+        expected = new long[]{0, MISSING_VALUE, -4, MISSING_VALUE, 0};
+        validateDifferenceColumn(expected, difference);
+    }
+
     private LongColumn createLongColumn(long[] values) {
         LongColumn column = new LongColumn("Test", values.length);
         Arrays.stream(values).forEach(column::append);


### PR DESCRIPTION
This PR addresses part-2 of #237: a generic subtract method implementation for `LongColumn` and `DoubleColumn`.

`aLongColumn.subtract(aDoubleColumn)` should result in a `DoubleColumn`. This could be achieved by delegating the operation to `DoubleColumn`. 

See discussion in #236 for more details.

**This PR is not merge-ready**. The intent of this PR is to demo high level code flow. If the approach is approved, changes will be required in other numeric types. Moreover the identification of a `delegate` could be abstracted out and be used in all numeric types.