### PR TITLE
Provide converter to Smile's AttributeDataset

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -121,6 +121,12 @@
             <version>0.7.14</version>
         </dependency>
         <dependency>
+            <groupId>com.github.haifengl</groupId>
+            <artifactId>smile-data</artifactId>
+            <version>1.5.1 </version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.2</version>


### PR DESCRIPTION
Smile defines an `AttributeDataset`, which is essentially the same thing as a Tablesaw `Table`

A lot of Smile algorithms take `AttributeDataset` as input, so this will make it easier still to interface with Smile. The dependency is `optional` which means `Smile` should not be added to your classpath, but if you're using `Smile` already you can simply call `table.as().smileDataset(...)`

It will also let us support named variables. The `Attribute`s are essentially column metadata such as the variable name. In the next release of Smile, `OLS` will have an `AttributeDataset` constructor which solves the variable name problem with that algorithm. Once a release is cut, you can simply do `new OLS(table.as().smileDataset(...))`. Let me know if you encounter other algorithms which you think should take an `AttributeDataset` and do not today