### PR TITLE
Fix all StringParser generics warnings

### DIFF
--- a/core/src/main/java/tech/tablesaw/aggregate/AggregateFunction.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/AggregateFunction.java
@@ -6,7 +6,7 @@ import tech.tablesaw.columns.Column;
 /**
  * A partial implementation of aggregate functions to summarize over a numeric column
  */
-public abstract class AggregateFunction<T, C extends Column> {
+public abstract class AggregateFunction<T, C extends Column<?>> {
 
     private final String functionName;
 

--- a/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
@@ -119,7 +119,7 @@ public class AggregateFunctions {
     public static CountFunction countNonMissing = new CountFunction("Count") {
 
         @Override
-        public Integer summarize(Column column) {
+        public Integer summarize(Column<?> column) {
             return column.size() - column.countMissing();
         }
     };
@@ -135,7 +135,7 @@ public class AggregateFunctions {
     public static CountFunction countMissing = new CountFunction("Missing Values") {
 
         @Override
-        public Integer summarize(Column column) {
+        public Integer summarize(Column<?> column) {
             return column.countMissing();
         }
     };
@@ -146,7 +146,7 @@ public class AggregateFunctions {
     public static CountFunction countUnique = new CountFunction("Count Unique") {
 
         @Override
-        public Integer summarize(Column doubles) {
+        public Integer summarize(Column<?> doubles) {
             return removeMissing(doubles.unique()).size();
         }
     };
@@ -184,7 +184,7 @@ public class AggregateFunctions {
     public static final CountFunction countWithMissing = new CountFunction("Count (incl. missing)") {
 
         @Override
-        public Integer summarize(Column column) {
+        public Integer summarize(Column<?> column) {
             return column.size();
         }
     };
@@ -355,7 +355,7 @@ public class AggregateFunctions {
         return column.removeMissing().asDoubleArray();
     }
 
-    private static Column removeMissing(Column column) {
+    private static <T> Column<T> removeMissing(Column<T> column) {
         return column.removeMissing();
     }
 

--- a/core/src/main/java/tech/tablesaw/aggregate/BooleanAggregateFunction.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/BooleanAggregateFunction.java
@@ -6,13 +6,13 @@ import tech.tablesaw.columns.Column;
 /**
  * A partial implementation of aggregate functions to summarize over a boolean column
  */
-public abstract class BooleanAggregateFunction extends AggregateFunction<Boolean, Column> {
+public abstract class BooleanAggregateFunction extends AggregateFunction<Boolean, Column<?>> {
 
     public BooleanAggregateFunction(String name) {
         super(name);
     }
 
-    abstract public Boolean summarize(Column column);
+    abstract public Boolean summarize(Column<?> column);
 
     @Override
     public boolean isCompatableColumn(ColumnType type) {

--- a/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
@@ -30,7 +30,6 @@ import it.unimi.dsi.fastutil.bytes.ByteSet;
 import it.unimi.dsi.fastutil.ints.IntComparator;
 import tech.tablesaw.columns.AbstractColumn;
 import tech.tablesaw.columns.Column;
-import tech.tablesaw.columns.StringParser;
 import tech.tablesaw.columns.booleans.BooleanColumnType;
 import tech.tablesaw.columns.booleans.BooleanColumnUtils;
 import tech.tablesaw.columns.booleans.BooleanFillers;
@@ -290,12 +289,6 @@ public class BooleanColumn extends AbstractColumn<Boolean> implements BooleanMap
     @Override
     public BooleanColumn appendCell(String object) {
         append(BooleanColumnType.DEFAULT_PARSER.parseByte(object));
-        return this;
-    }
-
-    @Override
-    public BooleanColumn appendCell(String object, StringParser parser) {
-        append(parser.parseByte(object));
         return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/api/ColumnType.java
+++ b/core/src/main/java/tech/tablesaw/api/ColumnType.java
@@ -57,9 +57,9 @@ public interface ColumnType {
 
     String getPrinterFriendlyName();
 
-    StringParser defaultParser();
+    StringParser<?> defaultParser();
 
-    StringParser customParser(CsvReadOptions options);
+    StringParser<?> customParser(CsvReadOptions options);
 
     default boolean compare(int rowNumber, Column<?> temp, Column<?> original) {
         return original.get(rowNumber).equals(temp.get(temp.size() - 1));

--- a/core/src/main/java/tech/tablesaw/api/DateColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateColumn.java
@@ -23,7 +23,6 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import tech.tablesaw.columns.AbstractColumn;
 import tech.tablesaw.columns.Column;
-import tech.tablesaw.columns.StringParser;
 import tech.tablesaw.columns.dates.DateColumnFormatter;
 import tech.tablesaw.columns.dates.DateColumnType;
 import tech.tablesaw.columns.dates.DateFillers;
@@ -326,12 +325,6 @@ public class DateColumn extends AbstractColumn<LocalDate> implements DateFilters
     @Override
     public DateColumn appendCell(String string) {
         appendInternal(PackedLocalDate.pack(DateColumnType.DEFAULT_PARSER.parse(string)));
-        return this;
-    }
-
-    @Override
-    public DateColumn appendCell(String string, StringParser parser) {
-        appendInternal(PackedLocalDate.pack((LocalDate) parser.parse(string)));
         return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
@@ -24,7 +24,6 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import tech.tablesaw.columns.AbstractColumn;
 import tech.tablesaw.columns.Column;
-import tech.tablesaw.columns.StringParser;
 import tech.tablesaw.columns.datetimes.DateTimeColumnFormatter;
 import tech.tablesaw.columns.datetimes.DateTimeColumnType;
 import tech.tablesaw.columns.datetimes.DateTimeFillers;
@@ -167,12 +166,6 @@ public class DateTimeColumn extends AbstractColumn<LocalDateTime>
     @Override
     public DateTimeColumn appendCell(String stringValue) {
         appendInternal(PackedLocalDateTime.pack(DateTimeColumnType.DEFAULT_PARSER.parse(stringValue)));
-        return this;
-    }
-
-    @Override
-    public DateTimeColumn appendCell(String stringValue, StringParser parser) {
-        appendInternal(PackedLocalDateTime.pack((LocalDateTime) parser.parse(stringValue)));
         return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
@@ -29,7 +29,6 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import tech.tablesaw.columns.AbstractColumn;
 import tech.tablesaw.columns.Column;
-import tech.tablesaw.columns.StringParser;
 import tech.tablesaw.columns.numbers.DoubleColumnType;
 import tech.tablesaw.columns.numbers.NumberColumnFormatter;
 import tech.tablesaw.columns.numbers.Stats;
@@ -394,16 +393,6 @@ public class DoubleColumn extends AbstractColumn<Double> implements NumberColumn
     public DoubleColumn appendCell(final String object) {
         try {
             append(DoubleColumnType.DEFAULT_PARSER.parseDouble(object));
-        } catch (final NumberFormatException e) {
-            throw new NumberFormatException(name() + ": " + e.getMessage());
-        }
-        return this;
-    }
-
-    @Override
-    public DoubleColumn appendCell(final String object, StringParser parser) {
-        try {
-            append(parser.parseDouble(object));
         } catch (final NumberFormatException e) {
             throw new NumberFormatException(name() + ": " + e.getMessage());
         }

--- a/core/src/main/java/tech/tablesaw/api/StringColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/StringColumn.java
@@ -28,7 +28,6 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import tech.tablesaw.columns.AbstractColumn;
 import tech.tablesaw.columns.Column;
-import tech.tablesaw.columns.StringParser;
 import tech.tablesaw.columns.strings.StringColumnFormatter;
 import tech.tablesaw.columns.strings.StringColumnType;
 import tech.tablesaw.columns.strings.StringFilters;
@@ -417,12 +416,6 @@ public class StringColumn extends AbstractColumn<String>
     @Override
     public StringColumn appendCell(String object) {
         addValue(StringColumnType.DEFAULT_PARSER.parse(object));
-        return this;
-    }
-
-    @Override
-    public StringColumn appendCell(String object, StringParser parser) {
-        addValue((String) parser.parse(object));
         return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/api/TimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TimeColumn.java
@@ -23,7 +23,6 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import tech.tablesaw.columns.AbstractColumn;
 import tech.tablesaw.columns.Column;
-import tech.tablesaw.columns.StringParser;
 import tech.tablesaw.columns.times.PackedLocalTime;
 import tech.tablesaw.columns.times.TimeColumnFormatter;
 import tech.tablesaw.columns.times.TimeColumnType;
@@ -337,12 +336,6 @@ public class TimeColumn extends AbstractColumn<LocalTime>
     @Override
     public TimeColumn appendCell(String object) {
         appendInternal(PackedLocalTime.pack(TimeColumnType.DEFAULT_PARSER.parse(object)));
-        return this;
-    }
-
-    @Override
-    public TimeColumn appendCell(String object, StringParser parser) {
-        appendInternal(PackedLocalTime.pack((LocalTime) parser.parse(object)));
         return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/columns/Column.java
+++ b/core/src/main/java/tech/tablesaw/columns/Column.java
@@ -170,8 +170,6 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
 
     Column<T> appendCell(String stringValue);
 
-    Column<T> appendCell(String stringValue, StringParser parser);
-
     IntComparator rowComparator();
 
     Column<T> set(int row, T value);

--- a/core/src/main/java/tech/tablesaw/columns/SkipColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/SkipColumnType.java
@@ -18,12 +18,12 @@ public class SkipColumnType extends AbstractColumnType {
     }
 
     @Override
-    public StringParser defaultParser() {
+    public StringParser<?> defaultParser() {
         throw new UnsupportedOperationException("Column type " + name() + " doesn't support parsing");
     }
 
     @Override
-    public StringParser customParser(CsvReadOptions options) {
+    public StringParser<?> customParser(CsvReadOptions options) {
         throw new UnsupportedOperationException("Column type " + name() + " doesn't support parsing");
     }
 }

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReader.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReader.java
@@ -173,10 +173,10 @@ public class CsvReader {
                 int cellIndex = 0;
                 for (int columnIndex : columnIndexes) {
                     Column<?> column = table.column(cellIndex);
-                    StringParser parser = column.type().customParser(options);
+                    StringParser<?> parser = column.type().customParser(options);
                     try {
                         String value = nextLine[columnIndex];
-                        column.appendCell(value, parser);
+                        column.appendObj(parser.parse(value));
                     } catch (Exception e) {
                         throw new AddCellToColumnException(e, columnIndex, rowNumber, columnNames, nextLine);
                     }
@@ -473,12 +473,12 @@ public class CsvReader {
      */
     private ColumnType detectType(List<String> valuesList, CsvReadOptions options) {
 
-        List<StringParser> parsers = getParserList(typeArray, options);
+        List<StringParser<?>> parsers = getParserList(typeArray, options);
 
         CopyOnWriteArrayList<ColumnType> typeCandidates = new CopyOnWriteArrayList<>(typeArray);
 
         for (String s : valuesList) {
-            for (StringParser parser : parsers) {
+            for (StringParser<?> parser : parsers) {
                 if (!parser.canParse(s)) {
                     typeCandidates.remove(parser.columnType());
                 }
@@ -503,10 +503,10 @@ public class CsvReader {
      * @param options CsvReadOptions to use to modify the default parsers for each type
      * @return  A list of parsers in the order they should be used for type detection
      */
-    private List<StringParser> getParserList(List<ColumnType> typeArray, CsvReadOptions options) {
+    private List<StringParser<?>> getParserList(List<ColumnType> typeArray, CsvReadOptions options) {
         // Types to choose from. When more than one would work, we pick the first of the options
 
-        List<StringParser> parsers = new ArrayList<>();
+        List<StringParser<?>> parsers = new ArrayList<>();
         for (ColumnType type : typeArray) {
             parsers.add(type.customParser(options));
         }


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Fixed all the warnings related to `StringParser`, which was about half of the remaining. 14 left that I will address in a follow up PR

I did a refactoring of cell appending in the `CSVReader` by calling another method to achieve the same thing. This meant that we no longer needed the new method `appendCell` which was recently added since that was the only place it was being called. This allowed for a reduction in the amount of code and doesn't require any generic types and removed most of the warnings

## Testing

N/A. Only refactoring and cleanup
