### PR TITLE
Add cumulative sum function to columns - cumSum()

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
@@ -841,4 +841,19 @@ public class DoubleColumn extends AbstractColumn implements DoubleIterable, Nume
         }
         return val1 - val2;
     }
+
+    /**
+    * Returns a new column with a cumulative sum calculated
+    */
+    public DoubleColumn cumSum() {
+        double cSum = 0.0;
+        DoubleColumn newColumn = new DoubleColumn(name() + "[cumSum]", size());
+        for (double value : this) {
+            if (!isMissing(value)) {
+                cSum += value;
+            }
+            newColumn.append(cSum);
+        }
+        return newColumn;
+    }
 }

--- a/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
@@ -843,8 +843,8 @@ public class DoubleColumn extends AbstractColumn implements DoubleIterable, Nume
     }
 
     /**
-    * Returns a new column with a cumulative sum calculated
-    */
+     * Returns a new column with a cumulative sum calculated
+     */
     public DoubleColumn cumSum() {
         double cSum = 0.0;
         DoubleColumn newColumn = new DoubleColumn(name() + "[cumSum]", size());

--- a/core/src/main/java/tech/tablesaw/api/FloatColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/FloatColumn.java
@@ -864,8 +864,8 @@ public class FloatColumn extends AbstractColumn implements FloatIterable, Numeri
     }
 
     /**
-    * Returns a new column with a cumulative sum calculated
-    */
+     * Returns a new column with a cumulative sum calculated
+     */
     public FloatColumn cumSum() {
         float cSum = 0.0f;
         FloatColumn newColumn = new FloatColumn(name() + "[cumSum]", size());

--- a/core/src/main/java/tech/tablesaw/api/FloatColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/FloatColumn.java
@@ -862,4 +862,19 @@ public class FloatColumn extends AbstractColumn implements FloatIterable, Numeri
         }
         return val1 - val2;
     }
+
+    /**
+    * Returns a new column with a cumulative sum calculated
+    */
+    public FloatColumn cumSum() {
+        float cSum = 0.0f;
+        FloatColumn newColumn = new FloatColumn(name() + "[cumSum]", size());
+        for (float value : this) {
+            if (!isMissing(value)) {
+                cSum += value;
+            }
+            newColumn.append(cSum);
+        }
+        return newColumn;
+    }
 }

--- a/core/src/main/java/tech/tablesaw/api/IntColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/IntColumn.java
@@ -745,8 +745,8 @@ public class IntColumn extends AbstractColumn implements IntMapUtils, NumericCol
     }
 
     /**
-    * Returns a new column with a cumulative sum calculated
-    */
+     * Returns a new column with a cumulative sum calculated
+     */
     public IntColumn cumSum() {
         int cSum = 0;
         IntColumn newColumn = new IntColumn(name() + "[cumSum]", size());

--- a/core/src/main/java/tech/tablesaw/api/IntColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/IntColumn.java
@@ -89,6 +89,10 @@ public class IntColumn extends AbstractColumn implements IntMapUtils, NumericCol
         data = new IntArrayList(metadata.getSize());
     }
 
+    protected static boolean isMissing(int value) {
+      return value == MISSING_VALUE;
+    }
+
     /**
      * Returns a float that is parsed from the given String
      * <p>
@@ -738,5 +742,20 @@ public class IntColumn extends AbstractColumn implements IntMapUtils, NumericCol
             return MISSING_VALUE;
         }
         return val1 - val2;
+    }
+
+    /**
+    * Returns a new column with a cumulative sum calculated
+    */
+    public IntColumn cumSum() {
+        int cSum = 0;
+        IntColumn newColumn = new IntColumn(name() + "[cumSum]", size());
+        for (int value : this) {
+            if (!isMissing(value)) {
+                cSum += value;
+            }
+            newColumn.append(cSum);
+        }
+        return newColumn;
     }
 }

--- a/core/src/main/java/tech/tablesaw/api/LongColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/LongColumn.java
@@ -727,8 +727,8 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
     }
 
     /**
-    * Returns a new column with a cumulative sum calculated
-    */
+     * Returns a new column with a cumulative sum calculated
+     */
     public LongColumn cumSum() {
         long cSum = 0L;
         LongColumn newColumn = new LongColumn(name() + "[cumSum]", size());

--- a/core/src/main/java/tech/tablesaw/api/LongColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/LongColumn.java
@@ -92,6 +92,10 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
         data = new LongArrayList(metadata.getSize());
     }
 
