### PR TITLE
 Add replaceColumn() to Table

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -265,6 +265,30 @@ public class Table extends Relation implements IntIterable {
     }
 
     /**
+     * Replaces an existing column (by index) in this table with the given new column
+     *
+     * @param colIndex  Zero-based index of the column to be replaced
+     * @param newColumn Column to be added
+     */
+    public Table replaceColumn(int colIndex, Column newColumn) {       
+        removeColumns(column(colIndex));
+        addColumn(colIndex, newColumn);
+        return this;
+    }
+
+    /**
+     * Replaces an existing column (by name) in this table with the given new column
+     *
+     * @param columnName String name of the column to be replaced
+     * @param newColumn  Column to be added
+     */
+    public Table replaceColumn(String columnName, Column newColumn) {
+        int colIndex = columnIndex(columnName);
+        replaceColumn(colIndex, newColumn);
+        return this;
+    }
+
+    /**
      * Sets the name of the table
      */
     @Override

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -167,6 +167,22 @@ public class TableTest {
         table.append(tableToAppend);
     }
 
+    @Test
+    public void testReplaceColumn() throws Exception {
+        FloatColumn first = new FloatColumn("c1", new float[]{1,2,3,4,5});
+        FloatColumn second = new FloatColumn("c2", new float[]{6,7,8,9,10});
+        FloatColumn replacement = new FloatColumn("c2", new float[]{10,20,30,40,50});
+
+        Table t = Table.create("populated", first, second);
+        
+        int colIndex = t.columnIndex(second);
+        assertTrue(t.column("c2") == second);
+        t.replaceColumn("c2", replacement);
+        assertTrue(t.column("c1") == first);
+        assertTrue(t.column("c2") == replacement);
+        assertTrue(t.columnIndex(replacement) == colIndex);
+    }
+
     private int appendRandomlyGeneratedColumn(Table table) {
         FloatColumn column = floatColumn.emptyCopy();
         populateColumn(column);


### PR DESCRIPTION
Two new table functions remove a column by either name or column index and replace with the supplied column.

Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

Added new functions to simplify replacing a column so you don't have to find the existing column, remove it, and append new column into previous location - it's all done for you so that the new column is a drop-in replacement of existing.

## Testing

Now includes a unit test that creates a table with two cols, then replaces one of the cols with a 3rd col and verifies it worked OK.
