### PR TITLE
Made ColumnType an interface

### DIFF
--- a/core/src/examples/java/tech/tablesaw/CrossTabsExample.java
+++ b/core/src/examples/java/tech/tablesaw/CrossTabsExample.java
@@ -21,36 +21,30 @@ public class CrossTabsExample {
         // make table print as integers with no decimals instead of the raw doubles it holds
         counts.columnsOfType(ColumnType.NUMBER)
                 .forEach(x -> ((NumberColumn)x).setPrintFormatter(NumberColumnFormatter.ints()));
-        System.out.println(counts);
 
         // single variable counts
         Table whoCounts = table.xTabCounts("who");
         whoCounts.columnsOfType(ColumnType.NUMBER)
                 .forEach(x -> ((NumberColumn)x).setPrintFormatter(NumberColumnFormatter.ints()));
-        System.out.println(whoCounts);
 
         // single variable percents
         Table whoPercents = table.xTabPercents("who");
         whoPercents.columnsOfType(ColumnType.NUMBER)
                 .forEach(x -> ((NumberColumn)x).setPrintFormatter(NumberColumnFormatter.percent(0)));
-        System.out.println(whoPercents);
 
         // table percents
         Table tablePercents = table.xTabTablePercents("month", "who");
         tablePercents.columnsOfType(ColumnType.NUMBER)
                 .forEach(x -> ((NumberColumn)x).setPrintFormatter(NumberColumnFormatter.percent(1)));
-        System.out.println(tablePercents);
 
         // column percents
         Table columnPercents = table.xTabColumnPercents("month", "who");
         columnPercents.columnsOfType(ColumnType.NUMBER)
                 .forEach(x -> ((NumberColumn)x).setPrintFormatter(NumberColumnFormatter.percent(0)));
-        System.out.println(columnPercents);
 
         // row percents
         Table rowPercents = table.xTabRowPercents("month", "who");
         rowPercents.columnsOfType(ColumnType.NUMBER)
                 .forEach(x -> ((NumberColumn)x).setPrintFormatter(NumberColumnFormatter.percent(0)));
-        System.out.println(rowPercents);
     }
 }

--- a/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
@@ -221,11 +221,6 @@ public class BooleanColumn extends AbstractColumn implements BooleanMapUtils, Ca
         return new BooleanColumn(name() + " Unique values", list);
     }
 
