### PR TITLE
Add convenience methods to convert to double arrays for easier usage with Smile

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -260,17 +260,6 @@ public class Table extends Relation implements Iterable<Row> {
     /**
      * Returns only the columns whose names are given in the input array
      */
-    public List<Column> columns(String... columnNames) {
-        List<Column> columns = new ArrayList<>();
-        for (String columnName : columnNames) {
-            columns.add(column(columnName));
-        }
-        return columns;
-    }
-
-    /**
-     * Returns only the columns whose names are given in the input array
-     */
     public List<CategoricalColumn> categoricalColumns(String... columnNames) {
         List<CategoricalColumn> columns = new ArrayList<>();
         for (String columnName : columnNames) {

--- a/core/src/main/java/tech/tablesaw/columns/Column.java
+++ b/core/src/main/java/tech/tablesaw/columns/Column.java
@@ -195,9 +195,7 @@ public interface Column {
         return "Column: " + name() + '\n';
     }
 
-    default double[] asDoubleArray() {
-        throw new UnsupportedOperationException("Method asDoubleArray() is not supported on non-numeric columns");
-    }
+    double[] asDoubleArray();
 
     /**
      * Returns the width of the column in characters, for printing

--- a/core/src/main/java/tech/tablesaw/conversion/TableConverter.java
+++ b/core/src/main/java/tech/tablesaw/conversion/TableConverter.java
@@ -1,0 +1,93 @@
+package tech.tablesaw.conversion;
+
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+
+import tech.tablesaw.columns.Column;
+import tech.tablesaw.table.Relation;
+
+public class TableConverter {
+
+  private final Relation table;
+  
+  public TableConverter(Relation table) {
+    this.table = table;
+  }
+
+  public double[][] doubleMatrix() {
+    return doubleMatrix(table.columns());
+  }
+
+  public double[][] doubleMatrix(int... columnIndicies) {
+    return doubleMatrix(table.columns(columnIndicies));
+  }
+
+  public double[][] doubleMatrix(String... columnNames) {
+    return doubleMatrix(table.columns(columnNames));
+  }
+
+  public float[][] floatMatrix() {
+    return floatMatrix(table.columns());
+  }
+
+  public float[][] floatMatrix(int... columnIndicies) {
+    return floatMatrix(table.columns(columnIndicies));
+  }
+
+  public float[][] floatMatrix(String... columnNames) {
+    return floatMatrix(table.columns(columnNames));
+  }
+  
+  public int[][] intMatrix() {
+    return intMatrix(table.columns());
+  }
+
+  public int[][] intMatrix(int... columnIndicies) {
+    return intMatrix(table.columns(columnIndicies));
+  }
+
+  public int[][] intMatrix(String... columnNames) {
+    return intMatrix(table.columns(columnNames));
+  }
+
+  private static double[][] doubleMatrix(List<Column> columns) {
+    Preconditions.checkArgument(columns.size() >= 1);
+    int obs = columns.get(0).size();
+    double[][] allVals = new double[obs][columns.size()];
+
+    for (int r = 0; r < obs; r++) {
+      for (int c = 0; c < columns.size(); c++) {
+        allVals[r][c] = columns.get(c).getDouble(r);
+      }
+    }
+    return allVals;
+  }
+
+  private static float[][] floatMatrix(List<Column> columns) {
+    Preconditions.checkArgument(columns.size() >= 1);
+    int obs = columns.get(0).size();
+    float[][] allVals = new float[obs][columns.size()];
+
+    for (int r = 0; r < obs; r++) {
+      for (int c = 0; c < columns.size(); c++) {
+        allVals[r][c] = (float) columns.get(c).getDouble(r);
+      }
+    }
+    return allVals;
+  }
+
+  private static int[][] intMatrix(List<Column> columns) {
+    Preconditions.checkArgument(columns.size() >= 1);
+    int obs = columns.get(0).size();
+    int[][] allVals = new int[obs][columns.size()];
+
+    for (int r = 0; r < obs; r++) {
+      for (int c = 0; c < columns.size(); c++) {
+        allVals[r][c] = (int) columns.get(c).getDouble(r);
+      }
+    }
+    return allVals;
+  }
+
+}

--- a/core/src/main/java/tech/tablesaw/table/Relation.java
+++ b/core/src/main/java/tech/tablesaw/table/Relation.java
@@ -26,11 +26,12 @@ import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.api.TimeColumn;
 import tech.tablesaw.columns.Column;
+import tech.tablesaw.conversion.TableConverter;
 import tech.tablesaw.io.string.DataFramePrinter;
 import tech.tablesaw.sorting.comparators.DescendingIntComparator;
-import tech.tablesaw.util.DoubleArrays;
 
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -51,7 +52,7 @@ public abstract class Relation {
         return rowCount() + " rows X " + columnCount() + " cols";
     }
 
-    public Relation removeColumns(int ... columnIndexes) {
+    public Relation removeColumns(int... columnIndexes) {
         IntArrays.quickSort(columnIndexes, DescendingIntComparator.instance());
         for (int i : columnIndexes) {
             removeColumns(column(i));
@@ -129,6 +130,28 @@ public abstract class Relation {
      * Returns a list of all the columns in the relation
      */
     public abstract List<Column> columns();
+
+    /**
+     * Returns the columns whose names are given in the input array
+     */
+    public List<Column> columns(String... columnName) {
+        List<Column> cols = new ArrayList<>(columnName.length);
+        for (int i = 0; i < columnName.length; i++) {
+            cols.add(column(columnName[i]));
+        }
+        return cols;
+    }
+
+    /**
+     * Returns the columns whose indices are given in the input array
+     */
+    public List<Column> columns(int... columnIndices) {
+        List<Column> cols = new ArrayList<>(columnIndices.length);
+        for (int i : columnIndices) {
+            cols.add(column(i));
+        }
+        return cols;
+    }
 
     /**
      * Returns the index of the given column
@@ -354,8 +377,8 @@ public abstract class Relation {
         return (DateTimeColumn) column(columnName);
     }
 
-    public double[][] asMatrix() {
-        return DoubleArrays.to2dArray(columns());
+    public TableConverter as() {
+        return new TableConverter(this);
     }
 
     public String getUnformatted(int r1, int c) {

--- a/core/src/main/java/tech/tablesaw/util/DoubleArrays.java
+++ b/core/src/main/java/tech/tablesaw/util/DoubleArrays.java
@@ -14,14 +14,6 @@
 
 package tech.tablesaw.util;
 
-import com.google.common.base.Preconditions;
-import tech.tablesaw.api.NumberColumn;
-import tech.tablesaw.columns.Column;
-import tech.tablesaw.table.TableSlice;
-import tech.tablesaw.table.TableSliceGroup;
-
-import java.util.List;
-
 /**
  * Utility functions for creating 2D double arrays from columns and other arrays
  */
@@ -38,54 +30,4 @@ public class DoubleArrays {
         return result;
     }
 
-    public static double[][] to2dArray(Column... columns) {
-        Preconditions.checkArgument(columns.length >= 1);
-        int obs = columns[0].size();
-        double[][] allVals = new double[obs][columns.length];
-
-        for (int r = 0; r < obs; r++) {
-            for (int c = 0; c < columns.length; c++) {
-                allVals[r][c] = columns[c].getDouble(r);
-            }
-        }
-        return allVals;
-    }
-
-    public static double[][] to2dArray(List<Column> columnList) {
-        return to2dArray(columnList.toArray(new Column[columnList.size()]));
-    }
-
-    public static double[][] to2dArray(TableSliceGroup views, int columnNumber) {
-
-        int viewCount = views.size();
-
-        double[][] allVals = new double[viewCount][];
-        for (int viewNumber = 0; viewNumber < viewCount; viewNumber++) {
-            TableSlice view = views.get(viewNumber);
-            allVals[viewNumber] = new double[view.rowCount()];
-            NumberColumn numberColumn = view.numberColumn(columnNumber);
-            for (int r = 0; r < view.rowCount(); r++) {
-                allVals[viewNumber][r] = numberColumn.get(r);
-            }
-        }
-        return allVals;
-    }
-
-    public static double[][] to2dArray(double[] x, double[] y) {
-        double[][] allVals = new double[x.length][2];
-        for (int i = 0; i < x.length; i++) {
-            allVals[i][0] = x[i];
-            allVals[i][1] = y[i];
-        }
-        return allVals;
-    }
-
-    public static double[][] to2dArray(Column x, Column y) {
-        double[][] allVals = new double[x.size()][2];
-        for (int i = 0; i < x.size(); i++) {
-            allVals[i][0] = x.getDouble(i);
-            allVals[i][1] = y.getDouble(i);
-        }
-        return allVals;
-    }
 }

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -432,7 +432,7 @@ public class TableTest {
         NumberColumn third =  DoubleColumn.create("c3", new double[]{10.0, 20.0, 30.0, 40.0, 50.0});
 
         Table t = Table.create("table", first, second, third);
-        double[][] matrix = t.asMatrix();
+        double[][] matrix = t.as().doubleMatrix();
         assertEquals(5, matrix.length);
         assertArrayEquals(new double[]{1.0, 6.0, 10.0}, matrix[0], 0.0000001);
         assertArrayEquals(new double[]{2.0, 7.0, 20.0}, matrix[1], 0.0000001);

--- a/core/src/test/java/tech/tablesaw/conversion/TableConverterTest.java
+++ b/core/src/test/java/tech/tablesaw/conversion/TableConverterTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.tablesaw.conversion;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.Table;
+
+public class TableConverterTest {
+
+    @Test
+    public void asDoubleMatrix() {
+        double[] array1 = {0, 1, 2};
+        double[] array2 = {0, 1, 2};
+
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
+        Table table = Table.create("test", c1, c2);
+
+        double[][] expected = {{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}};
+        double[][] results = table.as().doubleMatrix();
+        assertTrue(Arrays.deepEquals(expected, results));
+    }
+
+    @Test
+    public void asDoubleMatrixColArgs() {
+        double[] array1 = {0, 1, 1};
+        double[] array2 = {0, 1, 2};
+        double[] array3 = {0, 1, 3};
+
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
+        DoubleColumn c3 = DoubleColumn.create("3", array3);
+        Table table = Table.create("test", c1, c2, c3);
+
+        double[][] expected = {{0.0, 0.0}, {1.0, 1.0}, {1.0, 3.0}};
+        double[][] results = table.as().doubleMatrix("1", "3");
+        assertTrue(Arrays.deepEquals(expected, results));
+    }    
+
+    @Test
+    public void asIntMatrix() {
+        double[] array1 = {0, 1, 2};
+        double[] array2 = {0, 1, 2};
+
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
+        Table table = Table.create("test", c1, c2);
+
+        int[][] expected = {{0, 0}, {1, 1}, {2, 2}};
+        int[][] results = table.as().intMatrix();
+        assertTrue(Arrays.deepEquals(expected, results));
+    }
+
+    @Test
+    public void asIntMatrixColArgs() {
+        double[] array1 = {0, 1, 1};
+        double[] array2 = {0, 1, 2};
+        double[] array3 = {0, 1, 3};
+
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
+        DoubleColumn c3 = DoubleColumn.create("3", array3);
+        Table table = Table.create("test", c1, c2, c3);
+
+        int[][] expected = {{0, 0}, {1, 1}, {1, 3}};
+        int[][] results = table.as().intMatrix("1", "3");
+        assertTrue(Arrays.deepEquals(expected, results));
+    }
+
+    @Test
+    public void asFloatMatrix() {
+        double[] array1 = {0, 1, 2};
+        double[] array2 = {0, 1, 2};
+
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
+        Table table = Table.create("test", c1, c2);
+
+        float[][] expected = {{0.0f, 0.0f}, {1.0f, 1.0f}, {2.0f, 2.0f}};
+        float[][] results = table.as().floatMatrix();
+        assertTrue(Arrays.deepEquals(expected, results));
+    }
+
+    @Test
+    public void asFloatMatrixColArgs() {
+        double[] array1 = {0, 1, 1};
+        double[] array2 = {0, 1, 2};
+        double[] array3 = {0, 1, 3};
+
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
+        DoubleColumn c3 = DoubleColumn.create("3", array3);
+        Table table = Table.create("test", c1, c2, c3);
+
+        float[][] expected = {{0.0f, 0.0f}, {1.0f, 1.0f}, {1.0f, 3.0f}};
+        float[][] results = table.as().floatMatrix("1", "3");
+        assertTrue(Arrays.deepEquals(expected, results));
+    }
+}

--- a/core/src/test/java/tech/tablesaw/util/DoubleArraysTest.java
+++ b/core/src/test/java/tech/tablesaw/util/DoubleArraysTest.java
@@ -14,30 +14,13 @@
 
 package tech.tablesaw.util;
 
-import com.google.common.collect.Lists;
-import org.junit.Test;
-import tech.tablesaw.api.DoubleColumn;
-import tech.tablesaw.api.Table;
-import tech.tablesaw.columns.Column;
-import tech.tablesaw.table.TableSliceGroup;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-
 import static org.junit.Assert.assertTrue;
 
-/**
- *
- */
-public class DoubleArraysTest {
+import java.util.Arrays;
 
-    @Test
-    public void testTo2dArray() throws Exception {
-        Table table = Table.read().csv("../data/tornadoes_1950-2014.csv");
-        TableSliceGroup tableSliceGroup = table.splitOn(table.numberColumn("Scale"));
-        int columnNuumber = table.columnIndex("Injuries");
-        DoubleArrays.to2dArray(tableSliceGroup, columnNuumber);
-    }
+import org.junit.Test;
+
+public class DoubleArraysTest {
 
     @Test
     public void testToN() {
@@ -45,40 +28,4 @@ public class DoubleArraysTest {
         assertTrue(Arrays.equals(array, DoubleArrays.toN(3)));
     }
 
-    @Test
-    public void testTo2DArray2() {
-        double[] array1 = {0, 1, 2};
-        double[] array2 = {0, 1, 2};
-
-        double[][] expected = {{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}};
-        double[][] results = DoubleArrays.to2dArray(array1, array2);
-        assertTrue(Arrays.deepEquals(expected, results));
-    }
-
-    @Test
-    public void testTo2DArray3() {
-        double[] array1 = {0, 1, 2};
-        double[] array2 = {0, 1, 2};
-
-        DoubleColumn c1 = DoubleColumn.create("1", array1);
-        DoubleColumn c2 = DoubleColumn.create("2", array2);
-
-        double[][] expected = {{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}};
-        double[][] results = DoubleArrays.to2dArray(c1, c2);
-        assertTrue(Arrays.deepEquals(expected, results));
-    }
-
-    @Test
-    public void testTo2DArray4() {
-        double[] array1 = {0, 1, 2};
-        double[] array2 = {0, 1, 2};
-
-        DoubleColumn c1 = DoubleColumn.create("1", array1);
-        DoubleColumn c2 = DoubleColumn.create("2", array2);
-        ArrayList<Column> columnArrayList = Lists.newArrayList(c1, c2);
-
-        double[][] expected = {{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}};
-        double[][] results = DoubleArrays.to2dArray(columnArrayList);
-        assertTrue(Arrays.deepEquals(expected, results));
-    }
 }


### PR DESCRIPTION
- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This makes using Tablesaw with Smile a bit smoother as described in https://github.com/jtablesaw/tablesaw/issues/280#issuecomment-403702698.

Converting to double arrays and matrices is super common. E.g.:
```
moneyball.numberColumn("RD").asDoubleArray()
moneyball.copy().retainColumns("W").asMatrix()
```

This PR provides a much simpler API for this common operation:
```
moneyball.asDoubleArray("RD")
moneyball.asMatrix("W")
```