+    protected static boolean isMissing(long value) {
+      return value == MISSING_VALUE;
+    }
+
     /**
      * Returns a float that is parsed from the given String
      * <p>
@@ -720,5 +724,20 @@ public class LongColumn extends AbstractColumn implements LongMapUtils, NumericC
             return MISSING_VALUE;
         }
         return val1 - val2;
+    }
+
+    /**
+    * Returns a new column with a cumulative sum calculated
+    */
+    public LongColumn cumSum() {
+        long cSum = 0L;
+        LongColumn newColumn = new LongColumn(name() + "[cumSum]", size());
+        for (long value : this) {
+            if (!isMissing(value)) {
+                cSum += value;
+            }
+            newColumn.append(cSum);
+        }
+        return newColumn;
     }
 }

--- a/core/src/main/java/tech/tablesaw/api/ShortColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/ShortColumn.java
@@ -716,8 +716,8 @@ public class ShortColumn extends AbstractColumn implements ShortMapUtils, Numeri
     }
 
     /**
-    * Returns a new column with a cumulative sum calculated
-    */
+     * Returns a new column with a cumulative sum calculated
+     */
     public ShortColumn cumSum() {
         short cSum = 0;
         ShortColumn newColumn = new ShortColumn(name() + "[cumSum]", size());

--- a/core/src/main/java/tech/tablesaw/api/ShortColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/ShortColumn.java
@@ -110,6 +110,10 @@ public class ShortColumn extends AbstractColumn implements ShortMapUtils, Numeri
         data = new ShortArrayList(metadata.getSize());
     }
 
+    protected static boolean isMissing(short value) {
+      return value == MISSING_VALUE;
+    }
+
     /**
      * Returns a float that is parsed from the given String
      * <p>
@@ -709,5 +713,20 @@ public class ShortColumn extends AbstractColumn implements ShortMapUtils, Numeri
             output[i] = data.getShort(i);
         }
         return output;
+    }
+
+    /**
+    * Returns a new column with a cumulative sum calculated
+    */
+    public ShortColumn cumSum() {
+        short cSum = 0;
+        ShortColumn newColumn = new ShortColumn(name() + "[cumSum]", size());
+        for (short value : this) {
+            if (!isMissing(value)) {
+                cSum += value;
+            }
+            newColumn.append(cSum);
+        }
+        return newColumn;
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
@@ -465,4 +465,23 @@ public class DoubleColumnTest {
         }
         return initial;
     }
+
+    private boolean computeAndValidateCumSum(double[] originalValues, double[] expectedValues) {
+        DoubleColumn initial = createDoubleColumn(originalValues);
+
+        DoubleColumn csum = initial.cumSum();
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
+        for (int index = 0; index < csum.size(); index++) {
+            double actual = csum.get(index);
+            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
+        }
+        return true;
+    }
+
+    @Test
+    public void testCumSum() {
+        double[] originalValues = new double[]{32, 42, MISSING_VALUE, 57, 52, -10, 0};
+        double[] expectedValues = new double[]{32, 74, 74, 131, 183, 173, 173};
+        assertTrue(computeAndValidateCumSum(originalValues, expectedValues));
+    }
 }

--- a/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
@@ -466,22 +466,18 @@ public class DoubleColumnTest {
         return initial;
     }
 