-    @Override
-    public ColumnType type() {
-        return BOOLEAN;
-    }
-
     public BooleanColumn append(boolean b) {
         if (b) {
             data.add(BYTE_TRUE);

--- a/core/src/main/java/tech/tablesaw/api/ColumnType.java
+++ b/core/src/main/java/tech/tablesaw/api/ColumnType.java
@@ -1,69 +1,63 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package tech.tablesaw.api;
 
-
+import com.google.common.base.Preconditions;
 import tech.tablesaw.columns.Column;
 
-/**
- * Defines the type of data held by a {@link Column}
- */
-public enum ColumnType {
+import java.util.ArrayList;
+import java.util.List;
 
-    BOOLEAN(Byte.MIN_VALUE, 1, "Boolean"),
-    STRING("", 4, "String"),
-    NUMBER(Double.NaN, 8, "Number"),
-    LOCAL_DATE(Integer.MIN_VALUE, 4, "Date"),
-    LOCAL_DATE_TIME(Long.MIN_VALUE, 8, "DateTime"),
-    LOCAL_TIME(Integer.MIN_VALUE, 4, "Time"),
-    SKIP(null, 0, "Skipped");
+public interface ColumnType {
 
-    private final Comparable<?> missingValue;
+    List<ColumnType> values = new ArrayList<>();
 
-    private final int byteSize;
+    // standard column types
+    ColumnType BOOLEAN = new StandardColumnType(Byte.MIN_VALUE, 1, "BOOLEAN", "Boolean");
+    ColumnType STRING = new StandardColumnType("", 4, "STRING", "String");
+    ColumnType NUMBER = new StandardColumnType(Double.NaN, 8, "NUMBER", "Number");
+    ColumnType LOCAL_DATE = new StandardColumnType(Integer.MIN_VALUE, 4, "LOCAL_DATE", "Date");
+    ColumnType LOCAL_DATE_TIME = new StandardColumnType(Long.MIN_VALUE, 8, "LOCAL_DATE_TIME","DateTime");
+    ColumnType LOCAL_TIME = new StandardColumnType(Integer.MIN_VALUE, 4, "LOCAL_TIME", "Time");
+    ColumnType SKIP = new StandardColumnType(null, 0, "SKIP", "Skipped");
 
-    private final String printerFriendlyName;
-
-    ColumnType(Comparable<?> missingValue, int byteSize, String name) {
-        this.missingValue = missingValue;
-        this.byteSize = byteSize;
-        this.printerFriendlyName = name;
+    static void register(ColumnType type) {
+        values.add(type);
     }
 
-    public Column create(String name) {
-        switch (this) {
-            case BOOLEAN: return BooleanColumn.create(name);
-            case STRING: return StringColumn.create(name);
-            case NUMBER: return DoubleColumn.create(name);
-            case LOCAL_DATE: return DateColumn.create(name);
-            case LOCAL_DATE_TIME: return DateTimeColumn.create(name);
-            case LOCAL_TIME: return TimeColumn.create(name);
-            case SKIP: throw new IllegalArgumentException("Cannot create column of type SKIP");
+    static ColumnType[] values() {
+        return values.toArray(new ColumnType[0]);
+    }
+
+    static ColumnType valueOf(String name) {
+        Preconditions.checkNotNull(name);
+
+        for (ColumnType type : values) {
+            if (type.name().equals(name)) {
+                return type;
+            }
         }
-        throw new UnsupportedOperationException("Column type " + this.name() + " doesn't support column creation");
+        throw new IllegalArgumentException(name + " is not a registered column type.");
     }
 
-    public Comparable<?> getMissingValue() {
-        return missingValue;
+    default Column create(String name) {
+        final String columnTypeName = this.name();
+        switch (columnTypeName) {
+            case "BOOLEAN": return BooleanColumn.create(name);
+            case "STRING": return StringColumn.create(name);
+            case "NUMBER": return DoubleColumn.create(name);
+            case "LOCAL_DATE": return DateColumn.create(name);
+            case "LOCAL_DATE_TIME": return DateTimeColumn.create(name);
+            case "LOCAL_TIME": return TimeColumn.create(name);
+            case "SKIP": throw new IllegalArgumentException("Cannot create column of type SKIP");
+        }
+        throw new UnsupportedOperationException("Column type " + name() + " doesn't support column creation");
     }
 
-    public int byteSize() {
-        return byteSize;
-    }
+    String name();
 
-    public String getPrinterFriendlyName() {
-        return printerFriendlyName;
-    }
+    Comparable<?> getMissingValue();
+
+    int byteSize();
+
+    String getPrinterFriendlyName();
+
 }

--- a/core/src/main/java/tech/tablesaw/api/ColumnType.java
+++ b/core/src/main/java/tech/tablesaw/api/ColumnType.java
@@ -2,6 +2,7 @@ package tech.tablesaw.api;
 
 import com.google.common.base.Preconditions;
 import tech.tablesaw.columns.Column;
+import tech.tablesaw.columns.ColumnTypeImpl;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -11,13 +12,13 @@ public interface ColumnType {
     Map<String, ColumnType> values = new HashMap<>();
 
     // standard column types
-    ColumnType BOOLEAN = new StandardColumnType(Byte.MIN_VALUE, 1, "BOOLEAN", "Boolean");
-    ColumnType STRING = new StandardColumnType("", 4, "STRING", "String");
-    ColumnType NUMBER = new StandardColumnType(Double.NaN, 8, "NUMBER", "Number");
-    ColumnType LOCAL_DATE = new StandardColumnType(Integer.MIN_VALUE, 4, "LOCAL_DATE", "Date");
-    ColumnType LOCAL_DATE_TIME = new StandardColumnType(Long.MIN_VALUE, 8, "LOCAL_DATE_TIME","DateTime");
-    ColumnType LOCAL_TIME = new StandardColumnType(Integer.MIN_VALUE, 4, "LOCAL_TIME", "Time");
-    ColumnType SKIP = new StandardColumnType(null, 0, "SKIP", "Skipped");
+    ColumnType BOOLEAN = new ColumnTypeImpl(Byte.MIN_VALUE, 1, "BOOLEAN", "Boolean");
+    ColumnType STRING = new ColumnTypeImpl("", 4, "STRING", "String");
+    ColumnType NUMBER = new ColumnTypeImpl(Double.NaN, 8, "NUMBER", "Number");
+    ColumnType LOCAL_DATE = new ColumnTypeImpl(Integer.MIN_VALUE, 4, "LOCAL_DATE", "Date");
+    ColumnType LOCAL_DATE_TIME = new ColumnTypeImpl(Long.MIN_VALUE, 8, "LOCAL_DATE_TIME","DateTime");
+    ColumnType LOCAL_TIME = new ColumnTypeImpl(Integer.MIN_VALUE, 4, "LOCAL_TIME", "Time");
+    ColumnType SKIP = new ColumnTypeImpl(null, 0, "SKIP", "Skipped");
 
     static void register(ColumnType type) {
         values.put(type.name(), type);

--- a/core/src/main/java/tech/tablesaw/api/ColumnType.java
+++ b/core/src/main/java/tech/tablesaw/api/ColumnType.java
@@ -48,8 +48,9 @@ public interface ColumnType {
             case "LOCAL_DATE_TIME": return DateTimeColumn.create(name);
             case "LOCAL_TIME": return TimeColumn.create(name);
             case "SKIP": throw new IllegalArgumentException("Cannot create column of type SKIP");
+            default:
+                throw new UnsupportedOperationException("Column type " + name() + " doesn't support column creation");
         }
-        throw new UnsupportedOperationException("Column type " + name() + " doesn't support column creation");
     }
 
     String name();

--- a/core/src/main/java/tech/tablesaw/api/ColumnType.java
+++ b/core/src/main/java/tech/tablesaw/api/ColumnType.java
@@ -3,12 +3,12 @@ package tech.tablesaw.api;
 import com.google.common.base.Preconditions;
 import tech.tablesaw.columns.Column;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 public interface ColumnType {
 
-    List<ColumnType> values = new ArrayList<>();
+    Map<String, ColumnType> values = new HashMap<>();
 
     // standard column types
     ColumnType BOOLEAN = new StandardColumnType(Byte.MIN_VALUE, 1, "BOOLEAN", "Boolean");
@@ -20,22 +20,21 @@ public interface ColumnType {
     ColumnType SKIP = new StandardColumnType(null, 0, "SKIP", "Skipped");
 
     static void register(ColumnType type) {
-        values.add(type);
+        values.put(type.name(), type);
     }
 
     static ColumnType[] values() {
-        return values.toArray(new ColumnType[0]);
+        return values.values().toArray(new ColumnType[0]);
     }
 
     static ColumnType valueOf(String name) {
         Preconditions.checkNotNull(name);
 
-        for (ColumnType type : values) {
-            if (type.name().equals(name)) {
-                return type;
-            }
+        ColumnType result = values.get(name);
+        if (result == null) {
+            throw new IllegalArgumentException(name + " is not a registered column type.");
         }
-        throw new IllegalArgumentException(name + " is not a registered column type.");
+        return result;
     }
 
     default Column create(String name) {
@@ -60,5 +59,4 @@ public interface ColumnType {
     int byteSize();
 
     String getPrinterFriendlyName();
-
 }

--- a/core/src/main/java/tech/tablesaw/api/ColumnType.java
+++ b/core/src/main/java/tech/tablesaw/api/ColumnType.java
@@ -1,8 +1,14 @@
 package tech.tablesaw.api;
 
 import com.google.common.base.Preconditions;
+import tech.tablesaw.columns.booleans.BooleanColumnType;
 import tech.tablesaw.columns.Column;
-import tech.tablesaw.columns.ColumnTypeImpl;
+import tech.tablesaw.columns.dates.DateColumnType;
+import tech.tablesaw.columns.datetimes.DateTimeColumnType;
+import tech.tablesaw.columns.numbers.DoubleColumnType;
+import tech.tablesaw.columns.SkipColumnType;
+import tech.tablesaw.columns.strings.StringColumnType;
+import tech.tablesaw.columns.times.TimeColumnType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -12,13 +18,13 @@ public interface ColumnType {
     Map<String, ColumnType> values = new HashMap<>();
 
     // standard column types
-    ColumnType BOOLEAN = new ColumnTypeImpl(Byte.MIN_VALUE, 1, "BOOLEAN", "Boolean");
-    ColumnType STRING = new ColumnTypeImpl("", 4, "STRING", "String");
-    ColumnType NUMBER = new ColumnTypeImpl(Double.NaN, 8, "NUMBER", "Number");
-    ColumnType LOCAL_DATE = new ColumnTypeImpl(Integer.MIN_VALUE, 4, "LOCAL_DATE", "Date");
-    ColumnType LOCAL_DATE_TIME = new ColumnTypeImpl(Long.MIN_VALUE, 8, "LOCAL_DATE_TIME","DateTime");
-    ColumnType LOCAL_TIME = new ColumnTypeImpl(Integer.MIN_VALUE, 4, "LOCAL_TIME", "Time");
-    ColumnType SKIP = new ColumnTypeImpl(null, 0, "SKIP", "Skipped");
+    ColumnType BOOLEAN = new BooleanColumnType(Byte.MIN_VALUE, 1, "BOOLEAN", "Boolean");
+    ColumnType STRING = new StringColumnType("", 4, "STRING", "String");
+    ColumnType NUMBER = new DoubleColumnType(Double.NaN, 8, "NUMBER", "Number");
+    ColumnType LOCAL_DATE = new DateColumnType(Integer.MIN_VALUE, 4, "LOCAL_DATE", "Date");
+    ColumnType LOCAL_DATE_TIME = new DateTimeColumnType(Long.MIN_VALUE, 8, "LOCAL_DATE_TIME","DateTime");
+    ColumnType LOCAL_TIME = new TimeColumnType(Integer.MIN_VALUE, 4, "LOCAL_TIME", "Time");
+    ColumnType SKIP = new SkipColumnType(null, 0, "SKIP", "Skipped");
 
     static void register(ColumnType type) {
         values.put(type.name(), type);
@@ -38,20 +44,7 @@ public interface ColumnType {
         return result;
     }
 
-    default Column create(String name) {
-        final String columnTypeName = this.name();
-        switch (columnTypeName) {
-            case "BOOLEAN": return BooleanColumn.create(name);
-            case "STRING": return StringColumn.create(name);
-            case "NUMBER": return DoubleColumn.create(name);
-            case "LOCAL_DATE": return DateColumn.create(name);
-            case "LOCAL_DATE_TIME": return DateTimeColumn.create(name);
-            case "LOCAL_TIME": return TimeColumn.create(name);
-            case "SKIP": throw new IllegalArgumentException("Cannot create column of type SKIP");
-            default:
-                throw new UnsupportedOperationException("Column type " + name() + " doesn't support column creation");
-        }
-    }
+    Column create(String name);
 
     String name();
 

--- a/core/src/main/java/tech/tablesaw/api/DateColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateColumn.java
@@ -129,11 +129,6 @@ DateMapFunctions, CategoricalColumn, Iterable<LocalDate> {
         return data.size();
     }
 
-    @Override
-    public ColumnType type() {
-        return ColumnType.LOCAL_DATE;
-    }
-
     public DateColumn appendInternal(int f) {
         data.add(f);
         return this;

--- a/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
@@ -238,11 +238,6 @@ implements DateTimeMapFunctions, DateTimeFilters, DateTimeFillers<DateTimeColumn
         return data;
     }
 
-    @Override
-    public ColumnType type() {
-        return LOCAL_DATE_TIME;
-    }
-
     public DateTimeColumn appendInternal(long dateTime) {
         data.add(dateTime);
         return this;

--- a/core/src/main/java/tech/tablesaw/api/StandardColumnType.java
+++ b/core/src/main/java/tech/tablesaw/api/StandardColumnType.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.tablesaw.api;
+
+
+import com.google.common.base.Objects;
+import tech.tablesaw.columns.Column;
+
+/**
+ * Defines the type of data held by a {@link Column}
+ */
+public class StandardColumnType implements ColumnType {
+
+    private final Comparable<?> missingValue;
+
+    private final int byteSize;
+
+    private final String name;
+
+    private final String printerFriendlyName;
+
+    public StandardColumnType(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
+        this.missingValue = missingValue;
+        this.byteSize = byteSize;
+        this.name = name;
+        this.printerFriendlyName = printerFriendlyName;
+        ColumnType.register(this);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    public Comparable<?> getMissingValue() {
+        return missingValue;
+    }
+
+    public int byteSize() {
+        return byteSize;
+    }
+
+    public String getPrinterFriendlyName() {
+        return printerFriendlyName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StandardColumnType that = (StandardColumnType) o;
+        return byteSize == that.byteSize &&
+                Objects.equal(missingValue, that.missingValue) &&
+                Objects.equal(name, that.name) &&
+                Objects.equal(printerFriendlyName, that.printerFriendlyName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(missingValue, byteSize, name, printerFriendlyName);
+    }
+}

--- a/core/src/main/java/tech/tablesaw/api/StringColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/StringColumn.java
@@ -140,11 +140,6 @@ public class StringColumn extends AbstractColumn
         return get(rowNumber).equals(MISSING_VALUE);
     }
 
-    @Override
-    public ColumnType type() {
-        return STRING;
-    }
-
     public void setPrintFormatter(StringColumnFormatter formatter) {
         Preconditions.checkNotNull(formatter);
         this.printFormatter = formatter;

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -607,29 +607,29 @@ public class Table extends Relation implements Iterable<Row> {
     public void addRow(int rowIndex, Table sourceTable) {
         for (int i = 0; i < columnCount(); i++) {
             Column column = column(i);
-            ColumnType type = column.type();
+            final String type = column.type().name();
             switch (type) {
-                case NUMBER:
+                case "NUMBER":
                     NumberColumn numberColumn = (NumberColumn) column;
                     numberColumn.append(sourceTable.numberColumn(i).get(rowIndex));
                     break;
-                case BOOLEAN:
+                case "BOOLEAN":
                     BooleanColumn booleanColumn = (BooleanColumn) column;
                     booleanColumn.append(sourceTable.booleanColumn(i).get(rowIndex));
                     break;
-                case LOCAL_DATE:
+                case "LOCAL_DATE":
                     DateColumn localDateColumn = (DateColumn) column;
                     localDateColumn.appendInternal(sourceTable.dateColumn(i).getIntInternal(rowIndex));
                     break;
-                case LOCAL_TIME:
+                case "LOCAL_TIME":
                     TimeColumn timeColumn = (TimeColumn) column;
                     timeColumn.appendInternal(sourceTable.timeColumn(i).getIntInternal(rowIndex));
                     break;
-                case LOCAL_DATE_TIME:
+                case "LOCAL_DATE_TIME":
                     DateTimeColumn localDateTimeColumn = (DateTimeColumn) column;
                     localDateTimeColumn.appendInternal(sourceTable.dateTimeColumn(i).getLongInternal(rowIndex));
                     break;
-                case STRING:
+                case "STRING":
                     StringColumn stringColumn = (StringColumn) column;
                     stringColumn.append(sourceTable.stringColumn(i).get(rowIndex));
                     break;
@@ -642,29 +642,29 @@ public class Table extends Relation implements Iterable<Row> {
     public void addRow(Row row) {
         //TODO Implement
         for (Column column : columns()) {
-            ColumnType type = column.type();
+            final String type = column.type().name();
             switch (type) {
-                case NUMBER:
+                case "NUMBER":
                     NumberColumn numberColumn = (NumberColumn) column;
                     numberColumn.append(row.getDouble(column.name()));
                     break;
-                case BOOLEAN:
+                case "BOOLEAN":
                     BooleanColumn booleanColumn = (BooleanColumn) column;
                     booleanColumn.append(row.getBoolean(column.name()));
                     break;
-                case LOCAL_DATE:
+                case "LOCAL_DATE":
                     DateColumn localDateColumn = (DateColumn) column;
                     localDateColumn.appendInternal(row.getPackedDate(column.name()).getPackedValue());
                     break;
-                case LOCAL_TIME:
+                case "LOCAL_TIME":
                     TimeColumn timeColumn = (TimeColumn) column;
                     timeColumn.appendInternal(row.getPackedTime(column.name()).getPackedValue());
                     break;
-                case LOCAL_DATE_TIME:
+                case "LOCAL_DATE_TIME":
                     DateTimeColumn localDateTimeColumn = (DateTimeColumn) column;
                     localDateTimeColumn.appendInternal(row.getPackedDateTime(column.name()).getPackedValue());
                     break;
-                case STRING:
+                case "STRING":
                     StringColumn stringColumn = (StringColumn) column;
                     stringColumn.append(row.getString(column.name()));
                     break;

--- a/core/src/main/java/tech/tablesaw/api/TimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TimeColumn.java
@@ -183,11 +183,6 @@ public class TimeColumn extends AbstractColumn implements CategoricalColumn, Ite
     }
 
     @Override
-    public ColumnType type() {
-        return LOCAL_TIME;
-    }
-
-    @Override
     public String getString(int row) {
         return printFormatter.format(getPackedTime(row));
     }

--- a/core/src/main/java/tech/tablesaw/columns/AbstractColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/AbstractColumnType.java
@@ -21,7 +21,7 @@ import tech.tablesaw.api.ColumnType;
 /**
  * Defines the type of data held by a {@link Column}
  */
-public class ColumnTypeImpl implements ColumnType {
+public abstract class AbstractColumnType implements ColumnType {
 
     private final Comparable<?> missingValue;
 
@@ -31,7 +31,7 @@ public class ColumnTypeImpl implements ColumnType {
 
     private final String printerFriendlyName;
 
-    public ColumnTypeImpl(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
+    protected AbstractColumnType(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
         this.missingValue = missingValue;
         this.byteSize = byteSize;
         this.name = name;
@@ -65,7 +65,7 @@ public class ColumnTypeImpl implements ColumnType {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        ColumnTypeImpl that = (ColumnTypeImpl) o;
+        AbstractColumnType that = (AbstractColumnType) o;
         return byteSize == that.byteSize &&
                 Objects.equal(missingValue, that.missingValue) &&
                 Objects.equal(name, that.name) &&

--- a/core/src/main/java/tech/tablesaw/columns/ColumnTypeImpl.java
+++ b/core/src/main/java/tech/tablesaw/columns/ColumnTypeImpl.java
@@ -12,16 +12,16 @@
  * limitations under the License.
  */
 
-package tech.tablesaw.api;
+package tech.tablesaw.columns;
 
 
 import com.google.common.base.Objects;
-import tech.tablesaw.columns.Column;
+import tech.tablesaw.api.ColumnType;
 
 /**
  * Defines the type of data held by a {@link Column}
  */
-public class StandardColumnType implements ColumnType {
+public class ColumnTypeImpl implements ColumnType {
 
     private final Comparable<?> missingValue;
 
@@ -31,7 +31,7 @@ public class StandardColumnType implements ColumnType {
 
     private final String printerFriendlyName;
 
-    public StandardColumnType(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
+    public ColumnTypeImpl(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
         this.missingValue = missingValue;
         this.byteSize = byteSize;
         this.name = name;
@@ -65,7 +65,7 @@ public class StandardColumnType implements ColumnType {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        StandardColumnType that = (StandardColumnType) o;
+        ColumnTypeImpl that = (ColumnTypeImpl) o;
         return byteSize == that.byteSize &&
                 Objects.equal(missingValue, that.missingValue) &&
                 Objects.equal(name, that.name) &&

--- a/core/src/main/java/tech/tablesaw/columns/SkipColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/SkipColumnType.java
@@ -1,0 +1,13 @@
+package tech.tablesaw.columns;
+
+public class SkipColumnType extends AbstractColumnType {
+
+    public SkipColumnType(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
+        super(missingValue, byteSize, name, printerFriendlyName);
+    }
+
+    @Override
+    public Column create(String name) {
+        throw new UnsupportedOperationException("Column type " + name() + " doesn't support column creation");
+    }
+}

--- a/core/src/main/java/tech/tablesaw/columns/booleans/BooleanColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/booleans/BooleanColumnType.java
@@ -1,0 +1,17 @@
+package tech.tablesaw.columns.booleans;
+
+import tech.tablesaw.api.BooleanColumn;
+import tech.tablesaw.columns.AbstractColumnType;
+import tech.tablesaw.columns.Column;
+
+public class BooleanColumnType extends AbstractColumnType {
+
+    public BooleanColumnType(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
+        super(missingValue, byteSize, name, printerFriendlyName);
+    }
+
+    @Override
+    public Column create(String name) {
+        return BooleanColumn.create(name);
+    }
+}

--- a/core/src/main/java/tech/tablesaw/columns/dates/DateColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/dates/DateColumnType.java
@@ -1,0 +1,16 @@
+package tech.tablesaw.columns.dates;
+
+import tech.tablesaw.api.DateColumn;
+import tech.tablesaw.columns.AbstractColumnType;
+
+public class DateColumnType extends AbstractColumnType {
+
+    public DateColumnType(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
+        super(missingValue, byteSize, name, printerFriendlyName);
+    }
+
+    @Override
+    public DateColumn create(String name) {
+        return DateColumn.create(name);
+    }
+}

--- a/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeColumnType.java
@@ -1,0 +1,16 @@
+package tech.tablesaw.columns.datetimes;
+
+import tech.tablesaw.api.DateTimeColumn;
+import tech.tablesaw.columns.AbstractColumnType;
+
+public class DateTimeColumnType extends AbstractColumnType {
+
+    public DateTimeColumnType(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
+        super(missingValue, byteSize, name, printerFriendlyName);
+    }
+
+    @Override
+    public DateTimeColumn create(String name) {
+        return DateTimeColumn.create(name);
+    }
+}

--- a/core/src/main/java/tech/tablesaw/columns/numbers/DoubleColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/DoubleColumnType.java
@@ -1,0 +1,16 @@
+package tech.tablesaw.columns.numbers;
+
+import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.columns.AbstractColumnType;
+
+public class DoubleColumnType extends AbstractColumnType {
+
+    public DoubleColumnType(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
+        super(missingValue, byteSize, name, printerFriendlyName);
+    }
+
+    @Override
+    public DoubleColumn create(String name) {
+        return DoubleColumn.create(name);
+    }
+}

--- a/core/src/main/java/tech/tablesaw/columns/strings/StringColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/StringColumnType.java
@@ -1,0 +1,16 @@
+package tech.tablesaw.columns.strings;
+
+import tech.tablesaw.api.StringColumn;
+import tech.tablesaw.columns.AbstractColumnType;
+
+public class StringColumnType extends AbstractColumnType {
+
+    public StringColumnType(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
+        super(missingValue, byteSize, name, printerFriendlyName);
+    }
+
+    @Override
+    public StringColumn create(String name) {
+        return StringColumn.create(name);
+    }
+}

--- a/core/src/main/java/tech/tablesaw/columns/times/TimeColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/times/TimeColumnType.java
@@ -1,0 +1,16 @@
+package tech.tablesaw.columns.times;
+
+import tech.tablesaw.api.TimeColumn;
+import tech.tablesaw.columns.AbstractColumnType;
+
+public class TimeColumnType extends AbstractColumnType {
+
+    public TimeColumnType(Comparable<?> missingValue, int byteSize, String name, String printerFriendlyName) {
+        super(missingValue, byteSize, name, printerFriendlyName);
+    }
+
+    @Override
+    public TimeColumn create(String name) {
+        return TimeColumn.create(name);
+    }
+}

--- a/core/src/main/java/tech/tablesaw/io/TypeUtils.java
+++ b/core/src/main/java/tech/tablesaw/io/TypeUtils.java
@@ -239,18 +239,19 @@ public final class TypeUtils {
         Preconditions.checkArgument(type != ColumnType.SKIP,
                 "SKIP-ped columns should be handled outside of this method.");
 
-        switch (type) {
-            case LOCAL_DATE:
+        final String columnTypeName = type.name();
+        switch (columnTypeName) {
+            case "LOCAL_DATE":
                 return DateColumn.create(name);
-            case LOCAL_TIME:
+            case "LOCAL_TIME":
                 return TimeColumn.create(name);
-            case LOCAL_DATE_TIME:
+            case "LOCAL_DATE_TIME":
                 return DateTimeColumn.create(name);
-            case NUMBER:
+            case "NUMBER":
                 return DoubleColumn.create(name);
-            case BOOLEAN:
+            case "BOOLEAN":
                 return BooleanColumn.create(name);
-            case STRING:
+            case "STRING":
                 return StringColumn.create(name);
             default:
                 throw new IllegalArgumentException("Unknown ColumnType: " + type);

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReader.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReader.java
@@ -254,18 +254,18 @@ public class CsvReader {
     }
 
     private static void addFormatter(Column newColumn, CsvReadOptions options) {
-        switch (newColumn.type()) {
-            case LOCAL_DATE_TIME :
+        final String columnTypeName = newColumn.type().name();
+        switch (columnTypeName) {
+            case "LOCAL_DATE_TIME" :
                 ((DateTimeColumn) newColumn).setFormatter(options.dateTimeFormatter());
                 return;
-            case LOCAL_DATE:
+            case "LOCAL_DATE":
                 ((DateColumn) newColumn).setFormatter(options.dateFormatter());
                 return;
-            case LOCAL_TIME :
+            case "LOCAL_TIME" :
                 ((TimeColumn) newColumn).setFormatter(options.timeFormatter());
                 return;
             default:
-                return;
         }
     }
 
@@ -510,7 +510,7 @@ public class CsvReader {
             ColumnType detectedType = detectType(valuesList, options);
             columnTypes.add(detectedType);
         }
-        return columnTypes.toArray(new ColumnType[columnTypes.size()]);
+        return columnTypes.toArray(new ColumnType[0]);
     }
 
     private static int nextRowWithoutSampling(int nextRow) {

--- a/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
+++ b/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
@@ -31,8 +31,8 @@ import java.sql.Types;
  */
 public class SqlResultSetReader {
 
-    // Maps from supported SQL types to their Airframe 'equivalents'
-    private static final ImmutableMap<Integer, ColumnType> SQL_TYPE_TO_Airframe_TYPE =
+    // Maps from supported SQL types to their Tablesaw equivalents'
+    private static final ImmutableMap<Integer, ColumnType> SQL_TYPE_TO_TABLESAW_TYPE =
             new ImmutableMap.Builder<Integer, ColumnType>()
                     .put(Types.BINARY, ColumnType.BOOLEAN)
                     .put(Types.BOOLEAN, ColumnType.BOOLEAN)
@@ -75,7 +75,7 @@ public class SqlResultSetReader {
         for (int i = 1; i <= metaData.getColumnCount(); i++) {
             String name = metaData.getColumnName(i);
 
-            ColumnType type = SQL_TYPE_TO_Airframe_TYPE.get(metaData.getColumnType(i));
+            ColumnType type = SQL_TYPE_TO_TABLESAW_TYPE.get(metaData.getColumnType(i));
             Preconditions.checkState(type != null,
                     "No column type found for %s as specified for column %s", metaData.getColumnType(i), name);
 

--- a/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
+++ b/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
@@ -25,6 +25,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Creates a Relation from the result of a SQL query, by passing the jdbc resultset to the constructor
@@ -32,34 +34,48 @@ import java.sql.Types;
 public class SqlResultSetReader {
 
     // Maps from supported SQL types to their Tablesaw equivalents'
-    private static final ImmutableMap<Integer, ColumnType> SQL_TYPE_TO_TABLESAW_TYPE =
-            new ImmutableMap.Builder<Integer, ColumnType>()
-                    .put(Types.BINARY, ColumnType.BOOLEAN)
-                    .put(Types.BOOLEAN, ColumnType.BOOLEAN)
-                    .put(Types.BIT, ColumnType.BOOLEAN)
+    private static final Map<Integer, ColumnType> SQL_TYPE_TO_TABLESAW_TYPE = initializeMap();
 
-                    .put(Types.DATE, ColumnType.LOCAL_DATE)
-                    .put(Types.TIME, ColumnType.LOCAL_TIME)
-                    .put(Types.TIMESTAMP, ColumnType.LOCAL_DATE_TIME)
+    private static Map<Integer, ColumnType> initializeMap() {
+        return new HashMap<>(
+                new ImmutableMap.Builder<Integer, ColumnType>()
+                .put(Types.BINARY, ColumnType.BOOLEAN)
+                .put(Types.BOOLEAN, ColumnType.BOOLEAN)
+                .put(Types.BIT, ColumnType.BOOLEAN)
 
-                    .put(Types.DECIMAL, ColumnType.NUMBER)
-                    .put(Types.DOUBLE, ColumnType.NUMBER)
-                    .put(Types.FLOAT, ColumnType.NUMBER)
-                    .put(Types.NUMERIC, ColumnType.NUMBER)
-                    .put(Types.REAL, ColumnType.NUMBER)
+                .put(Types.DATE, ColumnType.LOCAL_DATE)
+                .put(Types.TIME, ColumnType.LOCAL_TIME)
+                .put(Types.TIMESTAMP, ColumnType.LOCAL_DATE_TIME)
 
-                    .put(Types.INTEGER, ColumnType.NUMBER)
-                    .put(Types.SMALLINT, ColumnType.NUMBER)
-                    .put(Types.TINYINT, ColumnType.NUMBER)
-                    .put(Types.BIGINT, ColumnType.NUMBER)
+                .put(Types.DECIMAL, ColumnType.NUMBER)
+                .put(Types.DOUBLE, ColumnType.NUMBER)
+                .put(Types.FLOAT, ColumnType.NUMBER)
+                .put(Types.NUMERIC, ColumnType.NUMBER)
+                .put(Types.REAL, ColumnType.NUMBER)
 
-                    .put(Types.CHAR, ColumnType.STRING)
-                    .put(Types.LONGVARCHAR, ColumnType.STRING)
-                    .put(Types.LONGNVARCHAR, ColumnType.STRING)
-                    .put(Types.NCHAR, ColumnType.STRING)
-                    .put(Types.NVARCHAR, ColumnType.STRING)
-                    .put(Types.VARCHAR, ColumnType.STRING)
-                    .build();
+                .put(Types.INTEGER, ColumnType.NUMBER)
+                .put(Types.SMALLINT, ColumnType.NUMBER)
+                .put(Types.TINYINT, ColumnType.NUMBER)
+                .put(Types.BIGINT, ColumnType.NUMBER)
+
+                .put(Types.CHAR, ColumnType.STRING)
+                .put(Types.LONGVARCHAR, ColumnType.STRING)
+                .put(Types.LONGNVARCHAR, ColumnType.STRING)
+                .put(Types.NCHAR, ColumnType.STRING)
+                .put(Types.NVARCHAR, ColumnType.STRING)
+                .put(Types.VARCHAR, ColumnType.STRING)
+                .build());
+    }
+
+    /**
+     * Change or add a mapping between the given Jdbc type and column type.
+     * When reading from a database, the db column type is automatically assigned to the associated tablesaw column type
+     * @param jdbc          an int representing a legal value from java.sql.types;
+     * @param columnType    a tablesaw column type
+     */
+    public static void mapJdbcTypeToColumnType(Integer jdbc, ColumnType columnType) {
+        SQL_TYPE_TO_TABLESAW_TYPE.put(jdbc, columnType);
+    }
 
     /**
      * Returns a new table with the given tableName, constructed from the given result set

--- a/core/src/main/java/tech/tablesaw/table/Relation.java
+++ b/core/src/main/java/tech/tablesaw/table/Relation.java
@@ -271,6 +271,14 @@ public abstract class Relation {
         return (BooleanColumn) column(columnName);
     }
 
+    /**
+     * Returns the NumberColumn at the given index.
+     * If the index points to a String or a boolean column, a new NumberColumn is created and returned
+     * TODO(lwhite):Consider separating the indexed access and the column type mods, which must be for ML functions (in smile or elsewhere)
+     * @param columnIndex The 0-based index of a column in the table
+     * @return A number column
+     * @throws ClassCastException if the cast to NumberColumn fails
+     */
     public NumberColumn numberColumn(int columnIndex) {
         Column c = column(columnIndex);
         if (c.type() == ColumnType.STRING) {
@@ -284,15 +292,7 @@ public abstract class Relation {
     }
 
     public NumberColumn numberColumn(String columnName) {
-        Column c = column(columnName);
-        if (c.type() == ColumnType.STRING) {
-            StringColumn stringColumn = (StringColumn) c;
-            return stringColumn.asNumberColumn();
-        } else if (c.type() == ColumnType.BOOLEAN) {
-            BooleanColumn booleanColumn = (BooleanColumn) c;
-            return booleanColumn.asNumberColumn();
-        }
-        return (NumberColumn) column(columnName);
+        return numberColumn(columnIndex(columnName));
     }
 
     public StringColumn[] stringColumns() {

--- a/core/src/main/java/tech/tablesaw/table/Rows.java
+++ b/core/src/main/java/tech/tablesaw/table/Rows.java
@@ -16,7 +16,6 @@ package tech.tablesaw.table;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import tech.tablesaw.api.BooleanColumn;
-import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DateTimeColumn;
 import tech.tablesaw.api.NumberColumn;
@@ -40,29 +39,29 @@ public class Rows {
     public static void copyRowsToTable(IntArrayList rows, Table oldTable, Table newTable) {
 
         for (int columnIndex = 0; columnIndex < oldTable.columnCount(); columnIndex++) {
-            ColumnType columnType = oldTable.column(columnIndex).type();
+            final String columnType = oldTable.column(columnIndex).type().name();
             switch (columnType) {
-                case STRING:
+                case "STRING":
                     copy(rows, (StringColumn) oldTable.column(columnIndex),
                             (StringColumn) newTable.column(columnIndex));
                     break;
-                case BOOLEAN:
+                case "BOOLEAN":
                     copy(rows, (BooleanColumn) oldTable.column(columnIndex),
                             (BooleanColumn) newTable.column(columnIndex));
                     break;
-                case NUMBER:
+                case "NUMBER":
                     copy(rows, (NumberColumn) oldTable.column(columnIndex),
                             (NumberColumn) newTable.column(columnIndex));
                     break;
-                case LOCAL_DATE:
+                case "LOCAL_DATE":
                     copy(rows, (DateColumn) oldTable.column(columnIndex),
                             (DateColumn) newTable.column(columnIndex));
                     break;
-                case LOCAL_DATE_TIME:
+                case "LOCAL_DATE_TIME":
                     copy(rows, (DateTimeColumn) oldTable.column(columnIndex),
                             (DateTimeColumn) newTable.column(columnIndex));
                     break;
-                case LOCAL_TIME:
+                case "LOCAL_TIME":
                     copy(rows, (TimeColumn) oldTable.column(columnIndex),
                             (TimeColumn) newTable.column(columnIndex));
                     break;
@@ -83,34 +82,34 @@ public class Rows {
 
         boolean result;
         for (int columnIndex = 0; columnIndex < original.columnCount(); columnIndex++) {
-            ColumnType columnType = original.column(columnIndex).type();
+            String columnType = original.column(columnIndex).type().name();
             switch (columnType) {
-                case NUMBER:
+                case "NUMBER":
                     result = compare(rowInOriginal, (NumberColumn) tempTable.column(columnIndex), (NumberColumn)
                             original.column(columnIndex));
                     if (!result) return false;
                     break;
-                case STRING:
+                case "STRING":
                     result = compare(rowInOriginal, (StringColumn) tempTable.column(columnIndex), (StringColumn)
                             original.column(columnIndex));
                     if (!result) return false;
                     break;
-                case BOOLEAN:
+                case "BOOLEAN":
                     result = compare(rowInOriginal, (BooleanColumn) tempTable.column(columnIndex), (BooleanColumn)
                             original.column(columnIndex));
                     if (!result) return false;
                     break;
-                case LOCAL_DATE:
+                case "LOCAL_DATE":
                     result = compare(rowInOriginal, (DateColumn) tempTable.column(columnIndex), (DateColumn) original
                             .column(columnIndex));
                     if (!result) return false;
                     break;
-                case LOCAL_DATE_TIME:
+                case "LOCAL_DATE_TIME":
                     result = compare(rowInOriginal, (DateTimeColumn) tempTable.column(columnIndex), (DateTimeColumn)
                             original.column(columnIndex));
                     if (!result) return false;
                     break;
-                case LOCAL_TIME:
+                case "LOCAL_TIME":
                     result = compare(rowInOriginal, (TimeColumn) tempTable.column(columnIndex), (TimeColumn) original
                             .column(columnIndex));
                     if (!result) return false;


### PR DESCRIPTION
Ben, if you could take a look when you some time, it would be greatly appreciated. Also LMK if it seems likely to break anything in client code. 

Thanks very much. 

This code makes ColumnType an interface so it will be easier to create new column types, and perhaps may be possible in the future for library users to add new column types specific to their needs.

Currently, this cannot be done because there are several key statements that switch on column type. It is a future enhancement to eliminate those switch statements by (if possible) moving the requisite logic to the column types.  This would be more object-oriented anyway

The interface subsumes most of the functionality of the enum it replaces, including implementations of methods like values() and valueOf() defined on Enum. The toString is compatible with the enum version. The enum method ordinal() is not supported. 

Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

What was changed
Made ColumnType an interface instead of an enum

## Testing
All tests pass.

Did you add a unit test?
no