### PR TITLE
Add cumulative sum function to columns

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
@@ -841,4 +841,27 @@ public class DoubleColumn extends AbstractColumn implements DoubleIterable, Nume
         }
         return val1 - val2;
     }
+
+    /**
+    * Returns a new column with a cumulative sum calculated
+    */
+    public DoubleColumn cumSum() {
+        double cSum = 0.0;
+        DoubleColumn newColumn = new DoubleColumn(name() + "[cumSum]", size());
+        for (double value : this) {
+            if (!isMissing(value)) {
+                cSum += value;
+            }
+            newColumn.append(cSum);
+        }
+        return newColumn;
+    }
+
+    /**
+     * cSum() is an alias for cumSum();
+     */
+    public DoubleColumn cSum() {
+        return cumSum();
+    }
+    
 }

--- a/core/src/main/java/tech/tablesaw/api/FloatColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/FloatColumn.java
@@ -862,4 +862,26 @@ public class FloatColumn extends AbstractColumn implements FloatIterable, Numeri
         }
         return val1 - val2;
     }
+
+    /**
+    * Returns a new column with a cumulative sum calculated
+    */
+    public FloatColumn cumSum() {
+        float cSum = 0.0f;
+        FloatColumn newColumn = new FloatColumn(name() + "[cumSum]", size());
+        for (float value : this) {
+            if (!isMissing(value)) {
+                cSum += value;
+            }
+            newColumn.append(cSum);
+        }
+        return newColumn;
+    }
+
+    /**
+     * cSum() is an alias for cumSum();
+     */
+    public FloatColumn cSum() {
+        return cumSum();
+    }
 }

--- a/core/src/main/java/tech/tablesaw/api/IntColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/IntColumn.java
@@ -89,6 +89,10 @@ public class IntColumn extends AbstractColumn implements IntMapUtils, NumericCol
         data = new IntArrayList(metadata.getSize());
     }
 
+    protected static boolean isMissing(int value) {
+      return value == MISSING_VALUE;
+    }
+
     /**
      * Returns a float that is parsed from the given String
      * <p>
@@ -738,5 +742,27 @@ public class IntColumn extends AbstractColumn implements IntMapUtils, NumericCol
             return MISSING_VALUE;
         }
         return val1 - val2;
+    }
+
+    /**
+    * Returns a new column with a cumulative sum calculated
+    */
+    public IntColumn cumSum() {
+        int cSum = 0;
+        IntColumn newColumn = new IntColumn(name() + "[cumSum]", size());
+        for (int value : this) {
+            if (!isMissing(value)) {
+                cSum += value;
+            }
+            newColumn.append(cSum);
+        }
+        return newColumn;
+    }
+
+    /**
+     * cSum() is an alias for cumSum();
+     */
+    public IntColumn cSum() {
+        return cumSum();
     }
 }

--- a/core/src/main/java/tech/tablesaw/api/LongColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/LongColumn.java
@@ -92,6 +92,10 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
         data = new LongArrayList(metadata.getSize());
     }
 
+    protected static boolean isMissing(long value) {
+      return value == MISSING_VALUE;
+    }
+
     /**
      * Returns a float that is parsed from the given String
      * <p>
@@ -720,5 +724,27 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
             return MISSING_VALUE;
         }
         return val1 - val2;
+    }
+
+    /**
+    * Returns a new column with a cumulative sum calculated
+    */
+    public LongColumn cumSum() {
+        long cSum = 0L;
+        LongColumn newColumn = new LongColumn(name() + "[cumSum]", size());
+        for (long value : this) {
+            if (!isMissing(value)) {
+                cSum += value;
+            }
+            newColumn.append(cSum);
+        }
+        return newColumn;
+    }
+
+    /**
+     * cSum() is an alias for cumSum();
+     */
+    public LongColumn cSum() {
+        return cumSum();
     }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

- Added cumSum() and alias cSum() to Double/Float/Int/LongColumns to replicate cumulative sum functionality in pandas, etc. that returns a new column with cSum() applied to original column.

- Also had to add the isMissing() to IntColumn/LongColumn to keep coding similar across all type implementations.

## Testing

Did you add a unit test?

No, Sorry.   DoubleColumn version is what I added for my use-case, should work for other numeric versions too, but haven't tested that.  Compiles OK.