-    private boolean computeAndValidateCumSum(double[] originalValues, double[] expectedValues) {
-        DoubleColumn initial = createDoubleColumn(originalValues);
-
-        DoubleColumn csum = initial.cumSum();
-        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
-        for (int index = 0; index < csum.size(); index++) {
-            double actual = csum.get(index);
-            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
-        }
-        return true;
-    }
-
     @Test
     public void testCumSum() {
         double[] originalValues = new double[]{32, 42, MISSING_VALUE, 57, 52, -10, 0};
         double[] expectedValues = new double[]{32, 74, 74, 131, 183, 173, 173};
-        assertTrue(computeAndValidateCumSum(originalValues, expectedValues));
+        DoubleColumn initial = createDoubleColumn(originalValues);
+        DoubleColumn csum = initial.cumSum();
+        
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
+        
+        for (int index = 0; index < csum.size(); index++) {
+            double actual = csum.get(index);
+            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
+        }
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
@@ -659,22 +659,18 @@ public class FloatColumnTest {
         return initial;
     }
 
-    private boolean computeAndValidateCumSum(float[] originalValues, float[] expectedValues) {
-        FloatColumn initial = createFloatColumn(originalValues);
-
-        FloatColumn csum = initial.cumSum();
-        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
-        for (int index = 0; index < csum.size(); index++) {
-            float actual = csum.get(index);
-            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
-        }
-        return true;
-    }
-
     @Test
     public void testCumSum() {
         float[] originalValues = new float[]{32, 42, MISSING_VALUE, 57, 52, -10, 0};
         float[] expectedValues = new float[]{32, 74, 74, 131, 183, 173, 173};
-        assertTrue(computeAndValidateCumSum(originalValues, expectedValues));
+        FloatColumn initial = createFloatColumn(originalValues);
+        FloatColumn csum = initial.cumSum();
+        
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
+        
+        for (int index = 0; index < csum.size(); index++) {
+            float actual = csum.get(index);
+            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
+        }
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
@@ -658,4 +658,23 @@ public class FloatColumnTest {
         }
         return initial;
     }
+
+    private boolean computeAndValidateCumSum(float[] originalValues, float[] expectedValues) {
+        FloatColumn initial = createFloatColumn(originalValues);
+
+        FloatColumn csum = initial.cumSum();
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
+        for (int index = 0; index < csum.size(); index++) {
+            float actual = csum.get(index);
+            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
+        }
+        return true;
+    }
+
+    @Test
+    public void testCumSum() {
+        float[] originalValues = new float[]{32, 42, MISSING_VALUE, 57, 52, -10, 0};
+        float[] expectedValues = new float[]{32, 74, 74, 131, 183, 173, 173};
+        assertTrue(computeAndValidateCumSum(originalValues, expectedValues));
+    }
 }

--- a/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
@@ -251,22 +251,18 @@ public class IntColumnTest {
         return column;
     }
 
-    private boolean computeAndValidateCumSum(int[] originalValues, int[] expectedValues) {
-        IntColumn initial = createIntColumn(originalValues);
-
-        IntColumn csum = initial.cumSum();
-        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
-        for (int index = 0; index < csum.size(); index++) {
-            int actual = csum.get(index);
-            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
-        }
-        return true;
-    }
-
     @Test
     public void testCumSum() {
         int[] originalValues = new int[]{32, 42, MISSING_VALUE, 57, 52, -10, 0};
         int[] expectedValues = new int[]{32, 74, 74, 131, 183, 173, 173};
-        assertTrue(computeAndValidateCumSum(originalValues, expectedValues));
+        IntColumn initial = createIntColumn(originalValues);
+        IntColumn csum = initial.cumSum();
+        
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
+        
+        for (int index = 0; index < csum.size(); index++) {
+            int actual = csum.get(index);
+            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
+        }
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
@@ -250,4 +250,23 @@ public class IntColumnTest {
         Arrays.stream(values).forEach(column::append);
         return column;
     }
+
+    private boolean computeAndValidateCumSum(int[] originalValues, int[] expectedValues) {
+        IntColumn initial = createIntColumn(originalValues);
+
+        IntColumn csum = initial.cumSum();
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
+        for (int index = 0; index < csum.size(); index++) {
+            int actual = csum.get(index);
+            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
+        }
+        return true;
+    }
+
+    @Test
+    public void testCumSum() {
+        int[] originalValues = new int[]{32, 42, MISSING_VALUE, 57, 52, -10, 0};
+        int[] expectedValues = new int[]{32, 74, 74, 131, 183, 173, 173};
+        assertTrue(computeAndValidateCumSum(originalValues, expectedValues));
+    }
 }

--- a/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
@@ -81,7 +81,7 @@ public class LongColumnTest {
     @Test
     public void testCumSum() {
         long[] originalValues = new long[]{32, 42, MISSING_VALUE, 57, 52, -10, 0};
-        long[] expectedValues = new long[]{32, 7c4, 74, 131, 183, 173, 173};
+        long[] expectedValues = new long[]{32, 74, 74, 131, 183, 173, 173};
         LongColumn initial = createLongColumn(originalValues);
         LongColumn csum = initial.cumSum();
         

--- a/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
@@ -77,4 +77,23 @@ public class LongColumnTest {
         Arrays.stream(values).forEach(column::append);
         return column;
     }
+		
+    private boolean computeAndValidateCumSum(long[] originalValues, long[] expectedValues) {
+        LongColumn initial = createLongColumn(originalValues);
+
+        LongColumn csum = initial.cumSum();
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
+        for (int index = 0; index < csum.size(); index++) {
+            long actual = csum.get(index);
+            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
+        }
+        return true;
+    }
+
+    @Test
+    public void testCumSum() {
+        long[] originalValues = new long[]{32, 42, MISSING_VALUE, 57, 52, -10, 0};
+        long[] expectedValues = new long[]{32, 74, 74, 131, 183, 173, 173};
+        assertTrue(computeAndValidateCumSum(originalValues, expectedValues));
+    }
 }

--- a/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
@@ -77,23 +77,19 @@ public class LongColumnTest {
         Arrays.stream(values).forEach(column::append);
         return column;
     }
-		
-    private boolean computeAndValidateCumSum(long[] originalValues, long[] expectedValues) {
-        LongColumn initial = createLongColumn(originalValues);
-
-        LongColumn csum = initial.cumSum();
-        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
-        for (int index = 0; index < csum.size(); index++) {
-            long actual = csum.get(index);
-            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
-        }
-        return true;
-    }
 
     @Test
     public void testCumSum() {
         long[] originalValues = new long[]{32, 42, MISSING_VALUE, 57, 52, -10, 0};
-        long[] expectedValues = new long[]{32, 74, 74, 131, 183, 173, 173};
-        assertTrue(computeAndValidateCumSum(originalValues, expectedValues));
+        long[] expectedValues = new long[]{32, 7c4, 74, 131, 183, 173, 173};
+        LongColumn initial = createLongColumn(originalValues);
+        LongColumn csum = initial.cumSum();
+        
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
+        
+        for (int index = 0; index < csum.size(); index++) {
+            long actual = csum.get(index);
+            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
+        }
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/ShortColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/ShortColumnTest.java
@@ -68,22 +68,19 @@ public class ShortColumnTest {
         return column;
     }
 
-    private boolean computeAndValidateCumSum(short[] originalValues, short[] expectedValues) {
-        ShortColumn initial = createShortColumn(originalValues);
-
-        ShortColumn csum = initial.cumSum();
-        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
-        for (int index = 0; index < csum.size(); index++) {
-            short actual = csum.get(index);
-            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
-        }
-        return true;
-    }
-
     @Test
     public void testCumSum() {
         short[] originalValues = new short[]{32, 42, MISSING_VALUE, 57, 52, -10, 0};
         short[] expectedValues = new short[]{32, 74, 74, 131, 183, 173, 173};
-        assertTrue(computeAndValidateCumSum(originalValues, expectedValues));
-    }	
+        ShortColumn initial = createShortColumn(originalValues);
+        ShortColumn csum = initial.cumSum();
+        
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
+        
+        for (int index = 0; index < csum.size(); index++) {
+            short actual = csum.get(index);
+            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
+        }
+    }
 }
+ 

--- a/core/src/test/java/tech/tablesaw/api/ShortColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/ShortColumnTest.java
@@ -67,4 +67,23 @@ public class ShortColumnTest {
         }
         return column;
     }
+
+    private boolean computeAndValidateCumSum(short[] originalValues, short[] expectedValues) {
+        ShortColumn initial = createShortColumn(originalValues);
+
+        ShortColumn csum = initial.cumSum();
+        assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
+        for (int index = 0; index < csum.size(); index++) {
+            short actual = csum.get(index);
+            assertEquals("cumSum() operation at index:" + index + " failed", expectedValues[index], actual, 0);
+        }
+        return true;
+    }
+
+    @Test
+    public void testCumSum() {
+        short[] originalValues = new short[]{32, 42, MISSING_VALUE, 57, 52, -10, 0};
+        short[] expectedValues = new short[]{32, 74, 74, 131, 183, 173, 173};
+        assertTrue(computeAndValidateCumSum(originalValues, expectedValues));
+    }	
 }


### PR DESCRIPTION
- Added cumSum() to Double/Float/Int/Long/ShortColumns to replicate cumulative sum functionality in pandas, etc. that returns a new column with cumSum() applied to original column.

- Also had to add the isMissing() to IntColumn/LongColumn/ShortColumn to keep coding similar across all type implementations.

Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

New functions added as described above

## Testing

Yes, this new PR includes unit tests for all of the data types that compare function results to an expected result.