### PR TITLE
Leverage recent improvements for lightweight IntColumn and FloatColumn

### DIFF
--- a/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
@@ -7,7 +7,7 @@ import org.apache.commons.math3.stat.descriptive.moment.Skewness;
 import tech.tablesaw.api.BooleanColumn;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DateTimeColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.columns.numbers.DoubleColumnType;
 
@@ -108,7 +108,7 @@ public class AggregateFunctions {
     public static NumericAggregateFunction first = new NumericAggregateFunction("First") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return column.isEmpty() ? DoubleColumnType.missingValueIndicator() : column.getDouble(0);
         }
     };
@@ -119,7 +119,7 @@ public class AggregateFunctions {
     public static NumericAggregateFunction last = new NumericAggregateFunction("Last") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return column.isEmpty() ? DoubleColumnType.missingValueIndicator() : column.getDouble(column.size() - 1);
         }
     };
@@ -130,7 +130,7 @@ public class AggregateFunctions {
     public static NumericAggregateFunction change = new NumericAggregateFunction("Change") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return column.size() < 2 ? DoubleColumnType.missingValueIndicator() : column.getDouble(column.size() - 1) - column.getDouble(0);
         }
     };
@@ -141,7 +141,7 @@ public class AggregateFunctions {
     public static NumericAggregateFunction pctChange = new NumericAggregateFunction("Percent Change") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return column.size() < 2 ? DoubleColumnType.missingValueIndicator() : (column.getDouble(column.size() - 1) - column.getDouble(0)) / column.getDouble(0);
         }
     };    
@@ -180,7 +180,7 @@ public class AggregateFunctions {
 
         @Override
         public Integer summarize(Column<?> doubles) {
-            return removeMissing(doubles.unique()).size();
+            return doubles.unique().removeMissing().size();
         }
     };
 
@@ -190,7 +190,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction mean = new NumericAggregateFunction("Mean") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return StatUtils.mean(removeMissing(column));
         }
     };
@@ -201,7 +201,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction sum = new NumericAggregateFunction("Sum") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return StatUtils.sum(removeMissing(column));
         }
     };
@@ -209,7 +209,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction median = new NumericAggregateFunction("Median") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return percentile(column, 50.0);
         }
     };
@@ -225,7 +225,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction quartile1 = new NumericAggregateFunction("First Quartile") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return percentile(column, 25.0);
         }
     };
@@ -233,7 +233,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction quartile3 = new NumericAggregateFunction("Third Quartile") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return percentile(column, 75.0);
         }
     };
@@ -241,7 +241,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction percentile90 = new NumericAggregateFunction("90th Percentile") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return percentile(column, 90.0);
         }
     };
@@ -249,7 +249,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction percentile95 = new NumericAggregateFunction("95th Percentile") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return percentile(column, 95.0);
         }
     };
@@ -257,7 +257,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction percentile99 = new NumericAggregateFunction("99th Percentile") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return percentile(column, 99.0);
         }
     };
@@ -265,7 +265,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction range = new NumericAggregateFunction("Range") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             double[] data = removeMissing(column);
             return StatUtils.max(data) - StatUtils.min(data);
         }
@@ -274,7 +274,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction min = new NumericAggregateFunction("Min") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return StatUtils.min(removeMissing(column));
         }
     };
@@ -282,7 +282,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction max = new NumericAggregateFunction("Max") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return StatUtils.max(removeMissing(column));
         }
     };
@@ -290,7 +290,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction product = new NumericAggregateFunction("Product") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return StatUtils.product(removeMissing(column));
         }
     };
@@ -298,7 +298,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction geometricMean = new NumericAggregateFunction("Geometric Mean") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return StatUtils.geometricMean(removeMissing(column));
         }
     };
@@ -306,7 +306,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction populationVariance = new NumericAggregateFunction("Population Variance") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return StatUtils.populationVariance(removeMissing(column));
         }
     };
@@ -317,7 +317,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction quadraticMean = new NumericAggregateFunction("Quadratic Mean") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return new DescriptiveStatistics(removeMissing(column)).getQuadraticMean();
         }
     };
@@ -325,7 +325,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction kurtosis = new NumericAggregateFunction("Kurtosis") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             double[] data = removeMissing(column);
             return new Kurtosis().evaluate(data, 0, data.length);
         }
@@ -334,7 +334,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction skewness = new NumericAggregateFunction("Skewness") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             double[] data = removeMissing(column);
             return new Skewness().evaluate(data, 0, data.length);
         }
@@ -348,7 +348,7 @@ public class AggregateFunctions {
         }
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return StatUtils.sumSq(removeMissing(column));
         }
     };
@@ -356,7 +356,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction sumOfLogs = new NumericAggregateFunction("Sum of Logs") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return StatUtils.sumLog(removeMissing(column));
         }
     };
@@ -364,7 +364,7 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction variance = new NumericAggregateFunction("Variance") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             double[] values = removeMissing(column);
             return StatUtils.variance(values);
         }
@@ -373,31 +373,27 @@ public class AggregateFunctions {
     public static final NumericAggregateFunction stdDev = new NumericAggregateFunction("Std. Deviation") {
 
         @Override
-        public Double summarize(NumberColumn column) {
+        public Double summarize(NumericColumn<?> column) {
             return Math.sqrt(StatUtils.variance(removeMissing(column)));
         }
     };
 
-    public static Double percentile(NumberColumn data, Double percentile) {
+    public static Double percentile(NumericColumn<?> data, Double percentile) {
         return StatUtils.percentile(removeMissing(data), percentile);
     }
 
     public static final NumericAggregateFunction standardDeviation = stdDev;
 
-    private static double[] removeMissing(NumberColumn column) {
+    private static double[] removeMissing(NumericColumn<?> column) {
         return column.removeMissing().asDoubleArray();
     }
 
-    private static <T> Column<T> removeMissing(Column<T> column) {
-        return column.removeMissing();
-    }
-
     // TODO(lwhite): These are two column reductions. We need a class for that
-    public static Double meanDifference(NumberColumn column1, NumberColumn column2) {
+    public static Double meanDifference(NumericColumn<?> column1, NumericColumn<?> column2) {
         return StatUtils.meanDifference(column1.asDoubleArray(), column2.asDoubleArray());
     }
 
-    public static Double sumDifference(NumberColumn column1, NumberColumn column2) {
+    public static Double sumDifference(NumericColumn<?> column1, NumericColumn<?> column2) {
         return StatUtils.sumDifference(column1.asDoubleArray(), column2.asDoubleArray());
     }
 }

--- a/core/src/main/java/tech/tablesaw/aggregate/CrossTab.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/CrossTab.java
@@ -15,9 +15,11 @@
 package tech.tablesaw.aggregate;
 
 import com.google.common.collect.TreeBasedTable;
+
 import tech.tablesaw.api.CategoricalColumn;
 import tech.tablesaw.api.ColumnType;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.IntColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
@@ -67,10 +69,10 @@ public final class CrossTab {
         }
 
         for (String colName : gTable.columnKeySet()) {
-            t.addColumns(NumberColumn.create(colName));
+            t.addColumns(IntColumn.create(colName));
         }
 
-        t.addColumns(NumberColumn.create("total"));
+        t.addColumns(IntColumn.create("total"));
 
         int[] columnTotals = new int[t.columnCount()];
 
@@ -83,15 +85,15 @@ public final class CrossTab {
                 Integer cellValue = gTable.get(rowKey, colKey);
                 if (cellValue != null) {
                     int colIdx = t.columnIndex(colKey);
-                    t.numberColumn(colIdx).append(cellValue);
+                    t.intColumn(colIdx).append(cellValue);
                     rowSum += cellValue;
                     columnTotals[colIdx] = columnTotals[colIdx] + cellValue;
 
                 } else {
-                    t.numberColumn(colKey).append(0);
+                    t.intColumn(colKey).append(0);
                 }
             }
-            t.numberColumn(t.columnCount() - 1).append(rowSum);
+            t.intColumn(t.columnCount() - 1).append(rowSum);
         }
         if (t.column(0).type().equals(ColumnType.STRING)) {
             t.column(0).appendCell("Total");
@@ -100,10 +102,10 @@ public final class CrossTab {
         }
         int grandTotal = 0;
         for (int i = 1; i < t.columnCount() - 1; i++) {
-            t.numberColumn(i).append(columnTotals[i]);
+            t.intColumn(i).append(columnTotals[i]);
             grandTotal = grandTotal + columnTotals[i];
         }
-        t.numberColumn(t.columnCount() - 1).append(grandTotal);
+        t.intColumn(t.columnCount() - 1).append(grandTotal);
         return t;
     }
 
@@ -116,8 +118,8 @@ public final class CrossTab {
         Table percentTable = Table.create(countTable.name());
         percentTable.addColumns(countTable.column(0).copy());
 
-        NumberColumn countsColumn = countTable.numberColumn("Count");
-        NumberColumn pctsColumn = NumberColumn.create("Percents");
+        IntColumn countsColumn = countTable.intColumn("Count");
+        DoubleColumn pctsColumn = DoubleColumn.create("Percents");
         double sum = countsColumn.sum();
         for (int i = 0; i < countsColumn.size(); i++) {
             pctsColumn.append(countsColumn.getDouble(i) / sum);
@@ -139,7 +141,7 @@ public final class CrossTab {
 
         for (int i = 1; i < xTabCounts.columnCount(); i++) {
             Column<?> column = xTabCounts.column(i);
-            pctTable.addColumns(NumberColumn.create(column.name()));
+            pctTable.addColumns(DoubleColumn.create(column.name()));
         }
 
         for (int i = 0; i < xTabCounts.rowCount(); i++) {
@@ -147,9 +149,9 @@ public final class CrossTab {
 
             for (int c = 1; c < xTabCounts.columnCount(); c++) {
                 if (rowTotal == 0) {
-                    pctTable.numberColumn(c).append(Float.NaN);
+                    pctTable.doubleColumn(c).append(Float.NaN);
                 } else {
-                    pctTable.numberColumn(c).append(xTabCounts.numberColumn(c).getDouble(i) / rowTotal);
+                    pctTable.doubleColumn(c).append(xTabCounts.numberColumn(c).getDouble(i) / rowTotal);
                 }
             }
         }
@@ -171,15 +173,15 @@ public final class CrossTab {
 
         for (int i = 1; i < xTabCounts.columnCount(); i++) {
             Column<?> column = xTabCounts.column(i);
-            pctTable.addColumns(NumberColumn.create(column.name()));
+            pctTable.addColumns(DoubleColumn.create(column.name()));
         }
 
         for (int i = 0; i < xTabCounts.rowCount(); i++) {
             for (int c = 1; c < xTabCounts.columnCount(); c++) {
                 if (grandTotal == 0) {
-                    pctTable.numberColumn(c).append(Double.NaN);
+                    pctTable.doubleColumn(c).append(Double.NaN);
                 } else {
-                    pctTable.numberColumn(c).append(xTabCounts.numberColumn(c).getDouble(i) / grandTotal);
+                    pctTable.doubleColumn(c).append(xTabCounts.numberColumn(c).getDouble(i) / grandTotal);
                 }
             }
         }
@@ -201,7 +203,7 @@ public final class CrossTab {
         // create the new cols
         for (int i = 1; i < xTabCounts.columnCount(); i++) {
             Column<?> column = xTabCounts.column(i);
-            pctTable.addColumns(NumberColumn.create(column.name()));
+            pctTable.addColumns(DoubleColumn.create(column.name()));
         }
 
         // get the column totals
@@ -215,9 +217,9 @@ public final class CrossTab {
         for (int i = 0; i < xTabCounts.rowCount(); i++) {
             for (int c = 1; c < xTabCounts.columnCount(); c++) {
                 if (columnTotals[c - 1] == 0) {
-                    pctTable.numberColumn(c).append(Float.NaN);
+                    pctTable.doubleColumn(c).append(Float.NaN);
                 } else {
-                    pctTable.numberColumn(c).append(xTabCounts.numberColumn(c).getDouble(i) / columnTotals[c - 1]);
+                    pctTable.doubleColumn(c).append(xTabCounts.numberColumn(c).getDouble(i) / columnTotals[c - 1]);
                 }
             }
         }

--- a/core/src/main/java/tech/tablesaw/aggregate/NumericAggregateFunction.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/NumericAggregateFunction.java
@@ -1,12 +1,12 @@
 package tech.tablesaw.aggregate;
 
 import tech.tablesaw.api.ColumnType;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.NumericColumn;
 
 /**
  * A partial implementation of aggregate functions to summarize over a numeric column
  */
-public abstract class NumericAggregateFunction extends AggregateFunction<NumberColumn, Double> {
+public abstract class NumericAggregateFunction extends AggregateFunction<NumericColumn<?>, Double> {
 
     public NumericAggregateFunction(String name) {
         super(name);

--- a/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
@@ -162,7 +162,7 @@ public class BooleanColumn extends AbstractColumn<Boolean> implements BooleanMap
         Table table = Table.create(name());
 
         BooleanColumn booleanColumn = create("Value");
-        NumberColumn countColumn = NumberColumn.create("Count");
+        DoubleColumn countColumn = DoubleColumn.create("Count");
         table.addColumns(booleanColumn);
         table.addColumns(countColumn);
 
@@ -636,8 +636,8 @@ public class BooleanColumn extends AbstractColumn<Boolean> implements BooleanMap
         return output;
     }
 
-    public NumberColumn asNumberColumn() {
-        NumberColumn numberColumn = NumberColumn.create(this.name() + ": ints", size());
+    public DoubleColumn asNumberColumn() {
+        DoubleColumn numberColumn = DoubleColumn.create(this.name() + ": ints", size());
         ByteArrayList data = data();
         for (int i = 0; i < size(); i++) {
             numberColumn.append(data.getByte(i));

--- a/core/src/main/java/tech/tablesaw/api/CategoricalColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/CategoricalColumn.java
@@ -44,7 +44,7 @@ public interface CategoricalColumn<T> extends Column<T> {
 
         final Table t = new Table("Column: " + name());
         final CategoricalColumn<?> categories = (CategoricalColumn<?>) type().create("Category");
-        final NumberColumn counts = NumberColumn.create("Count");
+        final IntColumn counts = IntColumn.create("Count");
 
         final Object2IntMap<String> valueToCount = new Object2IntOpenHashMap<>();
 

--- a/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
@@ -1,0 +1,304 @@
+package tech.tablesaw.api;
+
+import static tech.tablesaw.api.ColumnType.DOUBLE;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.DoubleConsumer;
+import java.util.function.DoublePredicate;
+import java.util.function.DoubleSupplier;
+import java.util.function.ToDoubleFunction;
+
+import com.google.common.base.Preconditions;
+
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.doubles.DoubleSet;
+import tech.tablesaw.columns.Column;
+import tech.tablesaw.columns.numbers.DoubleDataWrapper;
+import tech.tablesaw.columns.numbers.NumberFillers;
+import tech.tablesaw.columns.numbers.NumberIterable;
+import tech.tablesaw.columns.numbers.NumberIterator;
+import tech.tablesaw.columns.numbers.NumericDataWrapper;
+
+public class DoubleColumn extends NumberColumn<Double> implements NumericColumn<Double>, NumberFillers<DoubleColumn> {
+
+    protected DoubleColumn(final String name, final DoubleArrayList data) {
+        super(DOUBLE, name);
+        setDataWrapper(new DoubleDataWrapper(data));
+    }
+
+    protected DoubleColumn(final String name, final NumericDataWrapper data) {
+        super(data.type(), name);
+        setDataWrapper(data);
+    }
+
+    public static DoubleColumn create(final String name, final double[] arr) {
+        return new DoubleColumn(name, new DoubleArrayList(arr));
+    }
+
+    public static DoubleColumn create(final String name, final NumericDataWrapper data) {
+        return new DoubleColumn(name, data);
+    }
+
+    public static DoubleColumn create(final String name) {
+        return new DoubleColumn(name, new DoubleArrayList());
+    }
+
+    public static DoubleColumn create(final String name, final float[] arr) {
+        final double[] doubles = new double[arr.length];
+        for (int i = 0; i < arr.length; i++) {
+            doubles[i] = arr[i];
+        }
+        return new DoubleColumn(name, new DoubleArrayList(doubles));
+    }
+
+    public static DoubleColumn create(final String name, final int[] arr) {
+        final double[] doubles = new double[arr.length];
+        for (int i = 0; i < arr.length; i++) {
+            doubles[i] = arr[i];
+        }
+        return new DoubleColumn(name, new DoubleArrayList(doubles));
+    }
+
+    public static DoubleColumn create(final String name, final long[] arr) {
+        final double[] doubles = new double[arr.length];
+        for (int i = 0; i < arr.length; i++) {
+            doubles[i] = arr[i];
+        }
+        return new DoubleColumn(name, new DoubleArrayList(doubles));
+    }
+
+    public static DoubleColumn create(final String name, final List<Number> numberList) {
+        // TODO This should be pushed down to the dataWrappers
+        final double[] doubles = new double[numberList.size()];
+        for (int i = 0; i < numberList.size(); i++) {
+            doubles[i] = numberList.get(i).doubleValue();
+        }
+        return new DoubleColumn(name, new DoubleArrayList(doubles));
+    }
+
+    public static DoubleColumn create(final String name, final Number[] numbers) {
+        final double[] doubles = new double[numbers.length];
+        for (int i = 0; i < numbers.length; i++) {
+            doubles[i] = numbers[i].doubleValue();
+        }
+        return new DoubleColumn(name, new DoubleArrayList(doubles));
+    }
+
+    public static DoubleColumn create(final String name, final int initialSize) {
+        return new DoubleColumn(name, new DoubleArrayList(initialSize));
+    }
+
+    @Override
+    protected NumberColumn<Double> createCol(String name, NumericDataWrapper data) {
+	return DoubleColumn.create(name, data);
+    }
+
+    @Override
+    public Double get(int index) {
+	return getDouble(index);
+    }
+
+    @Override
+    public DoubleColumn unique() {
+        final DoubleSet doubles = new DoubleOpenHashSet();
+        for (int i = 0; i < size(); i++) {
+            if (!isMissing(i)) {
+                doubles.add(getDouble(i));
+            }
+        }
+        final DoubleColumn column = DoubleColumn.create(name() + " Unique values", doubles.size());
+        doubles.forEach((DoubleConsumer) column::append);
+        return column;
+    }
+
+    public double firstElement() {
+        if (size() > 0) {
+            return getDouble(0);
+        }
+        return data.missingValueIndicator();
+    }
+
+    /**
+     * Adds the given float to this column
+     */
+    public DoubleColumn append(final float f) {
+        data.append(f);
+        return this;
+    }
+
+    /**
+     * Adds the given double to this column
+     */
+    public DoubleColumn append(double d) {
+        data.append(d);
+        return this;
+    }
+
+    public DoubleColumn append(int i) {
+        data.append(i);
+        return this;
+    }
+
+    @Override
+    public DoubleColumn append(Double val) {
+        this.append(val.doubleValue());
+        return this;
+    }
+
+    public DoubleColumn append(Integer val) {
+        this.append(val.doubleValue());
+        return this;
+    }
+
+    @Override
+    public DoubleColumn emptyCopy() {
+        return (DoubleColumn) super.emptyCopy();
+    }
+
+    @Override
+    public DoubleColumn emptyCopy(final int rowSize) {
+	return (DoubleColumn) super.emptyCopy(rowSize);
+    }
+
+    @Override
+    public DoubleColumn copy() {
+        return (DoubleColumn) super.copy();
+    }
+
+    /**
+     * Returns a DateTimeColumn where each value is the LocalDateTime represented by the values in this column
+     * <p>
+     * The values in this column must be longs that represent the time in milliseconds from the epoch as in standard
+     * Java date/time calculations
+     *
+     * @param offset The ZoneOffset to use in the calculation
+     * @return A column of LocalDateTime values
+     */
+    public DateTimeColumn asDateTimes(ZoneOffset offset) {
+        DateTimeColumn column = DateTimeColumn.create(name() + ": date time");
+        NumberIterator it = numberIterator();
+        while (it.hasNext()) {
+            double d = it.next();
+            LocalDateTime dateTime =
+                    Instant.ofEpochMilli((long) d).atZone(offset).toLocalDateTime();
+            column.append(dateTime);
+        }
+        return column;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Iterator<Double> iterator() {
+        return (Iterator<Double>) data.iterator();
+    }
+
+    @Override
+    public Object[] asObjectArray() {
+        final Double[] output = new Double[size()];
+        for (int i = 0; i < size(); i++) {
+            output[i] = getDouble(i);
+        }
+        return output;
+    }
+
+    @Override
+    public int compare(Double o1, Double o2) {
+        return Double.compare(o1, o2);
+    }
+
+    @Override
+    public DoubleColumn set(int i, Double val) {
+        return (DoubleColumn) set(i, (double) val);
+    }
+
+    @Override
+    public DoubleColumn append(final Column<Double> column) {
+        Preconditions.checkArgument(column.type() == this.type());
+        final DoubleColumn numberColumn = (DoubleColumn) column;
+        for (int i = 0; i < numberColumn.size(); i++) {
+            append(numberColumn.getDouble(i));
+        }
+        return this;
+    }
+
+    // fillWith methods
+
+    @Override
+    public DoubleColumn fillWith(final NumberIterator iterator) {
+        for (int r = 0; r < size(); r++) {
+            if (!iterator.hasNext()) {
+                break;
+            }
+            set(r, iterator.next());
+        }
+        return this;
+    }
+
+    @Override
+    public DoubleColumn fillWith(final NumberIterable iterable) {
+        NumberIterator iterator = iterable.numberIterator();
+        for (int r = 0; r < size(); r++) {
+            if (iterator == null || (!iterator.hasNext())) {
+                iterator = numberIterator();
+                if (!iterator.hasNext()) {
+                    break;
+                }
+            }
+            set(r, iterator.next());
+        }
+        return this;
+    }
+
+    @Override
+    public DoubleColumn fillWith(final DoubleSupplier supplier) {
+        for (int r = 0; r < size(); r++) {
+            try {
+                set(r, supplier.getAsDouble());
+            } catch (final Exception e) {
+                break;
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new NumberColumn
+     *
+     * @param fun function to map
+     * @return the NumberColumn with the results
+     */
+    public DoubleColumn map(ToDoubleFunction<Double> fun) {
+        DoubleColumn result = DoubleColumn.create(name());
+        for (double t : this) {
+            try {
+                result.append(fun.applyAsDouble(t));
+            } catch (Exception e) {
+                result.appendMissing();
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns a new NumberColumn with only those rows satisfying the predicate
+     *
+     * @param test the predicate
+     * @return a new NumberColumn with only those rows satisfying the predicate
+     */
+    public DoubleColumn filter(DoublePredicate test) {
+        DoubleColumn result = DoubleColumn.create(name());
+        for (int i = 0; i < size(); i++) {
+            double d = getDouble(i);
+            if (test.test(d)) {
+                result.append(d);
+            }
+        }
+        return result;
+    }
+
+}

--- a/core/src/main/java/tech/tablesaw/api/FloatColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/FloatColumn.java
@@ -1,0 +1,150 @@
+package tech.tablesaw.api;
+
+import static tech.tablesaw.api.ColumnType.FLOAT;
+
+import java.util.Iterator;
+
+import com.google.common.base.Preconditions;
+
+import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import tech.tablesaw.columns.Column;
+import tech.tablesaw.columns.numbers.FloatDataWrapper;
+import tech.tablesaw.columns.numbers.NumericDataWrapper;
+
+public class FloatColumn extends NumberColumn<Float> implements NumericColumn<Float> {
+
+    protected FloatColumn(final String name, FloatArrayList data) {
+        super(FLOAT, name);
+        setDataWrapper(new FloatDataWrapper(data));
+    }
+
+    protected FloatColumn(final String name, final NumericDataWrapper data) {
+        super(data.type(), name);
+        setDataWrapper(data);
+    }
+
+    public static FloatColumn create(final String name, final NumericDataWrapper data) {
+        return new FloatColumn(name, data);
+    }
+
+    public static FloatColumn create(final String name) {
+        return new FloatColumn(name, new FloatArrayList());
+    }
+
+    public static FloatColumn create(final String name, final float[] arr) {
+        return new FloatColumn(name, new FloatArrayList(arr));
+    }
+
+    public static FloatColumn create(final String name, final int initialSize) {
+        return new FloatColumn(name, new FloatArrayList(initialSize));
+    }
+
+    public static FloatColumn createWithIntegers(String name) {
+        return new FloatColumn(name, new FloatArrayList(DEFAULT_ARRAY_SIZE));
+    }
+
+    public static FloatColumn createWithIntegers(String name, int size) {
+        return new FloatColumn(name, new FloatArrayList(size));
+    }
+
+    /**
+     * Returns a new numeric column initialized with the given name and size. The values in the column are
+     * integers beginning at startsWith and continuing through size (exclusive), monotonically increasing by 1
+     * TODO consider a generic fill function including steps or random samples from various distributions
+     */
+    public static FloatColumn indexColumn(final String columnName, final int size, final int startsWith) {
+        final FloatColumn indexColumn = FloatColumn.createWithIntegers(columnName, size);
+        for (int i = 0; i < size; i++) {
+            indexColumn.append(i + startsWith);
+        }
+        return indexColumn;
+    }
+
+    @Override
+    protected NumberColumn<Float> createCol(String name, NumericDataWrapper data) {
+	return FloatColumn.create(name, data);
+    }
+
+    @Override
+    public Float get(int index) {
+	return data.getFloat(index);
+    }
+
+    @Override
+    public FloatColumn unique() {
+        final IntSet values = new IntOpenHashSet();
+        for (int i = 0; i < size(); i++) {
+            if (!isMissing(i)) {
+                values.add(getInt(i));
+            }
+        }
+        final FloatColumn column = FloatColumn.create(name() + " Unique values", values.size());
+        for (int value : values) {
+            column.append(value);
+        }
+        return column;
+    }
+
+    public FloatColumn append(float i) {
+        data.append(i);
+        return this;
+    }
+
+    public FloatColumn append(Float val) {
+        this.append(val.intValue());
+        return this;
+    }
+
+    @Override
+    public FloatColumn emptyCopy() {
+        return (FloatColumn) super.emptyCopy();
+    }
+
+    @Override
+    public FloatColumn emptyCopy(final int rowSize) {
+	return (FloatColumn) super.emptyCopy(rowSize);
+    }
+
+    @Override
+    public FloatColumn copy() {
+        return (FloatColumn) super.copy();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Iterator<Float> iterator() {
+        return (Iterator<Float>) data.iterator();
+    }
+
+    @Override
+    public Object[] asObjectArray() {
+        final Integer[] output = new Integer[size()];
+        for (int i = 0; i < size(); i++) {
+            output[i] = getInt(i);
+        }
+        return output;
+    }
+
+    @Override
+    public int compare(Float o1, Float o2) {
+        return Float.compare(o1, o2);
+    }
+
+    @Override
+    public FloatColumn set(int i, Float val) {
+        return (FloatColumn) set(i, (float) val);
+    }
+
+    @Override
+    public FloatColumn append(final Column<Float> column) {
+        Preconditions.checkArgument(column.type() == this.type());
+        final FloatColumn numberColumn = (FloatColumn) column;
+        for (int i = 0; i < numberColumn.size(); i++) {
+            append(numberColumn.getFloat(i));
+        }
+        return this;
+    }
+
+}

--- a/core/src/main/java/tech/tablesaw/api/IntColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/IntColumn.java
@@ -1,0 +1,161 @@
+package tech.tablesaw.api;
+
+import static tech.tablesaw.api.ColumnType.INTEGER;
+
+import java.util.Iterator;
+
+import com.google.common.base.Preconditions;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import tech.tablesaw.columns.Column;
+import tech.tablesaw.columns.numbers.IntDataWrapper;
+import tech.tablesaw.columns.numbers.NumberColumnFormatter;
+import tech.tablesaw.columns.numbers.NumericDataWrapper;
+
+public class IntColumn extends NumberColumn<Integer> implements NumericColumn<Integer>, CategoricalColumn<Integer> {
+
+    protected IntColumn(final String name, IntArrayList data) {
+        super(INTEGER, name);
+        this.printFormatter = NumberColumnFormatter.ints();
+        setDataWrapper(new IntDataWrapper(data));
+    }
+
+    protected IntColumn(final String name, final NumericDataWrapper data) {
+        super(data.type(), name);
+        setDataWrapper(data);
+    }
+
+    public static IntColumn create(final String name, final NumericDataWrapper data) {
+        return new IntColumn(name, data);
+    }
+
+    public static IntColumn create(final String name) {
+        return new IntColumn(name, new IntArrayList());
+    }
+
+    public static IntColumn create(final String name, final int[] arr) {
+        return new IntColumn(name, new IntArrayList(arr));
+    }
+
+    public static IntColumn create(final String name, final int initialSize) {
+        return new IntColumn(name, new IntArrayList(initialSize));
+    }
+
+    public static IntColumn createWithIntegers(String name) {
+        return new IntColumn(name, new IntArrayList(DEFAULT_ARRAY_SIZE));
+    }
+
+    public static IntColumn createWithIntegers(String name, int size) {
+        return new IntColumn(name, new IntArrayList(size));
+    }
+
+    /**
+     * Returns a new numeric column initialized with the given name and size. The values in the column are
+     * integers beginning at startsWith and continuing through size (exclusive), monotonically increasing by 1
+     * TODO consider a generic fill function including steps or random samples from various distributions
+     */
+    public static IntColumn indexColumn(final String columnName, final int size, final int startsWith) {
+        final IntColumn indexColumn = IntColumn.createWithIntegers(columnName, size);
+        for (int i = 0; i < size; i++) {
+            indexColumn.append(i + startsWith);
+        }
+        return indexColumn;
+    }
+
+    @Override
+    protected NumberColumn<Integer> createCol(String name, NumericDataWrapper data) {
+	return IntColumn.create(name, data);
+    }
+
+    @Override
+    public Integer get(int index) {
+	return data.getInt(index);
+    }
+
+    @Override
+    public IntColumn unique() {
+        final IntSet values = new IntOpenHashSet();
+        for (int i = 0; i < size(); i++) {
+            if (!isMissing(i)) {
+                values.add(getInt(i));
+            }
+        }
+        final IntColumn column = IntColumn.create(name() + " Unique values", values.size());
+        for (int value : values) {
+            column.append(value);
+        }
+        return column;
+    }
+
+    public IntColumn append(int i) {
+        data.append(i);
+        return this;
+    }
+
+    public IntColumn append(Integer val) {
+        this.append(val.intValue());
+        return this;
+    }
+
+    @Override
+    public IntColumn emptyCopy() {
+        return (IntColumn) super.emptyCopy();
+    }
+
+    @Override
+    public IntColumn emptyCopy(final int rowSize) {
+	return (IntColumn) super.emptyCopy(rowSize);
+    }
+
+    @Override
+    public IntColumn copy() {
+        return (IntColumn) super.copy();
+    }
+
+    @Override
+    public int[] asIntArray() {  // TODO: Need to figure out how to handle NaN -> Maybe just use a list with nulls?
+        final int[] result = new int[size()];
+        for (int i = 0; i < size(); i++) {
+            result[i] = roundInt(i);
+        }
+        return result;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Iterator<Integer> iterator() {
+        return (Iterator<Integer>) data.iterator();
+    }
+
+    @Override
+    public Object[] asObjectArray() {
+        final Integer[] output = new Integer[size()];
+        for (int i = 0; i < size(); i++) {
+            output[i] = getInt(i);
+        }
+        return output;
+    }
+
+    @Override
+    public int compare(Integer o1, Integer o2) {
+        return Integer.compare(o1, o2);
+    }
+
+    @Override
+    public IntColumn set(int i, Integer val) {
+        return (IntColumn) set(i, (int) val);
+    }
+
+    @Override
+    public IntColumn append(final Column<Integer> column) {
+        Preconditions.checkArgument(column.type() == this.type());
+        final IntColumn numberColumn = (IntColumn) column;
+        for (int i = 0; i < numberColumn.size(); i++) {
+            append(numberColumn.getInt(i));
+        }
+        return this;
+    }
+
+}

--- a/core/src/main/java/tech/tablesaw/api/NumericColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/NumericColumn.java
@@ -84,7 +84,7 @@ public interface NumericColumn<T> extends Column<T>, NumberMapFunctions, NumberF
     }
 
     @Override
-    default Selection eval(final DoubleBiPredicate predicate, final NumberColumn otherColumn) {
+    default Selection eval(final DoubleBiPredicate predicate, final DoubleColumn otherColumn) {
         final Selection selection = new BitmapBackedSelection();
         for (int idx = 0; idx < size(); idx++) {
             if (predicate.test(getDouble(idx), otherColumn.getDouble(idx))) {

--- a/core/src/main/java/tech/tablesaw/api/NumericColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/NumericColumn.java
@@ -1,0 +1,454 @@
+package tech.tablesaw.api;
+
+import static tech.tablesaw.aggregate.AggregateFunctions.geometricMean;
+import static tech.tablesaw.aggregate.AggregateFunctions.kurtosis;
+import static tech.tablesaw.aggregate.AggregateFunctions.max;
+import static tech.tablesaw.aggregate.AggregateFunctions.mean;
+import static tech.tablesaw.aggregate.AggregateFunctions.median;
+import static tech.tablesaw.aggregate.AggregateFunctions.min;
+import static tech.tablesaw.aggregate.AggregateFunctions.populationVariance;
+import static tech.tablesaw.aggregate.AggregateFunctions.product;
+import static tech.tablesaw.aggregate.AggregateFunctions.quadraticMean;
+import static tech.tablesaw.aggregate.AggregateFunctions.quartile1;
+import static tech.tablesaw.aggregate.AggregateFunctions.quartile3;
+import static tech.tablesaw.aggregate.AggregateFunctions.range;
+import static tech.tablesaw.aggregate.AggregateFunctions.skewness;
+import static tech.tablesaw.aggregate.AggregateFunctions.stdDev;
+import static tech.tablesaw.aggregate.AggregateFunctions.sum;
+import static tech.tablesaw.aggregate.AggregateFunctions.sumOfLogs;
+import static tech.tablesaw.aggregate.AggregateFunctions.sumOfSquares;
+import static tech.tablesaw.aggregate.AggregateFunctions.variance;
+import static tech.tablesaw.columns.numbers.NumberPredicates.isMissing;
+import static tech.tablesaw.columns.numbers.NumberPredicates.isNotMissing;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleFunction;
+import java.util.function.DoublePredicate;
+
+import org.apache.commons.math3.exception.NotANumberException;
+import org.apache.commons.math3.stat.correlation.KendallsCorrelation;
+import org.apache.commons.math3.stat.correlation.PearsonsCorrelation;
+import org.apache.commons.math3.stat.correlation.SpearmansCorrelation;
+
+import it.unimi.dsi.fastutil.doubles.DoubleComparator;
+import it.unimi.dsi.fastutil.doubles.DoubleRBTreeSet;
+import tech.tablesaw.aggregate.AggregateFunctions;
+import tech.tablesaw.aggregate.NumericAggregateFunction;
+import tech.tablesaw.columns.Column;
+import tech.tablesaw.columns.numbers.NumberFilters;
+import tech.tablesaw.columns.numbers.NumberMapFunctions;
+import tech.tablesaw.columns.numbers.NumberRollingColumn;
+import tech.tablesaw.columns.numbers.Stats;
+import tech.tablesaw.filtering.predicates.DoubleBiPredicate;
+import tech.tablesaw.filtering.predicates.DoubleRangePredicate;
+import tech.tablesaw.selection.BitmapBackedSelection;
+import tech.tablesaw.selection.Selection;
+
+public interface NumericColumn<T> extends Column<T>, NumberMapFunctions, NumberFilters {
+
+    @Override
+    T get(final int index);
+
+    @Override
+    default boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    default double[] asDoubleArray() {
+        final double[] output = new double[size()];
+        for (int i = 0; i < size(); i++) {
+            output[i] = getDouble(i);
+        }
+        return output;
+    }
+
+    @Override
+    default String getUnformattedString(final int row) {
+        return String.valueOf(getDouble(row));
+    }
+
+    @Override
+    default Selection eval(final DoublePredicate predicate) {
+        final Selection bitmap = new BitmapBackedSelection();
+        for (int idx = 0; idx < size(); idx++) {
+            final double next = getDouble(idx);
+            if (predicate.test(next)) {
+                bitmap.add(idx);
+            }
+        }
+        return bitmap;
+    }
+
+    @Override
+    default Selection eval(final DoubleBiPredicate predicate, final NumberColumn otherColumn) {
+        final Selection selection = new BitmapBackedSelection();
+        for (int idx = 0; idx < size(); idx++) {
+            if (predicate.test(getDouble(idx), otherColumn.getDouble(idx))) {
+                selection.add(idx);
+            }
+        }
+        return selection;
+    }
+
+    @Override
+    default Selection eval(final DoubleBiPredicate predicate, final Number number) {
+        final double value = number.doubleValue();
+        final Selection bitmap = new BitmapBackedSelection();
+        for (int idx = 0; idx < size(); idx++) {
+            final double next = getDouble(idx);
+            if (predicate.test(next, value)) {
+                bitmap.add(idx);
+            }
+        }
+        return bitmap;
+    }
+
+    @Override
+    default Selection eval(final BiPredicate<Number, Number> predicate, final Number number) {
+        final double value = number.doubleValue();
+        final Selection bitmap = new BitmapBackedSelection();
+        for (int idx = 0; idx < size(); idx++) {
+            final double next = getDouble(idx);
+            if (predicate.test(next, value)) {
+                bitmap.add(idx);
+            }
+        }
+        return bitmap;
+    }
+
+    @Override
+    default Selection eval(final DoubleRangePredicate predicate, final Number rangeStart, final Number rangeEnd) {
+        final double start = rangeStart.doubleValue();
+        final double end = rangeEnd.doubleValue();
+        final Selection bitmap = new BitmapBackedSelection();
+        for (int idx = 0; idx < size(); idx++) {
+            final double next = getDouble(idx);
+            if (predicate.test(next, start, end)) {
+                bitmap.add(idx);
+            }
+        }
+        return bitmap;
+    }
+
+    @Override
+    default Selection isIn(final Number... numbers) {
+        return isIn(Arrays.stream(numbers).mapToDouble(Number::doubleValue).toArray());
+    }
+
+    @Override
+    default Selection isIn(final double... doubles) {
+        final Selection results = new BitmapBackedSelection();
+        final DoubleRBTreeSet doubleSet = new DoubleRBTreeSet(doubles);
+        for (int i = 0; i < size(); i++) {
+            if (doubleSet.contains(getDouble(i))) {
+                results.add(i);
+            }
+        }
+        return results;
+    }
+
+    @Override
+    default Selection isNotIn(final Number... numbers) {
+        final Selection results = new BitmapBackedSelection();
+        results.addRange(0, size());
+        results.andNot(isIn(numbers));
+        return results;
+    }
+
+    @Override
+    default Selection isNotIn(final double... doubles) {
+        final Selection results = new BitmapBackedSelection();
+        results.addRange(0, size());
+        results.andNot(isIn(doubles));
+        return results;
+    }
+
+    @Override
+    default Selection isMissing() {
+        return eval(isMissing);
+    }
+
+    @Override
+    default Selection isNotMissing() {
+        return eval(isNotMissing);
+    }
+
+    /**
+     * Counts the number of rows satisfying predicate
+     *
+     * @param test the predicate
+     * @return the number of rows satisfying the predicate
+     */
+    default int count(DoublePredicate test) {
+        return count(test, size());
+    }
+
+    /**
+     * Counts the number of rows satisfying predicate, but only upto the max value
+     *
+     * @param test the predicate
+     * @param max  the maximum number of rows to count
+     * @return the number of rows satisfying the predicate
+     */
+    default int count(DoublePredicate test, int max) {
+        int count = 0;
+        for (int i = 0; i < size(); i++) {
+            if (test.test(getDouble(i))) {
+                count++;
+                if (count >= max) {
+                    return count;
+                }
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Returns the maximum row according to the provided Comparator
+     *
+     * @param comp
+     * @return the maximum row
+     */
+    default Optional<Double> max(DoubleComparator comp) {
+        boolean first = true;
+        double d1 = 0.0;
+        for (int i = 0; i < size(); i++) {
+            double d2 = getDouble(i);
+            if (first) {
+                d1 = d2;
+                first = false;
+            } else if (comp.compare(d1, d2) < 0) {
+                d1 = d2;
+            }
+        }
+        return (first ? Optional.<Double>empty() : Optional.<Double>of(d1));
+    }
+
+    /**
+     * Returns the minimum row according to the provided Comparator
+     *
+     * @param comp
+     * @return the minimum row
+     */
+    default Optional<Double> min(DoubleComparator comp) {
+        boolean first = true;
+        double d1 = 0.0;
+        for (int i = 0; i < size(); i++) {
+            double d2 = getDouble(i);
+            if (first) {
+                d1 = d2;
+                first = false;
+            } else if (comp.compare(d1, d2) > 0) {
+                d1 = d2;
+            }
+        }
+        return (first ? Optional.<Double>empty() : Optional.<Double>of(d1));
+    }
+
+    /**
+     * Reduction with binary operator and initial value
+     *
+     * @param initial initial value
+     * @param op      the operator
+     * @return the result of reducing initial value and all rows with operator
+     */
+    default double reduce(double initial, DoubleBinaryOperator op) {
+        double acc = initial;
+        for (int i = 0; i < size(); i++) {
+            acc = op.applyAsDouble(acc, getDouble(i));
+        }
+        return acc;
+    }
+
+    /**
+     * Reduction with binary operator
+     *
+     * @param op the operator
+     * @return Optional with the result of reducing all rows with operator
+     */
+    default Optional<Double> reduce(DoubleBinaryOperator op) {
+        boolean first = true;
+        double acc = 0.0;
+        for (int i = 0; i < size(); i++) {
+            double d = getDouble(i);
+            if (first) {
+                acc = d;
+                first = false;
+            } else {
+                acc = op.applyAsDouble(acc, d);
+            }
+        }
+        return (first ? Optional.<Double>empty() : Optional.<Double>of(acc));
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to the provided Column
+     *
+     * @param fun  function to map
+     * @param into Column to which results are appended
+     * @return the provided Column, to which results are appended
+     */
+    default <R> Column<R> mapInto(DoubleFunction<? extends R> fun, Column<R> into) {
+        for (int i = 0; i < size(); i++) {
+            try {
+                into.append(fun.apply(getDouble(i)));
+            } catch (Exception e) {
+                into.appendMissing();
+            }
+        }
+        return into;
+    }
+
+    @Override
+    default NumericColumn<T> where(final Selection selection) {
+        return (NumericColumn<T>) subset(selection);
+    }
+
+    /**
+     * Summarizes the data in this column for all rows where the current value matches the selection criteria
+     * <p>
+     * Example:
+     * myColumn.summarize(myColumn.isLessThan(100), AggregateFunctions.count);
+     */
+    default Double summarize(Selection selection, NumericAggregateFunction function) {
+        NumericColumn<T> column = where(selection);
+        return function.summarize(column);
+    }
+
+    // Reduce functions applied to the whole column
+    default double sum() {
+        return sum.summarize(this);
+    }
+
+    default double product() {
+        return product.summarize(this);
+    }
+
+    default double mean() {
+        return mean.summarize(this);
+    }
+
+    default double median() {
+        return median.summarize(this);
+    }
+
+    default double quartile1() {
+        return quartile1.summarize(this);
+    }
+
+    default double quartile3() {
+        return quartile3.summarize(this);
+    }
+
+    default double percentile(double percentile) {
+        return AggregateFunctions.percentile(this, percentile);
+    }
+
+    default double range() {
+        return range.summarize(this);
+    }
+
+    default double max() {
+        return max.summarize(this);
+    }
+
+    default double min() {
+        return min.summarize(this);
+    }
+
+    default double variance() {
+        return variance.summarize(this);
+    }
+
+    default double populationVariance() {
+        return populationVariance.summarize(this);
+    }
+
+    default double standardDeviation() {
+        return stdDev.summarize(this);
+    }
+
+    default double sumOfLogs() {
+        return sumOfLogs.summarize(this);
+    }
+
+    default double sumOfSquares() {
+        return sumOfSquares.summarize(this);
+    }
+
+    default double geometricMean() {
+        return geometricMean.summarize(this);
+    }
+
+    /**
+     * Returns the quadraticMean, aka the root-mean-square, for all values in this column
+     */
+    default double quadraticMean() {
+        return quadraticMean.summarize(this);
+    }
+
+    default double kurtosis() {
+        return kurtosis.summarize(this);
+    }
+
+    default double skewness() {
+        return skewness.summarize(this);
+    }
+
+    /**
+     * Returns the pearson's correlation between the receiver and the otherColumn
+     **/
+    default double pearsons(NumericColumn<?> otherColumn) {
+        double[] x = asDoubleArray();
+        double[] y = otherColumn.asDoubleArray();
+        return new PearsonsCorrelation().correlation(x, y);
+    }
+
+    /**
+     * Returns the Spearman's Rank correlation between the receiver and the otherColumn
+     *
+     * @param otherColumn A NumberColumn with no missing values
+     * @throws NotANumberException if either column contains any missing values
+     **/
+    default double spearmans(NumericColumn<?> otherColumn) {
+        double[] x = asDoubleArray();
+        double[] y = otherColumn.asDoubleArray();
+        return new SpearmansCorrelation().correlation(x, y);
+    }
+
+    /**
+     * Returns the Kendall's Tau Rank correlation between the receiver and the otherColumn
+     **/
+    default double kendalls(NumericColumn<?> otherColumn) {
+        double[] x = asDoubleArray();
+        double[] y = otherColumn.asDoubleArray();
+        return new KendallsCorrelation().correlation(x, y);
+    }
+
+    default Table summary() {
+        return stats().asTable();
+    }
+
+    default Stats stats() {
+        return Stats.create(this);
+    }
+    
+    default NumberRollingColumn rolling(final int windowSize) {
+        return new NumberRollingColumn(this, windowSize);
+    }
+
+
+    @Override
+    default NumericColumn<T> lead(final int n) {
+        final NumericColumn<T> numberColumn = lag(-n);
+        numberColumn.setName(name() + " lead(" + n + ")");
+        return numberColumn;
+    }
+
+    NumericColumn<T> lag(final int n);
+
+}

--- a/core/src/main/java/tech/tablesaw/api/Row.java
+++ b/core/src/main/java/tech/tablesaw/api/Row.java
@@ -16,7 +16,9 @@ public class Row implements Iterator<Row> {
     private final Table table;
     private final String[] columnNames;
     private final Map<String, DateColumn> dateColumnMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    private final Map<String, NumberColumn> doubleColumnMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    private final Map<String, DoubleColumn> doubleColumnMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    private final Map<String, IntColumn> intColumnMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    private final Map<String, FloatColumn> floatColumnMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private final Map<String, StringColumn> stringColumnMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private final Map<String, BooleanColumn> booleanColumnMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private final Map<String, DateTimeColumn> dateTimeColumnMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -29,8 +31,14 @@ public class Row implements Iterator<Row> {
         columnNames = table.columnNames().toArray(new String[0]);
         rowNumber = -1;
         for (Column<?> column : table.columns()) {
-            if (column instanceof NumberColumn) {
-                doubleColumnMap.put(column.name(), (NumberColumn) column);
+            if (column instanceof DoubleColumn) {
+                doubleColumnMap.put(column.name(), (DoubleColumn) column);
+            }
+            if (column instanceof IntColumn) {
+                intColumnMap.put(column.name(), (IntColumn) column);
+            }
+            if (column instanceof FloatColumn) {
+                floatColumnMap.put(column.name(), (FloatColumn) column);
             }
             if (column instanceof BooleanColumn) {
                 booleanColumnMap.put(column.name(), (BooleanColumn) column);
@@ -82,13 +90,21 @@ public class Row implements Iterator<Row> {
     }
 
     public int getInt(String columnName) {
-        return (int) getDouble(columnName);
+	return intColumnMap.get(columnName).getInt(rowNumber);
     }
 
     public int getInt(int columnIndex) {
-        return (int) getDouble(columnIndex);
+        return getInt(columnNames[columnIndex]);
     }
 
+    public int getFloat(String columnName) {
+	return floatColumnMap.get(columnName).getInt(rowNumber);
+    }
+
+    public int getFloat(int columnIndex) {
+        return getFloat(columnNames[columnIndex]);
+    }
+    
     public String getString(String columnName) {
         return stringColumnMap.get(columnName).get(rowNumber);
     }

--- a/core/src/main/java/tech/tablesaw/api/StringColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/StringColumn.java
@@ -224,7 +224,7 @@ public class StringColumn extends AbstractColumn<String>
     public Table countByCategory() {
         Table t = new Table("Column: " + name());
         StringColumn categories = create("Category");
-        NumberColumn counts = NumberColumn.create("Count");
+        IntColumn counts = IntColumn.create("Count");
 
         Int2IntMap valueToCount = new Int2IntOpenHashMap();
 
@@ -511,8 +511,8 @@ public class StringColumn extends AbstractColumn<String>
     }
 
 
-    public NumberColumn asNumberColumn() {
-        NumberColumn numberColumn = NumberColumn.create(this.name() + ": codes", size());
+    public DoubleColumn asNumberColumn() {
+        DoubleColumn numberColumn = DoubleColumn.create(this.name() + ": codes", size());
         IntArrayList data = data();
         for (int i = 0; i < size(); i++) {
             numberColumn.append(data.getInt(i));

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -14,8 +14,21 @@
 
 package tech.tablesaw.api;
 
+import static tech.tablesaw.aggregate.AggregateFunctions.countMissing;
+import static tech.tablesaw.selection.Selection.selectNRowsAtRandom;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
+
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntArrays;
 import it.unimi.dsi.fastutil.ints.IntComparator;
@@ -36,18 +49,6 @@ import tech.tablesaw.table.Relation;
 import tech.tablesaw.table.Rows;
 import tech.tablesaw.table.StandardTableSliceGroup;
 import tech.tablesaw.table.TableSliceGroup;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import static tech.tablesaw.aggregate.AggregateFunctions.countMissing;
-import static tech.tablesaw.selection.Selection.selectNRowsAtRandom;
 
 /**
  * A table of data, consisting of some number of columns, each of which has the same number of rows.
@@ -691,7 +692,7 @@ public class Table extends Relation implements Iterable<Row> {
     public Table structure() {
         Table t = new Table("Structure of " + name());
         //NumberColumn index = NumberColumn.create("Index", columnCount());
-        NumberColumn index = NumberColumn.indexColumn("Index", columnCount(), 0);
+        IntColumn index = IntColumn.indexColumn("Index", columnCount(), 0);
         StringColumn columnName = StringColumn.create("Column Name", columnCount());
         StringColumn columnType = StringColumn.create("Column Type", columnCount());
         t.addColumns(index);

--- a/core/src/main/java/tech/tablesaw/columns/StringParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/StringParser.java
@@ -45,7 +45,7 @@ public abstract class StringParser<T> {
     }
 
     public int parseInt(String s) {
-        throw new UnsupportedOperationException(this.getClass().getSimpleName() + " doesn't support parsing to booleans");
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() + " doesn't support parsing to ints");
     }
 
     public double parseDouble(String s) {

--- a/core/src/main/java/tech/tablesaw/columns/dates/DateMapFunctions.java
+++ b/core/src/main/java/tech/tablesaw/columns/dates/DateMapFunctions.java
@@ -14,17 +14,8 @@
 
 package tech.tablesaw.columns.dates;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import tech.tablesaw.api.DateColumn;
-import tech.tablesaw.api.DateTimeColumn;
-import tech.tablesaw.api.NumberColumn;
-import tech.tablesaw.api.StringColumn;
-import tech.tablesaw.api.TimeColumn;
-import tech.tablesaw.columns.Column;
-import tech.tablesaw.columns.datetimes.PackedLocalDateTime;
-import tech.tablesaw.columns.numbers.DoubleColumnType;
-import tech.tablesaw.columns.numbers.NumberColumnFormatter;
+import static tech.tablesaw.api.DateColumn.MISSING_VALUE;
+import static tech.tablesaw.api.DateColumn.valueIsMissing;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -32,7 +23,18 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
 
-import static tech.tablesaw.api.DateColumn.*;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+import tech.tablesaw.api.DateColumn;
+import tech.tablesaw.api.DateTimeColumn;
+import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.IntColumn;
+import tech.tablesaw.api.StringColumn;
+import tech.tablesaw.api.TimeColumn;
+import tech.tablesaw.columns.Column;
+import tech.tablesaw.columns.datetimes.PackedLocalDateTime;
+import tech.tablesaw.columns.numbers.NumberColumnFormatter;
 
 /**
  * An interface for mapping operations unique to Date columns
@@ -43,28 +45,28 @@ public interface DateMapFunctions extends Column<LocalDate> {
         return column1.name() + ": " + value + " " + unit.toString() + "(s)";
     }
 
-    default NumberColumn daysUntil(DateColumn column2) {
+    default DoubleColumn daysUntil(DateColumn column2) {
         return timeUntil(column2, ChronoUnit.DAYS);
     }
 
-    default NumberColumn weeksUntil(DateColumn column2) {
+    default DoubleColumn weeksUntil(DateColumn column2) {
         return timeUntil(column2, ChronoUnit.WEEKS);
     }
 
-    default NumberColumn monthsUntil(DateColumn column2) {
+    default DoubleColumn monthsUntil(DateColumn column2) {
         return timeUntil(column2, ChronoUnit.MONTHS);
     }
 
-    default NumberColumn yearsUntil(DateColumn column2) {
+    default DoubleColumn yearsUntil(DateColumn column2) {
         return timeUntil(column2, ChronoUnit.YEARS);
     }
 
-    default NumberColumn dayOfMonth() {
-        NumberColumn newColumn = NumberColumn.create(this.name() + " day of month");
+    default IntColumn dayOfMonth() {
+	IntColumn newColumn = IntColumn.create(this.name() + " day of month");
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.append(DoubleColumnType.missingValueIndicator());
+        	newColumn.appendMissing();
             } else {
                 newColumn.append(PackedLocalDate.getDayOfMonth(c1));
             }
@@ -72,12 +74,12 @@ public interface DateMapFunctions extends Column<LocalDate> {
         return newColumn;
     }
 
-    default NumberColumn dayOfYear() {
-        NumberColumn newColumn = NumberColumn.create(this.name() + " day of year");
+    default IntColumn dayOfYear() {
+	IntColumn newColumn = IntColumn.create(this.name() + " day of year");
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.append(DoubleColumnType.missingValueIndicator());
+        	newColumn.appendMissing();
             } else {
                 newColumn.append((short) PackedLocalDate.getDayOfYear(c1));
             }
@@ -85,13 +87,13 @@ public interface DateMapFunctions extends Column<LocalDate> {
         return newColumn;
     }
 
-    default NumberColumn monthValue() {
-        NumberColumn newColumn = NumberColumn.create(this.name() + " month");
+    default IntColumn monthValue() {
+	IntColumn newColumn = IntColumn.create(this.name() + " month");
 
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.append(DoubleColumnType.missingValueIndicator());
+                newColumn.appendMissing();
             } else {
                 newColumn.append(PackedLocalDate.getMonthValue(c1));
             }
@@ -105,7 +107,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.append(StringColumn.MISSING_VALUE);
+        	newColumn.appendMissing();
             } else {
                 newColumn.append(PackedLocalDate.getMonth(c1).name());
             }
@@ -113,12 +115,12 @@ public interface DateMapFunctions extends Column<LocalDate> {
         return newColumn;
     }
 
-    default NumberColumn year() {
-        NumberColumn newColumn = NumberColumn.create(this.name() + " year");
+    default IntColumn year() {
+	IntColumn newColumn = IntColumn.create(this.name() + " year");
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.append(DoubleColumnType.missingValueIndicator());
+                newColumn.appendMissing();
             } else {
                 newColumn.append(PackedLocalDate.getYear(c1));
             }
@@ -139,7 +141,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.append(StringColumn.MISSING_VALUE);
+        	newColumn.appendMissing();
             } else {
                 String yq = String.valueOf(PackedLocalDate.getYear(c1));
                 yq = yq + "-" + Strings.padStart(
@@ -163,7 +165,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.append(StringColumn.MISSING_VALUE);
+        	newColumn.appendMissing();
             } else {
                 String ym = String.valueOf(PackedLocalDate.getYear(c1));
                 ym = ym + "-" + Strings.padStart(
@@ -187,7 +189,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.append(StringColumn.MISSING_VALUE);
+        	newColumn.appendMissing();
             } else {
                 String ym = String.valueOf(PackedLocalDate.getYear(c1));
                 ym = ym + "-" + Strings.padStart(
@@ -211,7 +213,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.append(StringColumn.MISSING_VALUE);
+        	newColumn.appendMissing();
             } else {
                 String ym = String.valueOf(PackedLocalDate.getYear(c1));
                 ym = ym + "-" + Strings.padStart(
@@ -222,12 +224,12 @@ public interface DateMapFunctions extends Column<LocalDate> {
         return newColumn;
     }
 
-    default NumberColumn dayOfWeekValue() {
-        NumberColumn newColumn = NumberColumn.create(this.name() + " day of week", this.size());
+    default IntColumn dayOfWeekValue() {
+	IntColumn newColumn = IntColumn.create(this.name() + " day of week", this.size());
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.set(r, DoubleColumnType.missingValueIndicator());
+                newColumn.appendMissing();
             } else {
                 newColumn.append((short) PackedLocalDate.getDayOfWeek(c1).getValue());
             }
@@ -240,7 +242,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.append(StringColumn.MISSING_VALUE);
+        	newColumn.appendMissing();
             } else {
                 newColumn.append(PackedLocalDate.getDayOfWeek(c1).toString());
             }
@@ -254,14 +256,14 @@ public interface DateMapFunctions extends Column<LocalDate> {
      * <p>
      * Missing values in either result in a Missing Value for the new column
      */
-    default NumberColumn timeUntil(DateColumn end, ChronoUnit unit) {
+    default DoubleColumn timeUntil(DateColumn end, ChronoUnit unit) {
 
-        NumberColumn newColumn = NumberColumn.create(name() + " - " + end.name());
+        DoubleColumn newColumn = DoubleColumn.create(name() + " - " + end.name());
         for (int r = 0; r < size(); r++) {
             int c1 = getIntInternal(r);
             int c2 = end.getIntInternal(r);
             if (valueIsMissing(c1) || valueIsMissing(c2)) {
-                newColumn.append(DoubleColumnType.missingValueIndicator());
+                newColumn.appendMissing();
             } else {
                 switch (unit) {
                     case DAYS:
@@ -336,10 +338,10 @@ public interface DateMapFunctions extends Column<LocalDate> {
      * @param n     The number of units in each group.
      * @param start The starting point of the first group; group boundaries are offsets from this point
      */
-    default NumberColumn timeWindow(ChronoUnit unit, int n, LocalDate start) {
+    default DoubleColumn timeWindow(ChronoUnit unit, int n, LocalDate start) {
         String newColumnName = "" +  n + " " + unit.toString() + " window [" + name() + "]";
         int packedStartDate = PackedLocalDate.pack(start);
-        NumberColumn numberColumn = NumberColumn.create(newColumnName, size());
+        DoubleColumn numberColumn = DoubleColumn.create(newColumnName, size());
         for (int i = 0; i < size(); i++) {
             int packedDate = getIntInternal(i);
             int result;
@@ -365,7 +367,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
         return numberColumn;
     }
 
-    default NumberColumn timeWindow(ChronoUnit unit, int n) {
+    default DoubleColumn timeWindow(ChronoUnit unit, int n) {
         return timeWindow(unit, n, min());
     }
 
@@ -377,7 +379,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
         for (int r = 0; r < column1.size(); r++) {
             int packedDate = column1.getIntInternal(r);
             if (packedDate == MISSING_VALUE) {
-                newColumn.appendInternal(MISSING_VALUE);
+        	newColumn.appendMissing();
             } else {
                 newColumn.appendInternal(PackedLocalDate.plus(value, unit, packedDate));
             }
@@ -395,7 +397,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
         for (int r = 0; r < this.size(); r++) {
             LocalDate c1 = this.get(r);
             if (c1 == null) {
-                newColumn.appendInternal(DateTimeColumn.MISSING_VALUE);
+        	newColumn.appendMissing();
             } else {
                 newColumn.append(c1.atStartOfDay());
             }
@@ -413,7 +415,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
         for (int r = 0; r < this.size(); r++) {
             int c1 = this.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1)) {
-                newColumn.appendInternal(DateTimeColumn.MISSING_VALUE);
+        	newColumn.appendMissing();
             } else {
                 LocalDate value1 = PackedLocalDate.asLocalDate(c1);
                 newColumn.appendInternal(PackedLocalDateTime.pack(value1, time));
@@ -432,7 +434,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
             int c1 = this.getIntInternal(r);
             int c2 = timeColumn.getIntInternal(r);
             if (DateColumn.valueIsMissing(c1) || DateColumn.valueIsMissing(c2)) {
-                newColumn.appendInternal(DateTimeColumn.MISSING_VALUE);
+        	newColumn.appendMissing();
             } else {
                 newColumn.appendInternal(PackedLocalDateTime.create(c1, c2));
             }

--- a/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeMapFunctions.java
+++ b/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeMapFunctions.java
@@ -17,7 +17,7 @@ package tech.tablesaw.columns.datetimes;
 import com.google.common.base.Strings;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DateTimeColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.TimeColumn;
 import tech.tablesaw.columns.Column;
@@ -35,32 +35,32 @@ import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.*;
 
 public interface DateTimeMapFunctions extends Column<LocalDateTime> {
 
-    default NumberColumn differenceInMilliseconds(DateTimeColumn column2) {
+    default DoubleColumn differenceInMilliseconds(DateTimeColumn column2) {
         return difference(column2, ChronoUnit.MILLIS);
     }
 
-    default NumberColumn differenceInSeconds(DateTimeColumn column2) {
+    default DoubleColumn differenceInSeconds(DateTimeColumn column2) {
         return difference(column2, ChronoUnit.SECONDS);
     }
 
-    default NumberColumn differenceInMinutes(DateTimeColumn column2) {
+    default DoubleColumn differenceInMinutes(DateTimeColumn column2) {
         return difference(column2, ChronoUnit.MINUTES);
     }
 
-    default NumberColumn differenceInHours(DateTimeColumn column2) {
+    default DoubleColumn differenceInHours(DateTimeColumn column2) {
         return difference(column2, ChronoUnit.HOURS);
     }
 
-    default NumberColumn differenceInDays(DateTimeColumn column2) {
+    default DoubleColumn differenceInDays(DateTimeColumn column2) {
         return difference(column2, ChronoUnit.DAYS);
     }
 
-    default NumberColumn differenceInYears(DateTimeColumn column2) {
+    default DoubleColumn differenceInYears(DateTimeColumn column2) {
         return difference(column2, ChronoUnit.YEARS);
     }
 
-    default NumberColumn difference(DateTimeColumn column2, ChronoUnit unit) {
-        NumberColumn newColumn = NumberColumn.create(name() + " - " + column2.name());
+    default DoubleColumn difference(DateTimeColumn column2, ChronoUnit unit) {
+        DoubleColumn newColumn = DoubleColumn.create(name() + " - " + column2.name());
 
         for (int r = 0; r < size(); r++) {
             long c1 = this.getLongInternal(r);
@@ -80,8 +80,8 @@ public interface DateTimeMapFunctions extends Column<LocalDateTime> {
         return newColumn;
     }
 
-    default NumberColumn hour() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[" + "hour" + "]");
+    default DoubleColumn hour() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[" + "hour" + "]");
         for (int r = 0; r < size(); r++) {
             long c1 = getLongInternal(r);
             if (c1 != MISSING_VALUE) {
@@ -93,8 +93,8 @@ public interface DateTimeMapFunctions extends Column<LocalDateTime> {
         return newColumn;
     }
 
-    default NumberColumn minuteOfDay() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[" + "minute-of-day" + "]");
+    default DoubleColumn minuteOfDay() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[" + "minute-of-day" + "]");
         for (int r = 0; r < size(); r++) {
             long c1 = getLongInternal(r);
             if (c1 != MISSING_VALUE) {
@@ -106,8 +106,8 @@ public interface DateTimeMapFunctions extends Column<LocalDateTime> {
         return newColumn;
     }
 
-    default NumberColumn secondOfDay() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[" + "second-of-day" + "]");
+    default DoubleColumn secondOfDay() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[" + "second-of-day" + "]");
         for (int r = 0; r < size(); r++) {
             long c1 = getLongInternal(r);
             if (c1 != MISSING_VALUE) {
@@ -145,8 +145,8 @@ public interface DateTimeMapFunctions extends Column<LocalDateTime> {
         return newColumn;
     }
 
-    default NumberColumn monthValue() {
-        NumberColumn newColumn = NumberColumn.create(this.name() + " month");
+    default DoubleColumn monthValue() {
+        DoubleColumn newColumn = DoubleColumn.create(this.name() + " month");
         for (int r = 0; r < this.size(); r++) {
             long c1 = getLongInternal(r);
             if (DateTimeColumn.valueIsMissing(c1)) {
@@ -309,8 +309,8 @@ public interface DateTimeMapFunctions extends Column<LocalDateTime> {
         return newColumn;
     }
 
-    default NumberColumn year() {
-        NumberColumn newColumn = NumberColumn.create(this.name() + " year");
+    default DoubleColumn year() {
+        DoubleColumn newColumn = DoubleColumn.create(this.name() + " year");
         for (int r = 0; r < this.size(); r++) {
             long c1 = getLongInternal(r);
             if (DateTimeColumn.valueIsMissing(c1)) {
@@ -335,8 +335,8 @@ public interface DateTimeMapFunctions extends Column<LocalDateTime> {
         return newColumn;
     }
 
-    default NumberColumn dayOfWeekValue() {
-        NumberColumn newColumn = NumberColumn.create(this.name() + " day of week", this.size());
+    default DoubleColumn dayOfWeekValue() {
+        DoubleColumn newColumn = DoubleColumn.create(this.name() + " day of week", this.size());
         for (int r = 0; r < this.size(); r++) {
             long c1 = this.getLongInternal(r);
             if (DateTimeColumn.valueIsMissing(c1)) {
@@ -348,8 +348,8 @@ public interface DateTimeMapFunctions extends Column<LocalDateTime> {
         return newColumn;
     }
 
-    default NumberColumn dayOfYear() {
-        NumberColumn newColumn = NumberColumn.create(this.name() + " day of year", this.size());
+    default DoubleColumn dayOfYear() {
+        DoubleColumn newColumn = DoubleColumn.create(this.name() + " day of year", this.size());
         for (int r = 0; r < this.size(); r++) {
             long c1 = this.getLongInternal(r);
             if (DateTimeColumn.valueIsMissing(c1)) {
@@ -361,8 +361,8 @@ public interface DateTimeMapFunctions extends Column<LocalDateTime> {
         return newColumn;
     }
 
-    default NumberColumn dayOfMonth() {
-        NumberColumn newColumn = NumberColumn.create(this.name() + " day of month");
+    default DoubleColumn dayOfMonth() {
+        DoubleColumn newColumn = DoubleColumn.create(this.name() + " day of month");
         for (int r = 0; r < this.size(); r++) {
             long c1 = this.getLongInternal(r);
             if (DateTimeColumn.valueIsMissing(c1)) {
@@ -384,10 +384,10 @@ public interface DateTimeMapFunctions extends Column<LocalDateTime> {
      * @param n     The number of units in each group.
      * @param start The starting point of the first group; group boundaries are offsets from this point
      */
-    default NumberColumn timeWindow(ChronoUnit unit, int n, LocalDateTime start) {
+    default DoubleColumn timeWindow(ChronoUnit unit, int n, LocalDateTime start) {
         String newColumnName = "" +  n + " " + unit.toString() + " window [" + name() + "]";
         long packedStartDate = pack(start);
-        NumberColumn numberColumn = NumberColumn.create(newColumnName, size());
+        DoubleColumn numberColumn = DoubleColumn.create(newColumnName, size());
         for (int i = 0; i < size(); i++) {
             long packedDate = getLongInternal(i);
             long result;
@@ -419,8 +419,8 @@ public interface DateTimeMapFunctions extends Column<LocalDateTime> {
         return numberColumn;
     }
 
-    default NumberColumn minute() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[" + "minute" + "]");
+    default DoubleColumn minute() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[" + "minute" + "]");
         for (int r = 0; r < size(); r++) {
             long c1 = getLongInternal(r);
             if (!DateTimeColumn.valueIsMissing(c1)) {
@@ -432,7 +432,7 @@ public interface DateTimeMapFunctions extends Column<LocalDateTime> {
         return newColumn;
     }
 
-    default NumberColumn timeWindow(ChronoUnit unit, int n) {
+    default DoubleColumn timeWindow(ChronoUnit unit, int n) {
         return timeWindow(unit, n, min());
     }
 

--- a/core/src/main/java/tech/tablesaw/columns/numbers/DoubleColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/DoubleColumnType.java
@@ -1,7 +1,7 @@
 package tech.tablesaw.columns.numbers;
 
 import tech.tablesaw.api.ColumnType;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.columns.AbstractColumnType;
 import tech.tablesaw.io.csv.CsvReadOptions;
 
@@ -19,8 +19,8 @@ public class DoubleColumnType extends AbstractColumnType {
     }
 
     @Override
-    public NumberColumn create(String name) {
-        return NumberColumn.create(name);
+    public DoubleColumn create(String name) {
+        return DoubleColumn.create(name);
     }
 
     @Override
@@ -31,6 +31,10 @@ public class DoubleColumnType extends AbstractColumnType {
     @Override
     public DoubleStringParser customParser(CsvReadOptions options) {
         return new DoubleStringParser(this, options);
+    }
+
+    public static boolean isMissingValue(double value) {
+	return Double.isNaN(value);
     }
 
     public static double missingValueIndicator() {

--- a/core/src/main/java/tech/tablesaw/columns/numbers/FloatColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/FloatColumnType.java
@@ -1,7 +1,7 @@
 package tech.tablesaw.columns.numbers;
 
 import tech.tablesaw.api.ColumnType;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.FloatColumn;
 import tech.tablesaw.columns.AbstractColumnType;
 import tech.tablesaw.io.csv.CsvReadOptions;
 
@@ -19,8 +19,8 @@ public class FloatColumnType extends AbstractColumnType {
     }
 
     @Override
-    public NumberColumn create(String name) {
-        return NumberColumn.createWithFloats(name);
+    public FloatColumn create(String name) {
+        return FloatColumn.create(name);
     }
 
     @Override
@@ -31,6 +31,10 @@ public class FloatColumnType extends AbstractColumnType {
     @Override
     public FloatStringParser customParser(CsvReadOptions options) {
         return new FloatStringParser(this, options);
+    }
+
+    public static boolean isMissingValue(float value) {
+	return Float.isNaN(value);
     }
 
     public static float missingValueIndicator() {

--- a/core/src/main/java/tech/tablesaw/columns/numbers/FloatDataWrapper.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/FloatDataWrapper.java
@@ -32,8 +32,8 @@ public class FloatDataWrapper implements NumericDataWrapper {
     }
 
     @Override
-    public Iterator<Double> iterator() {
-        return new NumberIterator(data).iterator();
+    public Iterator<Float> iterator() {
+        return data.iterator();
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/columns/numbers/IntColumnType.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/IntColumnType.java
@@ -1,7 +1,7 @@
 package tech.tablesaw.columns.numbers;
 
 import tech.tablesaw.api.ColumnType;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.IntColumn;
 import tech.tablesaw.columns.AbstractColumnType;
 import tech.tablesaw.io.csv.CsvReadOptions;
 
@@ -19,8 +19,8 @@ public class IntColumnType extends AbstractColumnType {
     }
 
     @Override
-    public NumberColumn create(String name) {
-        return NumberColumn.createWithIntegers(name);
+    public IntColumn create(String name) {
+        return IntColumn.create(name);
     }
 
     @Override
@@ -31,6 +31,10 @@ public class IntColumnType extends AbstractColumnType {
     @Override
     public IntStringParser customParser(CsvReadOptions options) {
         return new IntStringParser(this, options);
+    }
+
+    public static boolean isMissingValue(int value) {
+	return value == missingValueIndicator();
     }
 
     public static int missingValueIndicator() {

--- a/core/src/main/java/tech/tablesaw/columns/numbers/IntDataWrapper.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/IntDataWrapper.java
@@ -33,8 +33,8 @@ public class IntDataWrapper implements NumericDataWrapper {
     }
 
     @Override
-    public Iterator<Double> iterator() {
-        return new NumberIterator(data).iterator();
+    public Iterator<Integer> iterator() {
+        return data.iterator();
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/columns/numbers/NumberFilters.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/NumberFilters.java
@@ -14,7 +14,7 @@
 
 package tech.tablesaw.columns.numbers;
 
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.filtering.predicates.DoubleBiPredicate;
 import tech.tablesaw.filtering.predicates.DoubleRangePredicate;
 import tech.tablesaw.selection.BitmapBackedSelection;
@@ -31,7 +31,7 @@ public interface NumberFilters {
 
     Selection eval(DoubleRangePredicate predicate, Number rangeStart, Number rangeEnd);
 
-    Selection eval(DoubleBiPredicate predicate, NumberColumn otherColumn);
+    Selection eval(DoubleBiPredicate predicate, DoubleColumn otherColumn);
 
     Selection eval(DoubleBiPredicate predicate, Number value);
 
@@ -114,7 +114,7 @@ public interface NumberFilters {
 
     // Column filters
 
-    default Selection isGreaterThan(NumberColumn d) {
+    default Selection isGreaterThan(DoubleColumn d) {
         Selection results = new BitmapBackedSelection();
         for (int i = 0; i < size(); i++) {
             if (this.getDouble(i) > d.getDouble(i)) {
@@ -124,7 +124,7 @@ public interface NumberFilters {
         return results;
     }
 
-    default Selection isGreaterThanOrEqualTo(NumberColumn d) {
+    default Selection isGreaterThanOrEqualTo(DoubleColumn d) {
         Selection results = new BitmapBackedSelection();
         for (int i = 0; i < size(); i++) {
             if (this.getDouble(i) >= d.getDouble(i)) {
@@ -134,7 +134,7 @@ public interface NumberFilters {
         return results;
     }
 
-    default Selection isEqualTo(NumberColumn d) {
+    default Selection isEqualTo(DoubleColumn d) {
         Selection results = new BitmapBackedSelection();
         for (int i = 0; i < size(); i++) {
             if (this.getDouble(i) == d.getDouble(i)) {
@@ -148,7 +148,7 @@ public interface NumberFilters {
 
     double getDouble(int i);
 
-    default Selection isNotEqualTo(NumberColumn d) {
+    default Selection isNotEqualTo(DoubleColumn d) {
         Selection results = new BitmapBackedSelection();
         for (int i = 0; i < size(); i++) {
             if (this.getDouble(i) != d.getDouble(i)) {
@@ -158,7 +158,7 @@ public interface NumberFilters {
         return results;
     }
 
-    default Selection isLessThan(NumberColumn d) {
+    default Selection isLessThan(DoubleColumn d) {
         Selection results = new BitmapBackedSelection();
         for (int i = 0; i < size(); i++) {
             if (this.getDouble(i) < d.getDouble(i)) {
@@ -168,7 +168,7 @@ public interface NumberFilters {
         return results;
     }
 
-    default Selection isLessThanOrEqualTo(NumberColumn d) {
+    default Selection isLessThanOrEqualTo(DoubleColumn d) {
         Selection results = new BitmapBackedSelection();
         for (int i = 0; i < size(); i++) {
             if (this.getDouble(i) <= d.getDouble(i)) {

--- a/core/src/main/java/tech/tablesaw/columns/numbers/NumberIterable.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/NumberIterable.java
@@ -1,6 +1,6 @@
 package tech.tablesaw.columns.numbers;
 
-public interface NumberIterable extends Iterable<Double> {
+public interface NumberIterable {
 
     NumberIterator numberIterator();
 }

--- a/core/src/main/java/tech/tablesaw/columns/numbers/NumberIterator.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/NumberIterator.java
@@ -10,7 +10,7 @@ import it.unimi.dsi.fastutil.floats.FloatIterator;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 
-public class NumberIterator implements Iterable<Double> {
+public class NumberIterator {
 
     private DoubleArrayList dList;
     private IntArrayList iList;
@@ -45,9 +45,11 @@ public class NumberIterator implements Iterable<Double> {
         if (dList != null) {
             return ((DoubleIterator) iterator).nextDouble();
         } else if (iList != null){
-            return ((IntIterator) iterator).nextInt();
+            int nextInt = ((IntIterator) iterator).nextInt();
+            return IntColumnType.isMissingValue(nextInt) ? DoubleColumnType.missingValueIndicator() : nextInt;
         } else {
-            return ((FloatIterator) iterator).nextFloat();
+            float nextFloat = ((FloatIterator) iterator).nextFloat();
+            return FloatColumnType.isMissingValue(nextFloat) ? DoubleColumnType.missingValueIndicator() : nextFloat;
         }
     }
 

--- a/core/src/main/java/tech/tablesaw/columns/numbers/NumberMapFunctions.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/NumberMapFunctions.java
@@ -17,7 +17,7 @@ package tech.tablesaw.columns.numbers;
 import org.apache.commons.math3.random.EmpiricalDistribution;
 import org.apache.commons.math3.stat.StatUtils;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 
 public interface NumberMapFunctions extends NumberIterable {
 
@@ -25,9 +25,9 @@ public interface NumberMapFunctions extends NumberIterable {
      * Returns a transformation of the data in this column such that the result has a mean of 0, and a
      * standard deviation of 1
      */
-    default NumberColumn normalize() {
+    default DoubleColumn normalize() {
         double[] result = StatUtils.normalize(asDoubleArray());
-        return NumberColumn.create(name() + " normalized", result);
+        return DoubleColumn.create(name() + " normalized", result);
     }
 
     String name();
@@ -42,8 +42,8 @@ public interface NumberMapFunctions extends NumberIterable {
      * Return the elements of this column as the ratios of their value and the sum of all
      * elements
      */
-    default NumberColumn asRatio() {
-      NumberColumn pctColumn = NumberColumn.create(name() + " percents");
+    default DoubleColumn asRatio() {
+      DoubleColumn pctColumn = DoubleColumn.create(name() + " percents");
         double total = sum();
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
@@ -63,8 +63,8 @@ public interface NumberMapFunctions extends NumberIterable {
      * Return the elements of this column as the percentages of their value relative to the sum of all
      * elements
      */
-    default NumberColumn asPercent() {
-        NumberColumn pctColumn = NumberColumn.create(name() + " percents");
+    default DoubleColumn asPercent() {
+        DoubleColumn pctColumn = DoubleColumn.create(name() + " percents");
         double total = sum();
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
@@ -78,61 +78,61 @@ public interface NumberMapFunctions extends NumberIterable {
         return pctColumn;
     }
 
-    default NumberColumn subtract(NumberColumn column2) {
+    default DoubleColumn subtract(DoubleColumn column2) {
         int col1Size = size();
         int col2Size = column2.size();
         if (col1Size != col2Size)
             throw new IllegalArgumentException("The columns must have the same number of elements");
 
-        NumberColumn result = NumberColumn.create(name() + " - " + column2.name(), col1Size);
+        DoubleColumn result = DoubleColumn.create(name() + " - " + column2.name(), col1Size);
         for (int r = 0; r < col1Size; r++) {
             result.append(subtract(getDouble(r), column2.getDouble(r)));
         }
         return result;
     }
 
-    default NumberColumn add(NumberColumn column2) {
+    default DoubleColumn add(DoubleColumn column2) {
         int col1Size = size();
         int col2Size = column2.size();
         if (col1Size != col2Size)
             throw new IllegalArgumentException("The columns must have the same number of elements");
 
-        NumberColumn result = NumberColumn.create(name() + " + " + column2.name(), col1Size);
+        DoubleColumn result = DoubleColumn.create(name() + " + " + column2.name(), col1Size);
         for (int r = 0; r < col1Size; r++) {
             result.append(add(getDouble(r), column2.getDouble(r)));
         }
         return result;
     }
 
-    default NumberColumn multiply(NumberColumn column2) {
+    default DoubleColumn multiply(DoubleColumn column2) {
         int col1Size = size();
         int col2Size = column2.size();
         if (col1Size != col2Size)
             throw new IllegalArgumentException("The columns must have the same number of elements");
 
-        NumberColumn result = NumberColumn.create(name() + " * " + column2.name(), col1Size);
+        DoubleColumn result = DoubleColumn.create(name() + " * " + column2.name(), col1Size);
         for (int r = 0; r < col1Size; r++) {
             result.append(multiply(getDouble(r), column2.getDouble(r)));
         }
         return result;
     }
 
-    default NumberColumn divide(NumberColumn column2) {
+    default DoubleColumn divide(DoubleColumn column2) {
         int col1Size = size();
         int col2Size = column2.size();
         if (col1Size != col2Size)
             throw new IllegalArgumentException("The columns must have the same number of elements");
 
-        NumberColumn result = NumberColumn.create(name() + " / " + column2.name(), col1Size);
+        DoubleColumn result = DoubleColumn.create(name() + " / " + column2.name(), col1Size);
         for (int r = 0; r < col1Size; r++) {
             result.append(divide(getDouble(r), column2.getDouble(r)));
         }
         return result;
     }
 
-    default NumberColumn add(Number value) {
+    default DoubleColumn add(Number value) {
         double val = value.doubleValue();
-        NumberColumn result = NumberColumn.create(name() + " + " + val);
+        DoubleColumn result = DoubleColumn.create(name() + " + " + val);
         for (int i = 0; i < size(); i++) {
             result.append(add(getDouble(i), val));
         }
@@ -140,27 +140,27 @@ public interface NumberMapFunctions extends NumberIterable {
     }
 
 
-    default NumberColumn subtract(Number value) {
+    default DoubleColumn subtract(Number value) {
         double val = value.doubleValue();
-        NumberColumn result = NumberColumn.create(name() + " - " + val);
+        DoubleColumn result = DoubleColumn.create(name() + " - " + val);
         for (int i = 0; i < size(); i++) {
             result.append(subtract(getDouble(i), val));
         }
         return result;
     }
 
-    default NumberColumn divide(Number value) {
+    default DoubleColumn divide(Number value) {
         double val = value.doubleValue();
-        NumberColumn result = NumberColumn.create(name() + " / " + val);
+        DoubleColumn result = DoubleColumn.create(name() + " / " + val);
         for (int i = 0; i < size(); i++) {
             result.append(divide(getDouble(i), val));
         }
         return result;
     }
 
-    default NumberColumn multiply(Number value) {
+    default DoubleColumn multiply(Number value) {
         double val = value.doubleValue();
-        NumberColumn result = NumberColumn.create(name() + " * " + val);
+        DoubleColumn result = DoubleColumn.create(name() + " * " + val);
         for (int i = 0; i < size(); i++) {
             result.append(multiply(getDouble(i), val));
         }
@@ -168,21 +168,21 @@ public interface NumberMapFunctions extends NumberIterable {
     }
 
     default double add(double val1, double val2) {
-        if (valueIsMissing(val1) || valueIsMissing(val2)) {
+        if (DoubleColumnType.isMissingValue(val1) || DoubleColumnType.isMissingValue(val2)) {
             return DoubleColumnType.missingValueIndicator();
         }
         return val1 + val2;
     }
 
     default double multiply(double val1, double val2) {
-        if (valueIsMissing(val1) || valueIsMissing(val2)) {
+        if (DoubleColumnType.isMissingValue(val1) || DoubleColumnType.isMissingValue(val2)) {
             return DoubleColumnType.missingValueIndicator();
         }
         return val1 * val2;
     }
 
     default double divide(double val1, double val2) {
-        if (valueIsMissing(val1) || valueIsMissing(val2)) {
+        if (DoubleColumnType.isMissingValue(val1) || DoubleColumnType.isMissingValue(val2)) {
             return DoubleColumnType.missingValueIndicator();
         }
         return val1 / val2;
@@ -192,7 +192,7 @@ public interface NumberMapFunctions extends NumberIterable {
      * Returns the result of subtracting val2 from val1, after handling missing values
      */
     default double subtract(double val1, double val2) {
-        if (valueIsMissing(val1) || valueIsMissing(val2)) {
+        if (DoubleColumnType.isMissingValue(val1) || DoubleColumnType.isMissingValue(val2)) {
             return DoubleColumnType.missingValueIndicator();
         }
         return val1 - val2;
@@ -201,8 +201,8 @@ public interface NumberMapFunctions extends NumberIterable {
     /**
      * Returns a NumberColumn with the exponential power of each value in this column
      */
-    default NumberColumn power(double power) {
-        NumberColumn newColumn = NumberColumn.create(name() + "[pow]", size());
+    default DoubleColumn power(double power) {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[pow]", size());
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
             double value = iterator.next();
@@ -214,14 +214,14 @@ public interface NumberMapFunctions extends NumberIterable {
     /**
      * Returns a NumberColumn with the square of each value in this column
      */
-    default NumberColumn square() {
-       NumberColumn newColumn = power(2);
+    default DoubleColumn square() {
+       DoubleColumn newColumn = power(2);
         newColumn.setName(name() + "[sq]");
         return newColumn;
     }
 
-    default NumberColumn sqrt() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[sqrt]", size());
+    default DoubleColumn sqrt() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[sqrt]", size());
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
             double value = iterator.next();
@@ -230,8 +230,8 @@ public interface NumberMapFunctions extends NumberIterable {
         return newColumn;
     }
 
-    default NumberColumn cubeRoot() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[cbrt]", size());
+    default DoubleColumn cubeRoot() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[cbrt]", size());
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
             double value = iterator.next();
@@ -240,19 +240,19 @@ public interface NumberMapFunctions extends NumberIterable {
         return newColumn;
     }
 
-    default NumberColumn cube() {
-        NumberColumn newColumn = power(3);
+    default DoubleColumn cube() {
+        DoubleColumn newColumn = power(3);
         newColumn.setName(name() + "[cb]");
         return newColumn;
     }
 
 
-    default NumberColumn remainder(NumberColumn column2) {
-        NumberColumn result = NumberColumn.create(name() + " % " + column2.name(), size());
+    default DoubleColumn remainder(DoubleColumn column2) {
+        DoubleColumn result = DoubleColumn.create(name() + " % " + column2.name(), size());
         for (int r = 0; r < size(); r++) {
             double val1 = getDouble(r);
             double val2 = column2.getDouble(r);
-            if (valueIsMissing(val1) || valueIsMissing(val2)) {
+            if (DoubleColumnType.isMissingValue(val1) || DoubleColumnType.isMissingValue(val2)) {
                 result.append(DoubleColumnType.missingValueIndicator());
             } else {
                 result.append(getDouble(r) % column2.getDouble(r));
@@ -264,8 +264,8 @@ public interface NumberMapFunctions extends NumberIterable {
     /**
      * Returns the natural log of the values in this column as a NumberColumn.
      */
-    default NumberColumn logN() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[logN]", size());
+    default DoubleColumn logN() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[logN]", size());
 
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
@@ -278,8 +278,8 @@ public interface NumberMapFunctions extends NumberIterable {
     /**
      * Returns the base 10 log of the values in this column as a NumberColumn.
      */
-    default NumberColumn log10() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[log10]", size());
+    default DoubleColumn log10() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[log10]", size());
 
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
@@ -293,8 +293,8 @@ public interface NumberMapFunctions extends NumberIterable {
      * Returns the natural log of the values in this column, after adding 1 to each so that zero
      * values don't return -Infinity
      */
-    default NumberColumn log1p() {
-      NumberColumn newColumn = NumberColumn.create(name() + "[1og1p]", size());
+    default DoubleColumn log1p() {
+      DoubleColumn newColumn = DoubleColumn.create(name() + "[1og1p]", size());
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
             double value = iterator.next();
@@ -303,8 +303,8 @@ public interface NumberMapFunctions extends NumberIterable {
         return newColumn;
     }
 
-    default NumberColumn round() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[rounded]", size());
+    default DoubleColumn round() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[rounded]", size());
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
             double value = iterator.next();
@@ -318,8 +318,8 @@ public interface NumberMapFunctions extends NumberIterable {
      *
      * @throws ClassCastException if the returned value will not fit in an int
      */
-    default NumberColumn roundInt() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[rounded]", size());
+    default DoubleColumn roundInt() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[rounded]", size());
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
             double value = iterator.next();
@@ -332,8 +332,8 @@ public interface NumberMapFunctions extends NumberIterable {
     /**
      * Returns a NumberColumn with the absolute value of each value in this column
      */
-    default NumberColumn abs() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[abs]", size());
+    default DoubleColumn abs() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[abs]", size());
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
             double value = iterator.next();
@@ -349,8 +349,8 @@ public interface NumberMapFunctions extends NumberIterable {
      * 2.135 returns -2.135
      * 0     returns  0
      */
-    default NumberColumn neg() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[neg]", size());
+    default DoubleColumn neg() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[neg]", size());
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
             double value = iterator.next();
@@ -359,8 +359,8 @@ public interface NumberMapFunctions extends NumberIterable {
         return newColumn;
     }
 
-    default NumberColumn difference() {
-        NumberColumn returnValue = NumberColumn.create(this.name(), this.size());
+    default DoubleColumn difference() {
+        DoubleColumn returnValue = DoubleColumn.create(this.name(), this.size());
         if (isEmpty()) {
             return returnValue;
         }
@@ -374,13 +374,13 @@ public interface NumberMapFunctions extends NumberIterable {
     /**
      * Returns a new column with a cumulative sum calculated
      */
-    default NumberColumn cumSum() {
+    default DoubleColumn cumSum() {
         double total = 0.0;
-        NumberColumn newColumn = NumberColumn.create(name() + "[cumSum]", size());
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[cumSum]", size());
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
             double value = iterator.next();
-            if (valueIsMissing(value)) {
+            if (DoubleColumnType.isMissingValue(value)) {
                 newColumn.append(DoubleColumnType.missingValueIndicator());
             } else {
                 total += value;
@@ -393,13 +393,13 @@ public interface NumberMapFunctions extends NumberIterable {
     /**
      * Returns a new column with a cumulative product calculated
      */
-    default NumberColumn cumProd() {
+    default DoubleColumn cumProd() {
         double total = 1.0;
-        NumberColumn newColumn = NumberColumn.create(name() + "[cumProd]", size());
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[cumProd]", size());
         NumberIterator iterator = numberIterator();
         while (iterator.hasNext()) {
             double value = iterator.next();
-            if (valueIsMissing(value)) {
+            if (DoubleColumnType.isMissingValue(value)) {
                 newColumn.append(DoubleColumnType.missingValueIndicator());
             } else {
                 total *= value;
@@ -412,8 +412,8 @@ public interface NumberMapFunctions extends NumberIterable {
     /**
      * Returns a new column with a percent change calculated
      */
-    default NumberColumn pctChange() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[pctChange]", size());
+    default DoubleColumn pctChange() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[pctChange]", size());
         newColumn.append(DoubleColumnType.missingValueIndicator());
         for (int i = 1; i < size(); i++) {
             newColumn.append(getDouble(i) / getDouble(i - 1) - 1);
@@ -421,7 +421,7 @@ public interface NumberMapFunctions extends NumberIterable {
         return newColumn;
     }
 
-    default NumberColumn bin(int binCount) {
+    default DoubleColumn bin(int binCount) {
         double[] histogram = new double[binCount];
         EmpiricalDistribution distribution = new EmpiricalDistribution(binCount);
         distribution.load(asDoubleArray());
@@ -429,10 +429,8 @@ public interface NumberMapFunctions extends NumberIterable {
         for(SummaryStatistics stats: distribution.getBinStats()) {
             histogram[k++] = stats.getN();
         }
-        return NumberColumn.create(name() + "[binned]", histogram);
+        return DoubleColumn.create(name() + "[binned]", histogram);
     }
 
     double getDouble(int i);
-
-    boolean valueIsMissing(double value);
 }

--- a/core/src/main/java/tech/tablesaw/columns/numbers/NumberRollingColumn.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/NumberRollingColumn.java
@@ -2,6 +2,7 @@ package tech.tablesaw.columns.numbers;
 
 import tech.tablesaw.aggregate.AggregateFunctions;
 import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.table.RollingColumn;
 
 /**
@@ -9,7 +10,7 @@ import tech.tablesaw.table.RollingColumn;
  */
 public class NumberRollingColumn extends RollingColumn {
 
-    public NumberRollingColumn(NumberColumn column, int window) {
+    public NumberRollingColumn(NumericColumn<?> column, int window) {
         super(column, window);
     }
 

--- a/core/src/main/java/tech/tablesaw/columns/numbers/NumberRollingColumn.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/NumberRollingColumn.java
@@ -1,7 +1,7 @@
 package tech.tablesaw.columns.numbers;
 
 import tech.tablesaw.aggregate.AggregateFunctions;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.table.RollingColumn;
 
@@ -14,24 +14,24 @@ public class NumberRollingColumn extends RollingColumn {
         super(column, window);
     }
 
-    public NumberColumn mean() {
-        return (NumberColumn) calc(AggregateFunctions.mean);
+    public DoubleColumn mean() {
+        return (DoubleColumn) calc(AggregateFunctions.mean);
     }
 
-    public NumberColumn median() {
-        return (NumberColumn) calc(AggregateFunctions.median);
+    public DoubleColumn median() {
+        return (DoubleColumn) calc(AggregateFunctions.median);
     }
 
-    public NumberColumn geometricMean() {
-        return (NumberColumn) calc(AggregateFunctions.geometricMean);
+    public DoubleColumn geometricMean() {
+        return (DoubleColumn) calc(AggregateFunctions.geometricMean);
     }
 
-    public NumberColumn sum() {
-        return (NumberColumn) calc(AggregateFunctions.sum);
+    public DoubleColumn sum() {
+        return (DoubleColumn) calc(AggregateFunctions.sum);
     }
 
-    public NumberColumn pctChange() {
-        return (NumberColumn) calc(AggregateFunctions.pctChange);
+    public DoubleColumn pctChange() {
+        return (DoubleColumn) calc(AggregateFunctions.pctChange);
     }
 
 }

--- a/core/src/main/java/tech/tablesaw/columns/numbers/NumericDataWrapper.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/NumericDataWrapper.java
@@ -1,9 +1,9 @@
 package tech.tablesaw.columns.numbers;
 
+import java.util.Iterator;
+
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.columns.StringParser;
-
-import java.util.Iterator;
 
 public interface NumericDataWrapper extends NumberIterable {
 
@@ -52,7 +52,7 @@ public interface NumericDataWrapper extends NumberIterable {
 
     NumberIterator numberIterator();
 
-    Iterator<Double> iterator();
+    Iterator<?> iterator();
 
     NumericDataWrapper top(final int n);
 

--- a/core/src/main/java/tech/tablesaw/columns/numbers/Stats.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/Stats.java
@@ -15,7 +15,9 @@
 package tech.tablesaw.columns.numbers;
 
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+
 import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 
@@ -43,15 +45,15 @@ public class Stats {
         this.name = name;
     }
 
-    public static Stats create(final NumberColumn values) {
+    public static Stats create(final NumericColumn<?> values) {
         SummaryStatistics summaryStatistics = new SummaryStatistics();
-        for (double f : values) {
+        for (double f : values.numberIterator()) {
             summaryStatistics.addValue(f);
         }
         return getStats(values, summaryStatistics);
     }
 
-    private static Stats getStats(NumberColumn values, SummaryStatistics summaryStatistics) {
+    private static Stats getStats(NumericColumn<?> values, SummaryStatistics summaryStatistics) {
         Stats stats = new Stats("Column: " + values.name());
         stats.min = summaryStatistics.getMin();
         stats.max = summaryStatistics.getMax();

--- a/core/src/main/java/tech/tablesaw/columns/numbers/Stats.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/Stats.java
@@ -16,7 +16,7 @@ package tech.tablesaw.columns.numbers;
 
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
@@ -47,8 +47,9 @@ public class Stats {
 
     public static Stats create(final NumericColumn<?> values) {
         SummaryStatistics summaryStatistics = new SummaryStatistics();
-        for (double f : values.numberIterator()) {
-            summaryStatistics.addValue(f);
+        NumberIterator itr = values.numberIterator();
+        while (itr.hasNext()) {
+            summaryStatistics.addValue(itr.next());
         }
         return getStats(values, summaryStatistics);
     }
@@ -130,7 +131,7 @@ public class Stats {
     public Table asTable() {
         Table t = Table.create(name);
         StringColumn measure = StringColumn.create("Measure");
-        NumberColumn value = NumberColumn.create("Value");
+        DoubleColumn value = DoubleColumn.create("Value");
         t.addColumns(measure);
         t.addColumns(value);
 
@@ -165,7 +166,7 @@ public class Stats {
         Table t = asTable();
 
         StringColumn measure = t.stringColumn("Measure");
-        NumberColumn value = t.numberColumn("Value");
+        DoubleColumn value = t.doubleColumn("Value");
 
         measure.append("Sum of Squares");
         value.append(sumOfSquares());

--- a/core/src/main/java/tech/tablesaw/columns/numbers/fillers/DoubleRangeIterable.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/fillers/DoubleRangeIterable.java
@@ -41,7 +41,6 @@ public class DoubleRangeIterable implements NumberIterable {
         return range(from, 1.0, count);
     }
 
-    @Override
     public DoubleIterator iterator() {
 
         return new DoubleIterator() {

--- a/core/src/main/java/tech/tablesaw/columns/strings/StringMapFunctions.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/StringMapFunctions.java
@@ -17,7 +17,7 @@ package tech.tablesaw.columns.strings;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.util.LevenshteinDistance;
@@ -144,9 +144,9 @@ public interface StringMapFunctions extends Column<String> {
         return newColumn;
     }
 
-    default NumberColumn parseInt() {
+    default DoubleColumn parseInt() {
 
-        NumberColumn newColumn = NumberColumn.create(name() + "[parsed]");
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[parsed]");
         for (int r = 0; r < size(); r++) {
             newColumn.append(Integer.parseInt(getString(r)));
         }
@@ -204,9 +204,9 @@ public interface StringMapFunctions extends Column<String> {
      * Returns a column containing the levenshtein distance between the two given string columns
      */
 
-    default NumberColumn distance(Column<?> column2) {
+    default DoubleColumn distance(Column<?> column2) {
 
-        NumberColumn newColumn = NumberColumn.create(name() + column2.name() + "[distance]");
+        DoubleColumn newColumn = DoubleColumn.create(name() + column2.name() + "[distance]");
 
         for (int r = 0; r < size(); r++) {
             String value1 = getString(r);
@@ -288,8 +288,8 @@ public interface StringMapFunctions extends Column<String> {
         return newColumn;
     }
 
-    default NumberColumn countTokens(String separator) {
-        NumberColumn newColumn = NumberColumn.create(name() + "[token count]", this.size());
+    default DoubleColumn countTokens(String separator) {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[token count]", this.size());
 
         for (int r = 0; r < size(); r++) {
             String value = getString(r);
@@ -348,8 +348,8 @@ public interface StringMapFunctions extends Column<String> {
      * Returns a column containing the character length of each string in this column
      * The returned column is the same size as the original
      */
-    default NumberColumn length() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[length]", this.size());
+    default DoubleColumn length() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[length]", this.size());
 
         for (int r = 0; r < size(); r++) {
             newColumn.append(getString(r).length());

--- a/core/src/main/java/tech/tablesaw/columns/times/TimeMapFunctions.java
+++ b/core/src/main/java/tech/tablesaw/columns/times/TimeMapFunctions.java
@@ -15,7 +15,7 @@
 package tech.tablesaw.columns.times;
 
 import com.google.common.base.Strings;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.TimeColumn;
 import tech.tablesaw.columns.Column;
@@ -31,19 +31,19 @@ import static tech.tablesaw.api.TimeColumn.MISSING_VALUE;
 
 public interface TimeMapFunctions extends Column<LocalTime> {
 
-    default NumberColumn differenceInMilliseconds(TimeColumn column2) {
+    default DoubleColumn differenceInMilliseconds(TimeColumn column2) {
         return difference(column2, MILLIS);
     }
 
-    default NumberColumn differenceInSeconds(TimeColumn column2) {
+    default DoubleColumn differenceInSeconds(TimeColumn column2) {
         return difference(column2, SECONDS);
     }
 
-    default NumberColumn differenceInMinutes(TimeColumn column2) {
+    default DoubleColumn differenceInMinutes(TimeColumn column2) {
         return difference(column2, MINUTES);
     }
 
-    default NumberColumn differenceInHours(TimeColumn column2) {
+    default DoubleColumn differenceInHours(TimeColumn column2) {
         return difference(column2, HOURS);
     }
 
@@ -56,8 +56,8 @@ public interface TimeMapFunctions extends Column<LocalTime> {
 
     TimeColumn lag(int n);
 
-    default NumberColumn difference(TimeColumn column2, ChronoUnit unit) {
-        NumberColumn newColumn = NumberColumn.create(name() + " - " + column2.name());
+    default DoubleColumn difference(TimeColumn column2, ChronoUnit unit) {
+        DoubleColumn newColumn = DoubleColumn.create(name() + " - " + column2.name());
 
         for (int r = 0; r < size(); r++) {
             int c1 = this.getIntInternal(r);
@@ -241,8 +241,8 @@ public interface TimeMapFunctions extends Column<LocalTime> {
         return newColumn;
     }
 
-    default NumberColumn hour() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[" + "hour" + "]");
+    default DoubleColumn hour() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[" + "hour" + "]");
         for (int r = 0; r < size(); r++) {
             int c1 = getIntInternal(r);
             if (!TimeColumn.valueIsMissing(c1)) {
@@ -254,8 +254,8 @@ public interface TimeMapFunctions extends Column<LocalTime> {
         return newColumn;
     }
 
-    default NumberColumn minute() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[" + "minute" + "]");
+    default DoubleColumn minute() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[" + "minute" + "]");
         for (int r = 0; r < size(); r++) {
             int c1 = getIntInternal(r);
             if (!TimeColumn.valueIsMissing(c1)) {
@@ -267,8 +267,8 @@ public interface TimeMapFunctions extends Column<LocalTime> {
         return newColumn;
     }
 
-    default NumberColumn second() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[" + "second" + "]");
+    default DoubleColumn second() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[" + "second" + "]");
         for (int r = 0; r < size(); r++) {
             int c1 = getIntInternal(r);
             if (!TimeColumn.valueIsMissing(c1)) {
@@ -280,8 +280,8 @@ public interface TimeMapFunctions extends Column<LocalTime> {
         return newColumn;
     }
 
-    default NumberColumn milliseconds() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[" + "ms" + "]");
+    default DoubleColumn milliseconds() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[" + "ms" + "]");
         for (int r = 0; r < size(); r++) {
             int c1 = getIntInternal(r);
             if (!TimeColumn.valueIsMissing(c1)) {
@@ -293,8 +293,8 @@ public interface TimeMapFunctions extends Column<LocalTime> {
         return newColumn;
     }
 
-    default NumberColumn minuteOfDay() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[" + "minute-of-day" + "]");
+    default DoubleColumn minuteOfDay() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[" + "minute-of-day" + "]");
         for (int r = 0; r < size(); r++) {
             int c1 = getIntInternal(r);
             if (!TimeColumn.valueIsMissing(c1)) {
@@ -306,8 +306,8 @@ public interface TimeMapFunctions extends Column<LocalTime> {
         return newColumn;
     }
 
-    default NumberColumn secondOfDay() {
-        NumberColumn newColumn = NumberColumn.create(name() + "[" + "second-of-day" + "]");
+    default DoubleColumn secondOfDay() {
+        DoubleColumn newColumn = DoubleColumn.create(name() + "[" + "second-of-day" + "]");
         for (int r = 0; r < size(); r++) {
             int c1 = getIntInternal(r);
             if (!TimeColumn.valueIsMissing(c1)) {
@@ -329,11 +329,11 @@ public interface TimeMapFunctions extends Column<LocalTime> {
      * @param n     The number of units in each group.
      * @param start The starting point of the first group; group boundaries are offsets from this point
      */
-    default NumberColumn timeWindow(ChronoUnit unit, int n, LocalTime start) {
+    default DoubleColumn timeWindow(ChronoUnit unit, int n, LocalTime start) {
         String newColumnName = "" +  n + " " + unit.toString() + " window [" + name() + "]";
 
         int packedStartTime = PackedLocalTime.pack(start);
-        NumberColumn numberColumn = NumberColumn.create(newColumnName, size());
+        DoubleColumn numberColumn = DoubleColumn.create(newColumnName, size());
         for (int i = 0; i < size(); i++) {
             int packedTime = getIntInternal(i);
             int result;
@@ -378,7 +378,7 @@ public interface TimeMapFunctions extends Column<LocalTime> {
         return newColumn;
     }
 
-    default NumberColumn timeWindow(ChronoUnit unit, int n) {
+    default DoubleColumn timeWindow(ChronoUnit unit, int n) {
         return timeWindow(unit, n, min());
     }
 

--- a/core/src/main/java/tech/tablesaw/index/DoubleIndex.java
+++ b/core/src/main/java/tech/tablesaw/index/DoubleIndex.java
@@ -18,7 +18,7 @@ import it.unimi.dsi.fastutil.doubles.Double2ObjectAVLTreeMap;
 import it.unimi.dsi.fastutil.doubles.Double2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.doubles.Double2ObjectSortedMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.selection.BitmapBackedSelection;
 import tech.tablesaw.selection.Selection;
 
@@ -29,7 +29,7 @@ public class DoubleIndex {
 
     private final Double2ObjectAVLTreeMap<IntArrayList> index;
 
-    public DoubleIndex(NumberColumn column) {
+    public DoubleIndex(DoubleColumn column) {
         int sizeEstimate = Integer.min(1_000_000, column.size() / 100);
         Double2ObjectOpenHashMap<IntArrayList> tempMap = new Double2ObjectOpenHashMap<>(sizeEstimate);
         for (int i = 0; i < column.size(); i++) {

--- a/core/src/main/java/tech/tablesaw/index/FloatIndex.java
+++ b/core/src/main/java/tech/tablesaw/index/FloatIndex.java
@@ -18,7 +18,7 @@ import it.unimi.dsi.fastutil.floats.Float2ObjectAVLTreeMap;
 import it.unimi.dsi.fastutil.floats.Float2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.floats.Float2ObjectSortedMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.selection.BitmapBackedSelection;
 import tech.tablesaw.selection.Selection;
 
@@ -29,7 +29,7 @@ public class FloatIndex {
 
     private final Float2ObjectAVLTreeMap<IntArrayList> index;
 
-    public FloatIndex(NumberColumn column) {
+    public FloatIndex(DoubleColumn column) {
         int sizeEstimate = Integer.min(1_000_000, column.size() / 100);
         Float2ObjectOpenHashMap<IntArrayList> tempMap = new Float2ObjectOpenHashMap<>(sizeEstimate);
         for (int i = 0; i < column.size(); i++) {

--- a/core/src/main/java/tech/tablesaw/index/IntIndex.java
+++ b/core/src/main/java/tech/tablesaw/index/IntIndex.java
@@ -14,22 +14,23 @@
 
 package tech.tablesaw.index;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 import com.google.common.base.Preconditions;
+
 import it.unimi.dsi.fastutil.ints.Int2ObjectAVLTreeMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectSortedMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.DateColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.IntColumn;
 import tech.tablesaw.api.TimeColumn;
 import tech.tablesaw.columns.dates.PackedLocalDate;
 import tech.tablesaw.columns.times.PackedLocalTime;
 import tech.tablesaw.selection.BitmapBackedSelection;
 import tech.tablesaw.selection.Selection;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
 
 
 /**
@@ -57,7 +58,7 @@ public class IntIndex {
         index = new Int2ObjectAVLTreeMap<>(tempMap);
     }
 
-    public IntIndex(NumberColumn column) {
+    public IntIndex(IntColumn column) {
         Preconditions.checkArgument(column.type().equals(ColumnType.INTEGER),
                 "Int indexing only allowed on INTEGER numeric columns");
         int sizeEstimate = Integer.min(1_000_000, column.size() / 100);

--- a/core/src/main/java/tech/tablesaw/index/LongIndex.java
+++ b/core/src/main/java/tech/tablesaw/index/LongIndex.java
@@ -19,7 +19,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectAVLTreeMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectSortedMap;
 import tech.tablesaw.api.DateTimeColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.columns.datetimes.PackedLocalDateTime;
 import tech.tablesaw.selection.BitmapBackedSelection;
 import tech.tablesaw.selection.Selection;
@@ -51,7 +51,7 @@ public class LongIndex {
         index = new Long2ObjectAVLTreeMap<>(tempMap);
     }
 
-    public LongIndex(NumberColumn column) {
+    public LongIndex(DoubleColumn column) {
         int sizeEstimate = Integer.min(1_000_000, column.size() / 100);
         Long2ObjectOpenHashMap<IntArrayList> tempMap = new Long2ObjectOpenHashMap<>(sizeEstimate);
         for (int i = 0; i < column.size(); i++) {

--- a/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
+++ b/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
@@ -1,11 +1,15 @@
 package tech.tablesaw.joining;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import com.google.common.collect.Streams;
+
 import tech.tablesaw.api.CategoricalColumn;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DateTimeColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.IntColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.api.TimeColumn;
@@ -20,8 +24,6 @@ import tech.tablesaw.index.LongIndex;
 import tech.tablesaw.index.StringIndex;
 import tech.tablesaw.selection.BitmapBackedSelection;
 import tech.tablesaw.selection.Selection;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class DataFrameJoiner {
 
@@ -149,8 +151,8 @@ public class DataFrameJoiner {
                 }
             }
         } else if (type instanceof IntColumnType) {
-            IntIndex index = new IntIndex(table2.numberColumn(col2Name));
-            NumberColumn col1 = (NumberColumn) column;
+            IntIndex index = new IntIndex(table2.intColumn(col2Name));
+            IntColumn col1 = (IntColumn) column;
             for (int i = 0; i < col1.size(); i++) {
                 int value = col1.getInt(i);
                 Table table1Rows = table.where(Selection.with(i));
@@ -273,11 +275,10 @@ public class DataFrameJoiner {
                 }
             }
         } else if (type instanceof IntColumnType) {
-
-            LongIndex index = new LongIndex(result.numberColumn(col2Name));
-            NumberColumn col2 = (NumberColumn) table2.column(col2Name);
+            IntIndex index = new IntIndex(result.intColumn(col2Name));
+            DoubleColumn col2 = (DoubleColumn) table2.column(col2Name);
             for (int i = 0; i < col2.size(); i++) {
-                long value = col2.getLong(i);
+                int value = col2.getInt(i);
                 if (index.get(value).isEmpty()) {
                     selection.add(i);
                 }

--- a/core/src/main/java/tech/tablesaw/table/Relation.java
+++ b/core/src/main/java/tech/tablesaw/table/Relation.java
@@ -14,12 +14,20 @@
 
 package tech.tablesaw.table;
 
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import it.unimi.dsi.fastutil.ints.IntArrays;
 import tech.tablesaw.api.BooleanColumn;
 import tech.tablesaw.api.CategoricalColumn;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DateTimeColumn;
+import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.FloatColumn;
+import tech.tablesaw.api.IntColumn;
 import tech.tablesaw.api.NumberColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
@@ -28,11 +36,6 @@ import tech.tablesaw.columns.Column;
 import tech.tablesaw.conversion.TableConverter;
 import tech.tablesaw.io.string.DataFramePrinter;
 import tech.tablesaw.sorting.comparators.DescendingIntComparator;
-
-import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * A tabular data structure like a table in a relational database, but not formally implementing the relational algebra
@@ -230,18 +233,18 @@ public abstract class Relation {
                 .append(" variables (cols)");
 
         Table structure = Table.create(nameBuilder.toString());
-        structure.addColumns(NumberColumn.create("Index"));
+        structure.addColumns(DoubleColumn.create("Index"));
         structure.addColumns(StringColumn.create("Column Name"));
         structure.addColumns(StringColumn.create("Type"));
-        structure.addColumns(NumberColumn.create("Unique Values"));
+        structure.addColumns(DoubleColumn.create("Unique Values"));
         structure.addColumns(StringColumn.create("First"));
         structure.addColumns(StringColumn.create("Last"));
 
         for (Column<?> column : columns()) {
-            structure.numberColumn("Index").append(columnIndex(column));
+            structure.intColumn("Index").append(columnIndex(column));
             structure.stringColumn("Column Name").append(column.name());
             structure.stringColumn("Type").append(column.type().name());
-            structure.numberColumn("Unique Values").append(column.countUnique());
+            structure.intColumn("Unique Values").append(column.countUnique());
             structure.stringColumn("First").append(column.getString(0));
             structure.stringColumn("Last").append(column.getString(column.size() - 1));
         }
@@ -278,7 +281,7 @@ public abstract class Relation {
      * @return A number column
      * @throws ClassCastException if the cast to NumberColumn fails
      */
-    public NumberColumn numberColumn(int columnIndex) {
+    public NumberColumn<?> numberColumn(int columnIndex) {
         Column<?> c = column(columnIndex);
         if (c.type() == ColumnType.STRING) {
             StringColumn stringColumn = (StringColumn) c;
@@ -287,27 +290,27 @@ public abstract class Relation {
             BooleanColumn booleanColumn = (BooleanColumn) c;
             return booleanColumn.asNumberColumn();
         }
-        return (NumberColumn) column(columnIndex);
+        return (NumberColumn<?>) column(columnIndex);
     }
 
-    public NumberColumn numberColumn(String columnName) {
+    public NumberColumn<?> numberColumn(String columnName) {
         return numberColumn(columnIndex(columnName));
     }
 
-    public NumberColumn doubleColumn(String columnName) {
+    public DoubleColumn doubleColumn(String columnName) {
         return doubleColumn(columnIndex(columnName));
     }
 
-    public NumberColumn doubleColumn(int columnIndex) {
-        return (NumberColumn) column(columnIndex);
+    public DoubleColumn doubleColumn(int columnIndex) {
+        return (DoubleColumn) column(columnIndex);
     }
 
     public StringColumn[] stringColumns() {
         return columns().stream().filter(e->e.type() == ColumnType.STRING).toArray(StringColumn[]::new);
     }
 
-    public NumberColumn[] numberColumns() {
-        return columns().stream().filter(e->e instanceof NumberColumn).toArray(NumberColumn[]::new);
+    public DoubleColumn[] numberColumns() {
+        return columns().stream().filter(e->e instanceof DoubleColumn).toArray(DoubleColumn[]::new);
     }
 
     public BooleanColumn[] booleanColumns() {
@@ -339,7 +342,7 @@ public abstract class Relation {
      * <p>
      * Shorthand for numberColumn()
      */
-    public NumberColumn nCol(String columnName) {
+    public NumberColumn<?> nCol(String columnName) {
         return numberColumn(columnName);
     }
 
@@ -348,8 +351,24 @@ public abstract class Relation {
      * <p>
      * Shorthand for numberColumn()
      */
-    public NumberColumn nCol(int columnIndex) {
+    public NumberColumn<?> nCol(int columnIndex) {
         return numberColumn(columnIndex);
+    }
+
+    public IntColumn intColumn(String columnName) {
+        return intColumn(columnIndex(columnName));
+    }
+
+    public IntColumn intColumn(int columnIndex) {
+        return (IntColumn) column(columnIndex);
+    }
+    
+    public FloatColumn floatColumn(String columnName) {
+        return floatColumn(columnIndex(columnName));
+    }
+
+    public FloatColumn floatColumn(int columnIndex) {
+        return (FloatColumn) column(columnIndex);
     }
 
     public DateColumn dateColumn(int columnIndex) {

--- a/core/src/main/java/tech/tablesaw/table/RollingColumn.java
+++ b/core/src/main/java/tech/tablesaw/table/RollingColumn.java
@@ -1,7 +1,7 @@
 package tech.tablesaw.table;
 
 import tech.tablesaw.aggregate.AggregateFunction;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.selection.BitmapBackedSelection;
 import tech.tablesaw.selection.Selection;
@@ -43,7 +43,7 @@ public class RollingColumn {
             OUT answer = function.summarize(subsetCol);
             if (answer instanceof Number) {
                 Number number = (Number) answer;
-                ((NumberColumn) result).append(number.doubleValue());
+                ((DoubleColumn) result).append(number.doubleValue());
             } else {
                 result.appendObj(answer);
             }

--- a/core/src/main/java/tech/tablesaw/table/TableSlice.java
+++ b/core/src/main/java/tech/tablesaw/table/TableSlice.java
@@ -14,6 +14,9 @@
 
 package tech.tablesaw.table;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import it.unimi.dsi.fastutil.ints.IntIterable;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import tech.tablesaw.aggregate.NumericAggregateFunction;
@@ -22,9 +25,6 @@ import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.selection.BitmapBackedSelection;
 import tech.tablesaw.selection.Selection;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A TableSlice is a facade around a Relation that acts as a filter.
@@ -161,7 +161,7 @@ public class TableSlice extends Relation implements IntIterable {
      * @throws IllegalArgumentException if numberColumnName doesn't name a numeric column in this table
      */
     public double reduce(String numberColumnName, NumericAggregateFunction function) {
-        NumberColumn column = table.numberColumn(numberColumnName);
+        NumberColumn<?> column = table.numberColumn(numberColumnName);
         return function.summarize(column.where(selection));
     }
 

--- a/core/src/main/java/tech/tablesaw/util/DoubleArrays.java
+++ b/core/src/main/java/tech/tablesaw/util/DoubleArrays.java
@@ -14,13 +14,14 @@
 
 package tech.tablesaw.util;
 
+import java.util.List;
+
 import com.google.common.base.Preconditions;
+
 import tech.tablesaw.api.NumberColumn;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.table.TableSlice;
 import tech.tablesaw.table.TableSliceGroup;
-
-import java.util.List;
 
 /**
  * Utility functions for creating 2D double arrays from columns and other arrays
@@ -56,14 +57,13 @@ public class DoubleArrays {
     }
 
     public static double[][] to2dArray(TableSliceGroup views, int columnNumber) {
-
         int viewCount = views.size();
 
         double[][] allVals = new double[viewCount][];
         for (int viewNumber = 0; viewNumber < viewCount; viewNumber++) {
             TableSlice view = views.get(viewNumber);
             allVals[viewNumber] = new double[view.rowCount()];
-            NumberColumn numberColumn = view.numberColumn(columnNumber);
+            NumberColumn<?> numberColumn = view.numberColumn(columnNumber);
             for (int r = 0; r < view.rowCount(); r++) {
                 allVals[viewNumber][r] = numberColumn.getDouble(r);
             }

--- a/core/src/test/java/tech/tablesaw/TableFilteringTest.java
+++ b/core/src/test/java/tech/tablesaw/TableFilteringTest.java
@@ -14,19 +14,23 @@
 
 package tech.tablesaw;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.LocalDate;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import tech.tablesaw.api.DateColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.IntColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.columns.dates.PackedLocalDate;
 import tech.tablesaw.io.csv.CsvReadOptions;
-
-import java.time.LocalDate;
-
-import static org.junit.Assert.*;
 
 /**
  * Tests for filtering on the T class
@@ -43,7 +47,7 @@ public class TableFilteringTest {
     @Test
     public void testFilter1() {
         Table result = table.where(table.numberColumn("approval").isLessThan(70));
-        NumberColumn a = result.numberColumn("approval");
+        IntColumn a = result.intColumn("approval");
         for (double v : a) {
             assertTrue(v < 70);
         }
@@ -52,7 +56,7 @@ public class TableFilteringTest {
     @Test
     public void testReject() {
         Table result = table.dropWhere(table.numberColumn("approval").isLessThan(70));
-        NumberColumn a = result.numberColumn("approval");
+        IntColumn a = result.intColumn("approval");
         for (double v : a) {
             assertFalse(v < 70);
         }
@@ -64,7 +68,7 @@ public class TableFilteringTest {
         String[] values = {"a", "b", "", "d"};
         double[] values2 = {1, Double.NaN, 3, 4};
         StringColumn sc = StringColumn.create("s", values);
-        NumberColumn nc = NumberColumn.create("n", values2);
+        DoubleColumn nc = DoubleColumn.create("n", values2);
         Table test = Table.create("test", sc, nc);
         Table result = test.dropRowsWithMissingValues();
         assertEquals(2, result.rowCount());
@@ -142,7 +146,7 @@ public class TableFilteringTest {
                         table.numberColumn("approval").isGreaterThan(70)));
 
         DateColumn dates = result.dateColumn("date");
-        NumberColumn approval = result.numberColumn("approval");
+        IntColumn approval = result.intColumn("approval");
         for (int row = 0; row < result.rowCount(); row++) {
             assertTrue(PackedLocalDate.isInApril(dates.getIntInternal(row)));
             assertTrue(approval.get(row) > 70);

--- a/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
+++ b/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import tech.tablesaw.api.BooleanColumn;
 import tech.tablesaw.api.DateColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.csv.CsvReadOptions;
@@ -108,7 +108,7 @@ public class AggregateFunctionsTest {
     public void testSummaryWithACalculatedColumn() {
         Summarizer summarizer = new Summarizer(table, table.dateColumn("date").year(), mean);
         Table t = summarizer.apply();
-        double avg = t.numberColumn(0).get(0);
+        double avg = t.doubleColumn(0).get(0);
         assertTrue(avg > 2002 && avg < 2003);
     }
 
@@ -142,7 +142,7 @@ public class AggregateFunctionsTest {
         BooleanColumn booleanColumn = BooleanColumn.create("b", args);
 
         double[] numbers = {1, 2, 3, 4};
-        NumberColumn numberColumn = NumberColumn.create("n", numbers);
+        DoubleColumn numberColumn = DoubleColumn.create("n", numbers);
 
         String[] strings = {"M", "F", "M", "F"};
         StringColumn stringColumn = StringColumn.create("s", strings);
@@ -158,14 +158,14 @@ public class AggregateFunctionsTest {
         BooleanColumn booleanColumn = BooleanColumn.create("b", args);
 
         double[] numbers = {1, 2, 3, 4};
-        NumberColumn numberColumn = NumberColumn.create("n", numbers);
+        DoubleColumn numberColumn = DoubleColumn.create("n", numbers);
 
         String[] strings = {"M", "F", "M", "F"};
         StringColumn stringColumn = StringColumn.create("s", strings);
 
         Table table = Table.create("test", booleanColumn, numberColumn, stringColumn);
         Table summarized = table.summarize(booleanColumn, numberColumn, countTrue, standardDeviation).apply();
-        assertEquals(1.2909944487358056, summarized.numberColumn(1).get(0), 0.00001);
+        assertEquals(1.2909944487358056, summarized.doubleColumn(1).get(0), 0.00001);
     }
 
     @Test
@@ -187,7 +187,7 @@ public class AggregateFunctionsTest {
     @Test
     public void testPercentileFunctions() {
         double[] values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-        NumberColumn c = NumberColumn.create("test", values);
+        DoubleColumn c = DoubleColumn.create("test", values);
         c.appendCell("");
 
         assertEquals(1, countMissing.summarize(c), 0.0001);

--- a/core/src/test/java/tech/tablesaw/aggregate/CrossTabTest.java
+++ b/core/src/test/java/tech/tablesaw/aggregate/CrossTabTest.java
@@ -1,13 +1,14 @@
 package tech.tablesaw.aggregate;
 
-import org.junit.Test;
-import tech.tablesaw.api.BooleanColumn;
-import tech.tablesaw.api.NumberColumn;
-import tech.tablesaw.api.Row;
-import tech.tablesaw.api.Table;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tech.tablesaw.api.BooleanColumn;
+import tech.tablesaw.api.IntColumn;
+import tech.tablesaw.api.Row;
+import tech.tablesaw.api.Table;
 
 public class CrossTabTest {
 
@@ -18,8 +19,8 @@ public class CrossTabTest {
         Table pcts = CrossTab.percents(bush, "who");
         double sum = counts.numberColumn("Count").sum();
         for (int row = 0; row < pcts.rowCount(); row++) {
-            assertEquals(counts.numberColumn("Count").get(row) / sum,
-                    pcts.numberColumn(1).get(row),
+            assertEquals(counts.intColumn("Count").get(row) / sum,
+                    pcts.doubleColumn(1).get(row),
                     0.01);
         }
     }
@@ -31,8 +32,8 @@ public class CrossTabTest {
         Table pcts = CrossTab.percents(bush, "date");
         double sum = counts.numberColumn("Count").sum();
         for (int row = 0; row < pcts.rowCount(); row++) {
-            assertEquals(counts.numberColumn("Count").get(row) / sum,
-                    pcts.numberColumn(1).get(row),
+            assertEquals(counts.intColumn("Count").get(row) / sum,
+                    pcts.doubleColumn(1).get(row),
                     0.01);
         }
     }
@@ -40,7 +41,7 @@ public class CrossTabTest {
     @Test
     public void testCounts3() throws Exception {
         Table bush = Table.read().csv("../data/bush.csv");
-        NumberColumn month = bush.dateColumn("date").monthValue();
+        IntColumn month = bush.dateColumn("date").monthValue();
         month.setName("month");
         BooleanColumn seventyPlus =
                 BooleanColumn.create("70",
@@ -52,7 +53,7 @@ public class CrossTabTest {
         Table counts = bush.xTabCounts("month", "seventyPlus" );
         for (Row row : counts) {
             assertEquals(
-                    counts.numberColumn("total").get(row.getRowNumber()),
+                    counts.intColumn("total").get(row.getRowNumber()),
                     row.getInt("true") + row.getInt("false"),
                     0.01);
         }
@@ -64,7 +65,7 @@ public class CrossTabTest {
         Table bush = Table.read().csv("../data/bush.csv");
         bush.addColumns(bush.dateColumn("date").year());
         Table xtab = CrossTab.columnPercents(bush, "who", "date year");
-        assertEquals(1, xtab.numberColumn(1).get(xtab.rowCount()-1), 0.001);
+        assertEquals(1, xtab.doubleColumn(1).getInt(xtab.rowCount() - 1));
     }
 
     @Test
@@ -72,7 +73,7 @@ public class CrossTabTest {
         Table bush = Table.read().csv("../data/bush.csv");
         bush.addColumns(bush.dateColumn("date").year());
         Table xtab = CrossTab.rowPercents(bush, "who", "date year");
-        assertEquals(1, xtab.numberColumn( xtab.columnCount() - 1).get(0), 0.001);
+        assertEquals(1, xtab.doubleColumn(xtab.columnCount() - 1).getInt(0));
     }
 
     @Test
@@ -80,6 +81,6 @@ public class CrossTabTest {
         Table bush = Table.read().csv("../data/bush.csv");
         bush.addColumns(bush.dateColumn("date").year());
         Table xtab = CrossTab.tablePercents(bush, "who", "date year");
-        assertEquals(1, xtab.numberColumn( xtab.columnCount() - 1).get(xtab.rowCount()-1), 0.001);
+        assertEquals(1, xtab.doubleColumn(xtab.columnCount() - 1).getInt(xtab.rowCount()-1));
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/DateColumnMapTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DateColumnMapTest.java
@@ -45,19 +45,19 @@ public class DateColumnMapTest {
         column1.appendInternal(day4);
         column1.appendInternal(day5);
 
-        NumberColumn group = column1.timeWindow(ChronoUnit.DAYS, 7);
+        DoubleColumn group = column1.timeWindow(ChronoUnit.DAYS, 7);
         assertEquals(0, group.get(0), 0.001);
         assertEquals(0, group.get(1), 0.001);
         assertEquals(1, group.get(2), 0.001);
         assertEquals(2, group.get(3), 0.001);
 
-        NumberColumn group2 = column1.timeWindow(ChronoUnit.WEEKS, 1);
+        DoubleColumn group2 = column1.timeWindow(ChronoUnit.WEEKS, 1);
         assertEquals(0, group2.get(0), 0.001);
         assertEquals(0, group2.get(1), 0.001);
         assertEquals(1, group2.get(2), 0.001);
         assertEquals(2, group2.get(3), 0.001);
 
-        NumberColumn group3 = column1.timeWindow(ChronoUnit.MONTHS, 1);
+        DoubleColumn group3 = column1.timeWindow(ChronoUnit.MONTHS, 1);
         assertEquals(0, group3.get(0), 0.001);
         assertEquals(0, group3.get(1), 0.001);
         assertEquals(0, group3.get(2), 0.001);
@@ -80,10 +80,10 @@ public class DateColumnMapTest {
         int day2 = pack(2018, 11, 23);
         DateColumn column2 = DateColumn.create("foo");
         column2.appendInternal(day2);
-        NumberColumn days = column1.daysUntil(column2);
-        NumberColumn weeks = column1.weeksUntil(column2);
-        NumberColumn months = column1.monthsUntil(column2);
-        NumberColumn years = column1.yearsUntil(column2);
+        DoubleColumn days = column1.daysUntil(column2);
+        DoubleColumn weeks = column1.weeksUntil(column2);
+        DoubleColumn months = column1.monthsUntil(column2);
+        DoubleColumn years = column1.yearsUntil(column2);
         assertEquals(asLocalDate(day1).until(asLocalDate(day2), ChronoUnit.DAYS), days.get(0), 0.01);
         assertEquals(asLocalDate(day1).until(asLocalDate(day2), ChronoUnit.WEEKS), weeks.get(0), 0.01);
         assertEquals(asLocalDate(day1).until(asLocalDate(day2), ChronoUnit.MONTHS), months.get(0), 0.01);

--- a/core/src/test/java/tech/tablesaw/api/DateColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DateColumnTest.java
@@ -75,7 +75,7 @@ public class DateColumnTest {
         column1.appendCell("12/24/1924");
         column1.appendCell("12-May-2015");
         column1.appendCell("14-Jan-2015");
-        NumberColumn c2 = column1.dayOfMonth();
+        IntColumn c2 = column1.dayOfMonth();
         assertEquals(23, c2.get(0), 0.0001);
         assertEquals(24, c2.get(1), 0.0001);
         assertEquals(12, c2.get(2), 0.0001);
@@ -88,7 +88,7 @@ public class DateColumnTest {
         column1.appendCell("12/24/1924");
         column1.appendCell("12-May-2015");
         column1.appendCell("14-Jan-2015");
-        NumberColumn c2 = column1.monthValue();
+        IntColumn c2 = column1.monthValue();
         assertEquals(10, c2.get(0), 0.0001);
         assertEquals(12, c2.get(1), 0.0001);
         assertEquals(5, c2.get(2), 0.0001);
@@ -113,7 +113,7 @@ public class DateColumnTest {
         column1.appendCell("2013-10-23");
         column1.appendCell("12/24/1924");
         column1.appendCell("12-May-2015");
-        NumberColumn c2 = column1.year();
+        IntColumn c2 = column1.year();
         assertEquals(2013, c2.get(0), 0.0001);
         assertEquals(1924, c2.get(1), 0.0001);
         assertEquals(2015, c2.get(2), 0.0001);

--- a/core/src/test/java/tech/tablesaw/api/DateTimeColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DateTimeColumnTest.java
@@ -57,7 +57,7 @@ public class DateTimeColumnTest {
     @Test
     public void testConvertMillisSinceEpoch() {
         long millis = 1503952123189L;
-        NumberColumn dc = NumberColumn.create("test");
+        DoubleColumn dc = DoubleColumn.create("test");
         dc.appendCell(Long.toString(millis));
         DateTimeColumn column2 = dc.asDateTimes(ZoneOffset.UTC);
 

--- a/core/src/test/java/tech/tablesaw/api/NumberColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/NumberColumnTest.java
@@ -55,7 +55,7 @@ public class NumberColumnTest {
         fairy.baseProducer().trueOrFalse();
 
         Table table = Table.create("t");
-        NumberColumn numberColumn = NumberColumn.create("test", 100_000_000);
+        DoubleColumn numberColumn = DoubleColumn.create("test", 100_000_000);
         //BooleanColumn booleanColumn = BooleanColumn.create("bools", 1_000_000_000);
         table.addColumns(numberColumn);
         //table.addColumns(booleanColumn);
@@ -75,8 +75,8 @@ public class NumberColumnTest {
 
     @Test
     public void testPercentiles() {
-        NumberColumn c = NumberColumn.indexColumn("t", 99, 1);
-        NumberColumn c2 = c.copy();
+	IntColumn c = IntColumn.indexColumn("t", 99, 1);
+	IntColumn c2 = c.copy();
         c2.appendCell("");
         assertEquals(50, c.median(), 0.00001);
         assertEquals(50, c2.median(), 0.00001);
@@ -102,8 +102,8 @@ public class NumberColumnTest {
 
     @Test
     public void testSummarize() {
-        NumberColumn c = NumberColumn.indexColumn("t", 99, 1);
-        NumberColumn c2 = c.copy();
+	IntColumn c = IntColumn.indexColumn("t", 99, 1);
+	IntColumn c2 = c.copy();
         c2.appendCell("");
         double c2Variance = c2.variance();
         double cVariance = StatUtils.variance(c.asDoubleArray());
@@ -134,7 +134,7 @@ public class NumberColumnTest {
     @Test
     public void testSortAndApplyFilter1() {
 
-        NumberColumn numberColumn =  NumberColumn.create("test", 1_000_000_000);
+        DoubleColumn numberColumn =  DoubleColumn.create("test", 1_000_000_000);
         for (int i = 0; i < 1_000_000_000; i++) {
             numberColumn.append(Math.random());
         }
@@ -154,25 +154,25 @@ public class NumberColumnTest {
     public void createFromNumbers() {
         List<Number> numberList = new ArrayList<>();
         numberList.add(4);
-        NumberColumn column =  NumberColumn.create("test", numberList);
+        DoubleColumn column =  DoubleColumn.create("test", numberList);
         assertEquals(4.0, column.get(0), 0.001);
 
-        NumberColumn column1 =  NumberColumn.create("T", numberList.toArray(new Number[numberList.size()]));
+        DoubleColumn column1 =  DoubleColumn.create("T", numberList.toArray(new Number[numberList.size()]));
         assertEquals(4.0, column1.get(0), 0.001);
 
         float[] floats = new float[1];
         floats[0] = 4.0f;
-        NumberColumn column2 =  NumberColumn.create("T", floats);
+        DoubleColumn column2 =  DoubleColumn.create("T", floats);
         assertEquals(4.0, column2.get(0), 0.001);
 
         int[] ints = new int[1];
         ints[0] = 4;
-        NumberColumn column3 =  NumberColumn.create("T", ints);
+        DoubleColumn column3 =  DoubleColumn.create("T", ints);
         assertEquals(4.0, column3.get(0), 0.001);
 
         long[] longs = new long[1];
         longs[0] = 4_000_000_000L;
-        NumberColumn column4 =  NumberColumn.create("T", longs);
+        DoubleColumn column4 =  DoubleColumn.create("T", longs);
         assertEquals(4_000_000_000.0, column4.get(0), 0.001);
     }
 
@@ -181,7 +181,7 @@ public class NumberColumnTest {
         int[] originalValues = new int[]{32, 42, 40, 57, 52, -2};
         double[] inValues = new double[]{10, -2, 57, -5};
 
-        NumberColumn initial =  NumberColumn.create("Test", originalValues.length);
+        DoubleColumn initial =  DoubleColumn.create("Test", originalValues.length);
         Table t = Table.create("t", initial);
 
         for (int value : originalValues) {
@@ -198,8 +198,8 @@ public class NumberColumnTest {
         double[] x = new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         double[] y = new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-        NumberColumn xCol =  NumberColumn.create("x", x);
-        NumberColumn yCol =  NumberColumn.create("y", y);
+        DoubleColumn xCol =  DoubleColumn.create("x", x);
+        DoubleColumn yCol =  DoubleColumn.create("y", y);
 
         double resultP = xCol.pearsons(yCol);
         double resultS = xCol.spearmans(yCol);
@@ -214,8 +214,8 @@ public class NumberColumnTest {
         double[] x = new double[]{1, 2, 3, 4, 5, 6, 7, NaN, 9, 10};
         double[] y = new double[]{1, 2, 3, NaN, 5, 6, 7, 8, 9, 10};
 
-        NumberColumn xCol =  NumberColumn.create("x", x);
-        NumberColumn yCol =  NumberColumn.create("y", y);
+        DoubleColumn xCol =  DoubleColumn.create("x", x);
+        DoubleColumn yCol =  DoubleColumn.create("y", y);
 
         double resultP = xCol.pearsons(yCol);
         double resultK = xCol.kendalls(yCol);
@@ -227,7 +227,7 @@ public class NumberColumnTest {
     public void testBetweenExclusive() {
         int[] originalValues = new int[]{32, 42, 40, 57, 52, -2};
 
-        NumberColumn initial =  NumberColumn.create("Test", originalValues);
+        IntColumn initial =  IntColumn.create("Test", originalValues);
         Table t = Table.create("t", initial);
 
         Selection filter = t.numberColumn("Test").isBetweenExclusive(42, 57);
@@ -239,7 +239,7 @@ public class NumberColumnTest {
     @Ignore
     @Test
     public void testSort1() {
-        NumberColumn numberColumn =  NumberColumn.create("test", 1_000_000_000);
+        DoubleColumn numberColumn =  DoubleColumn.create("test", 1_000_000_000);
         System.out.println("Adding doubles to column");
         for (int i = 0; i < 100_000_000; i++) {
             numberColumn.append(Math.random());
@@ -254,7 +254,7 @@ public class NumberColumnTest {
     public void testIsLessThan() {
         int size = 1_000_000;
         Table table = Table.create("t");
-        NumberColumn numberColumn =  NumberColumn.create("test", size);
+        DoubleColumn numberColumn =  DoubleColumn.create("test", size);
         table.addColumns(numberColumn);
         for (int i = 0; i < size; i++) {
             numberColumn.append(Math.random());
@@ -273,7 +273,7 @@ public class NumberColumnTest {
 
     @Test
     public void testNumberFormat1() {
-        NumberColumn numberColumn =  NumberColumn.create("test");
+        DoubleColumn numberColumn =  DoubleColumn.create("test");
         numberColumn.append(48392.2932);
         numberColumn.setPrintFormatter(NumberColumnFormatter.currency("en", "US"));
         assertEquals("$48,392.29", numberColumn.getString(0));
@@ -282,7 +282,7 @@ public class NumberColumnTest {
 
     @Test
     public void testNumberFormat2() {
-        NumberColumn numberColumn =  NumberColumn.create("test");
+        DoubleColumn numberColumn =  DoubleColumn.create("test");
         numberColumn.append(48392.2932);
         numberColumn.setPrintFormatter(NumberColumnFormatter.intsWithGrouping());
         assertEquals("48,392", numberColumn.getString(0));
@@ -290,7 +290,7 @@ public class NumberColumnTest {
 
     @Test
     public void testNumberFormat3() {
-        NumberColumn numberColumn =  NumberColumn.create("test");
+        DoubleColumn numberColumn =  DoubleColumn.create("test");
         numberColumn.append(48392.2932);
         numberColumn.setPrintFormatter(NumberColumnFormatter.ints());
         assertEquals("48392", numberColumn.getString(0));
@@ -299,7 +299,7 @@ public class NumberColumnTest {
 
     @Test
     public void testNumberFormat4() {
-        NumberColumn numberColumn =  NumberColumn.create("test");
+        DoubleColumn numberColumn =  DoubleColumn.create("test");
         numberColumn.append(48392.2932);
         numberColumn.setPrintFormatter(NumberColumnFormatter.fixedWithGrouping(3));
         assertEquals("48,392.293", numberColumn.getString(0));
@@ -307,7 +307,7 @@ public class NumberColumnTest {
 
     @Test
     public void testNumberFormat5() {
-        NumberColumn numberColumn =  NumberColumn.create("test");
+        DoubleColumn numberColumn =  DoubleColumn.create("test");
         numberColumn.append(0.2932);
         numberColumn.setPrintFormatter(NumberColumnFormatter.percent(1));
         assertEquals("29.3%", numberColumn.getString(0));
@@ -315,7 +315,7 @@ public class NumberColumnTest {
 
     @Test
     public void testIndexColumn() {
-        NumberColumn numberColumn = NumberColumn.indexColumn("index", 12424, 0);
+	IntColumn numberColumn = IntColumn.indexColumn("index", 12424, 0);
         assertEquals("12423", numberColumn.getString(numberColumn.size() - 1));
     }
 
@@ -323,7 +323,7 @@ public class NumberColumnTest {
     public void testIsGreaterThan() {
         int size = 1_000_000;
         Table table = Table.create("t");
-        NumberColumn numberColumn =  NumberColumn.create("test", size);
+        DoubleColumn numberColumn =  DoubleColumn.create("test", size);
         table.addColumns(numberColumn);
         for (int i = 0; i < size; i++) {
             numberColumn.append(Math.random());
@@ -344,7 +344,7 @@ public class NumberColumnTest {
     @Test
     public void testSort() {
         int records = 1_000_000;
-        NumberColumn numberColumn =  NumberColumn.create("test", records);
+        DoubleColumn numberColumn =  DoubleColumn.create("test", records);
         for (int i = 0; i < records; i++) {
             numberColumn.append(Math.random());
         }
@@ -361,7 +361,7 @@ public class NumberColumnTest {
             last = n;
         }
         records = 10;
-        numberColumn =  NumberColumn.create("test", records);
+        numberColumn =  DoubleColumn.create("test", records);
         for (int i = 0; i < records; i++) {
             numberColumn.append(Math.random());
         }
@@ -375,12 +375,12 @@ public class NumberColumnTest {
 
     @Test
     public void testMaxAndMin() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 100);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 100);
         for (int i = 0; i < 100; i++) {
             doubles.append(RandomUtils.nextDouble(0, 10_000));
         }
-        NumberColumn doubles1 = doubles.top(50);
-        NumberColumn doubles2 = doubles.bottom(50);
+        NumericColumn<?> doubles1 = doubles.top(50);
+        NumericColumn<?> doubles2 = doubles.bottom(50);
         double[] doublesA = new double[50];
         double[] doublesB = new double[50];
         for (int i = 0; i < doubles1.size(); i++) {
@@ -395,7 +395,7 @@ public class NumberColumnTest {
 
     @Test
     public void testClear() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 100);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 100);
         for (int i = 0; i < 100; i++) {
             doubles.append(RandomUtils.nextDouble(0, 10_000));
         }
@@ -406,7 +406,7 @@ public class NumberColumnTest {
 
     @Test
     public void testCountMissing() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 10);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 10);
         for (int i = 0; i < 10; i++) {
             doubles.append(RandomUtils.nextDouble(0, 1_000));
         }
@@ -421,7 +421,7 @@ public class NumberColumnTest {
 
     @Test
     public void testCountUnique() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 10);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 10);
         double[] uniques = {0.0f, 0.00000001f, -0.000001f, 92923.29340f, 24252, 23442f, 2252, 2342f};
         for (double unique : uniques) {
             doubles.append(unique);
@@ -439,7 +439,7 @@ public class NumberColumnTest {
 
     @Test
     public void testUnique() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 10);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 10);
         double[] uniques = {0.0f, 0.00000001f, -0.000001f, 92923.29340f, 24252, 23442f, 2252, 2342f};
         for (double unique : uniques) {
             doubles.append(unique);
@@ -457,7 +457,7 @@ public class NumberColumnTest {
 
     @Test
     public void testIsMissingAndIsNotMissing() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 10);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 10);
         for (int i = 0; i < 10; i++) {
             doubles.append(RandomUtils.nextDouble(0, 1_000));
         }
@@ -473,11 +473,11 @@ public class NumberColumnTest {
 
     @Test
     public void testEmptyCopy() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 100);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 100);
         for (int i = 0; i < 100; i++) {
             doubles.append(RandomUtils.nextDouble(0, 10_000));
         }
-        NumberColumn empty = doubles.emptyCopy();
+        DoubleColumn empty = doubles.emptyCopy();
         assertTrue(empty.isEmpty());
         assertEquals(doubles.name(), empty.name());
     }
@@ -485,7 +485,7 @@ public class NumberColumnTest {
     @Test
     public void testSize() {
         int size = 100;
-        NumberColumn doubles =  NumberColumn.create("doubles", size);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", size);
         assertEquals(0, doubles.size());
         for (int i = 0; i < size; i++) {
             doubles.append(RandomUtils.nextDouble(0, 10_000));
@@ -497,7 +497,7 @@ public class NumberColumnTest {
 
     @Test
     public void testType() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 100);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 100);
         assertEquals(ColumnType.DOUBLE, doubles.type());
     }
 
@@ -517,15 +517,15 @@ public class NumberColumnTest {
     }
 
     private boolean computeAndValidateDifference(double[] originalValues, double[] expectedValues) {
-        NumberColumn initial =  NumberColumn.create("Test", originalValues);
-        NumberColumn difference = initial.difference();
+        DoubleColumn initial =  DoubleColumn.create("Test", originalValues);
+        DoubleColumn difference = initial.difference();
         return validateEquality(expectedValues, difference);
     }
 
     @Test
     public void testDifferenceEmptyColumn() {
-        NumberColumn initial =  NumberColumn.create("Test");
-        NumberColumn difference = initial.difference();
+        DoubleColumn initial =  DoubleColumn.create("Test");
+        DoubleColumn difference = initial.difference();
         assertEquals("Expecting empty data set.", 0, difference.size());
     }
 
@@ -533,8 +533,8 @@ public class NumberColumnTest {
     public void testCumSum() {
         double[] originalValues = new double[]{32, 42, MISSING, 57, 52, -10, 0};
         double[] expectedValues = new double[]{32, 74, MISSING, 131, 183, 173, 173};
-        NumberColumn initial =  NumberColumn.create("Test", originalValues);
-        NumberColumn csum = initial.cumSum();
+        DoubleColumn initial =  DoubleColumn.create("Test", originalValues);
+        DoubleColumn csum = initial.cumSum();
 
         assertEquals("Both sets of data should be the same size.", expectedValues.length, csum.size());
 
@@ -548,8 +548,8 @@ public class NumberColumnTest {
     public void testCumProd() {
         double[] originalValues = new double[]{1, 2, MISSING, 3, 4};
         double[] expectedValues = new double[]{1, 2, MISSING, 6, 24};
-        NumberColumn initial =  NumberColumn.create("Test", originalValues);
-        NumberColumn cprod = initial.cumProd();
+        DoubleColumn initial =  DoubleColumn.create("Test", originalValues);
+        DoubleColumn cprod = initial.cumProd();
 
         assertEquals("Both sets of data should be the same size.", expectedValues.length, cprod.size());
 
@@ -565,10 +565,10 @@ public class NumberColumnTest {
         double[] col2Values = new double[]{32, 42, 38.67, MISSING, 52.01};
         double[] expected = new double[]{0.5, MISSING, 3.33, MISSING, -.01};
 
-        NumberColumn col1 =  NumberColumn.create("1", col1Values);
-        NumberColumn col2 =  NumberColumn.create("2", col2Values);
+        DoubleColumn col1 =  DoubleColumn.create("1", col1Values);
+        DoubleColumn col2 =  DoubleColumn.create("2", col2Values);
 
-        NumberColumn difference = col1.subtract(col2);
+        DoubleColumn difference = col1.subtract(col2);
         assertTrue(validateEquality(expected, difference));
 
         // change order to verify size of returned column
@@ -581,8 +581,8 @@ public class NumberColumnTest {
     public void testPctChange() {
         double[] originalValues = new double[]{10, 12, 13};
         double[] expectedValues = new double[]{MISSING, 0.2, 0.083333};
-        NumberColumn initial =  NumberColumn.create("Test", originalValues);
-        NumberColumn pctChange = initial.pctChange();
+        DoubleColumn initial =  DoubleColumn.create("Test", originalValues);
+        DoubleColumn pctChange = initial.pctChange();
 
         assertEquals("Both sets of data should be the same size.", expectedValues.length, pctChange.size());
 
@@ -592,7 +592,7 @@ public class NumberColumnTest {
         }
     }
 
-    private boolean validateEquality(double[] expectedValues, NumberColumn col) {
+    private boolean validateEquality(double[] expectedValues, DoubleColumn col) {
         assertEquals("Both sets of data should be the same size.", expectedValues.length, col.size());
         for (int index = 0; index < col.size(); index++) {
             double actual = col.get(index);
@@ -607,35 +607,35 @@ public class NumberColumnTest {
 
     @Test
     public void testCountAtLeast() {
-        assertEquals(2, NumberColumn.create("t1", new double[] {0, 1, 2}).count(isPositiveOrZeroD, 2));
-        assertEquals(0, NumberColumn.create("t1", new double[] {0, 1, 2}).count(isNegativeD, 2));
+        assertEquals(2, DoubleColumn.create("t1", new double[] {0, 1, 2}).count(isPositiveOrZeroD, 2));
+        assertEquals(0, DoubleColumn.create("t1", new double[] {0, 1, 2}).count(isNegativeD, 2));
     }
 
     @Test
     public void testCount() {
-        assertEquals(3, NumberColumn.create("t1", new double[] {0, 1, 2}).count(isPositiveOrZeroD));
-        assertEquals(0, NumberColumn.create("t1", new double[] {0, 1, 2}).count(isNegativeD));
+        assertEquals(3, DoubleColumn.create("t1", new double[] {0, 1, 2}).count(isPositiveOrZeroD));
+        assertEquals(0, DoubleColumn.create("t1", new double[] {0, 1, 2}).count(isNegativeD));
     }
 
     @Test
     public void testAllMatch() {
-        assertTrue(NumberColumn.create("t1", new double[] {0, 1, 2}).allMatch(isPositiveOrZeroD));
-        assertFalse(NumberColumn.create("t1", new double[] {-1, 0, 1}).allMatch(isPositiveOrZeroD));
-        assertFalse(NumberColumn.create("t1", new double[] {1, 0, -1}).allMatch(isPositiveOrZeroD));
+        assertTrue(DoubleColumn.create("t1", new double[] {0, 1, 2}).allMatch(isPositiveOrZeroD));
+        assertFalse(DoubleColumn.create("t1", new double[] {-1, 0, 1}).allMatch(isPositiveOrZeroD));
+        assertFalse(DoubleColumn.create("t1", new double[] {1, 0, -1}).allMatch(isPositiveOrZeroD));
     }
 
     @Test
     public void testAnyMatch() {
-        assertTrue(NumberColumn.create("t1", new double[] {0, 1, 2}).anyMatch(isPositiveOrZeroD));
-        assertTrue(NumberColumn.create("t1", new double[] {-1, 0, -1}).anyMatch(isPositiveOrZeroD));
-        assertFalse(NumberColumn.create("t1", new double[] {0, 1, 2}).anyMatch(isNegativeD));
+        assertTrue(DoubleColumn.create("t1", new double[] {0, 1, 2}).anyMatch(isPositiveOrZeroD));
+        assertTrue(DoubleColumn.create("t1", new double[] {-1, 0, -1}).anyMatch(isPositiveOrZeroD));
+        assertFalse(DoubleColumn.create("t1", new double[] {0, 1, 2}).anyMatch(isNegativeD));
     }
 
     @Test
     public void noneMatch() {
-        assertTrue(NumberColumn.create("t1", new double[] {0, 1, 2}).noneMatch(isNegativeD));
-        assertFalse(NumberColumn.create("t1", new double[] {-1, 0, 1}).noneMatch(isNegativeD));
-        assertFalse(NumberColumn.create("t1", new double[] {1, 0, -1}).noneMatch(isNegativeD));
+        assertTrue(DoubleColumn.create("t1", new double[] {0, 1, 2}).noneMatch(isNegativeD));
+        assertFalse(DoubleColumn.create("t1", new double[] {-1, 0, 1}).noneMatch(isNegativeD));
+        assertFalse(DoubleColumn.create("t1", new double[] {1, 0, -1}).noneMatch(isNegativeD));
     }
 
     private <T> void check(Column<T> column, @SuppressWarnings("unchecked") T... ts) {
@@ -647,7 +647,7 @@ public class NumberColumnTest {
 
     @Test
     public void testFilter() {
-        Column<Double> filtered = NumberColumn.create("t1", new double[] {-1, 0, 1}).filter(isPositiveOrZeroD);
+        Column<Double> filtered = DoubleColumn.create("t1", new double[] {-1, 0, 1}).filter(isPositiveOrZeroD);
         check(filtered, 0.0, 1.0);
     }
     
@@ -655,32 +655,32 @@ public class NumberColumnTest {
 
     @Test
     public void testMapInto() {
-        check(NumberColumn.create("t1", new double[] {-1, 0, 1}).mapInto(toStringD, StringColumn.create("result")), "-1.0", "0.0", "1.0");
+        check(DoubleColumn.create("t1", new double[] {-1, 0, 1}).mapInto(toStringD, StringColumn.create("result")), "-1.0", "0.0", "1.0");
     }
 
     @Test
     public void testMaxDoubleComparator() {
-        assertEquals(Double.valueOf(1.0), NumberColumn.create("t1", new double[] {-1, 0, 1}).max(Double::compare).get());
-        assertFalse(NumberColumn.create("t1").max((d1, d2) -> (int) (d1 - d2)).isPresent());
+        assertEquals(Double.valueOf(1.0), DoubleColumn.create("t1", new double[] {-1, 0, 1}).max(Double::compare).get());
+        assertFalse(DoubleColumn.create("t1").max((d1, d2) -> (int) (d1 - d2)).isPresent());
     }
 
     @Test
     public void testMinDoubleComparator() {
-        assertEquals(Double.valueOf(-1.0), NumberColumn.create("t1", new double[] {-1, 0, 1}).min(Double::compare).get());
-        assertFalse(NumberColumn.create("t1").min((d1, d2) -> (int) (d1 - d2)).isPresent());
+        assertEquals(Double.valueOf(-1.0), DoubleColumn.create("t1", new double[] {-1, 0, 1}).min(Double::compare).get());
+        assertFalse(DoubleColumn.create("t1").min((d1, d2) -> (int) (d1 - d2)).isPresent());
     }
 
     private DoubleBinaryOperator sumD = (d1, d2) -> d1 + d2;
 
     @Test
     public void testReduceTDoubleBinaryOperator() {
-        assertEquals(1.0, NumberColumn.create("t1", new double[] {-1, 0, 1}).reduce(1.0, sumD), 0.0);
+        assertEquals(1.0, DoubleColumn.create("t1", new double[] {-1, 0, 1}).reduce(1.0, sumD), 0.0);
     }
 
     @Test
     public void testReduceDoubleBinaryOperator() {
-        assertEquals(Double.valueOf(0.0), NumberColumn.create("t1", new double[] {-1, 0, 1}).reduce(sumD).get());
-        assertFalse(NumberColumn.create("t1", new double[] {}).reduce(sumD).isPresent());
+        assertEquals(Double.valueOf(0.0), DoubleColumn.create("t1", new double[] {-1, 0, 1}).reduce(sumD).get());
+        assertFalse(DoubleColumn.create("t1", new double[] {}).reduce(sumD).isPresent());
     }
 
 }

--- a/core/src/test/java/tech/tablesaw/api/RowPerformanceTest.java
+++ b/core/src/test/java/tech/tablesaw/api/RowPerformanceTest.java
@@ -200,8 +200,8 @@ public class RowPerformanceTest {
         t = Table.create("Observations");
         StringColumn conceptId = StringColumn.create("concept");
         DateTimeColumn date = DateTimeColumn.create("date");
-        NumberColumn lowValues = NumberColumn.create("lowValue");
-        NumberColumn highValues = NumberColumn.create("highValue");
+        DoubleColumn lowValues = DoubleColumn.create("lowValue");
+        DoubleColumn highValues = DoubleColumn.create("highValue");
         highValues.setPrintFormatter(NumberColumnFormatter.ints());
         lowValues.setPrintFormatter(NumberColumnFormatter.ints());
 
@@ -236,8 +236,8 @@ public class RowPerformanceTest {
 
         DateTimeColumn dateColumn = table.dateTimeColumn("date");
         StringColumn conceptColumn = table.stringColumn("concept");
-        NumberColumn lowValues = table.numberColumn("lowValue");
-        NumberColumn highValues = table.numberColumn("highValue");
+        DoubleColumn lowValues = table.doubleColumn("lowValue");
+        DoubleColumn highValues = table.doubleColumn("highValue");
 
         // sample from the pools to write the data
         for (int i = 0; i < observationCount; i++) {

--- a/core/src/test/java/tech/tablesaw/api/RowTest.java
+++ b/core/src/test/java/tech/tablesaw/api/RowTest.java
@@ -45,27 +45,14 @@ public class RowTest {
     }
 
     @Test
-    public void testGetDouble() throws IOException {
-        Table table = Table.read().csv("../data/bush.csv");
-        Row row = new Row(table);
-        while (row.hasNext()) {
-            row.next();
-            assertEquals(table.numberColumn(1).get(row.getRowNumber()),
-                    row.getDouble(1), 0.00001);
-            assertEquals(table.numberColumn("approval").get(row.getRowNumber()),
-                    row.getDouble("approval"), 0.00001);
-        }
-    }
-
-    @Test
     public void testGetInt() throws IOException {
         Table table = Table.read().csv("../data/bush.csv");
         Row row = new Row(table);
         while (row.hasNext()) {
             row.next();
-            assertEquals((int) table.numberColumn(1).getDouble(row.getRowNumber()),
+            assertEquals(table.intColumn(1).getInt(row.getRowNumber()),
                     row.getInt(1));
-            assertEquals((int) table.numberColumn("approval").getDouble(row.getRowNumber()),
+            assertEquals(table.intColumn("approval").getInt(row.getRowNumber()),
                     row.getInt("approval"));
         }
     }

--- a/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
@@ -288,7 +288,7 @@ TODO: fix
         String[] words2 = {"cancel", "bananas", "islander", "calypso"};
         StringColumn wordColumn = StringColumn.create("words", words);
         StringColumn word2Column = StringColumn.create("words2", words2);
-        NumberColumn distance = wordColumn.distance(word2Column);
+        DoubleColumn distance = wordColumn.distance(word2Column);
         assertEquals(distance.get(0), 3, 0.0001);
         assertEquals(distance.get(3), 7, 0.0001);
     }

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -49,8 +49,8 @@ public class TableTest {
     private static final Random RANDOM = new Random();
 
     private Table table;
-    private NumberColumn f1 =  NumberColumn.create("f1");
-    private NumberColumn numberColumn =  NumberColumn.create("d1");
+    private DoubleColumn f1 =  DoubleColumn.create("f1");
+    private DoubleColumn numberColumn =  DoubleColumn.create("d1");
 
     @Before
     public void setUp() {
@@ -79,14 +79,14 @@ public class TableTest {
         double[] b = {3, 4, 5};
         double[] c = {3, 4, 5};
         Table t = Table.create("test",
-                NumberColumn.create("a", a),
-                NumberColumn.create("b", b),
-                NumberColumn.create("c", c));
+                DoubleColumn.create("a", a),
+                DoubleColumn.create("b", b),
+                DoubleColumn.create("c", c));
 
-        NumberColumn n =
-                t.numberColumn(0)
-                .add(t.numberColumn(1))
-                .add(t.numberColumn(2));
+        DoubleColumn n =
+                t.doubleColumn(0)
+                .add(t.doubleColumn(1))
+                .add(t.doubleColumn(2));
 
         assertEquals(n.get(0), 9, 0);
         assertEquals(n.get(1), 12, 0);
@@ -99,11 +99,11 @@ public class TableTest {
         double[] b = {3, 4, 5};
         double[] c = {3, 4, 5};
         Table t = Table.create("test",
-                NumberColumn.create("a", a),
-                NumberColumn.create("b", b),
-                NumberColumn.create("c", c));
+                DoubleColumn.create("a", a),
+                DoubleColumn.create("b", b),
+                DoubleColumn.create("c", c));
 
-        NumberColumn n = sum(t.numberColumns());
+        DoubleColumn n = sum(t.numberColumns());
 
         assertEquals(n.get(0), 9, 0);
         assertEquals(n.get(1), 12, 0);
@@ -149,10 +149,10 @@ public class TableTest {
     @Test
     public void testMissingValueCounts() {
         StringColumn c1 = StringColumn.create("SC");
-        NumberColumn c2 = NumberColumn.create("NC");
+        DoubleColumn c2 = DoubleColumn.create("NC");
         DateColumn c3 = DateColumn.create("DC");
         Table t = Table.create("Test", c1, c2, c3);
-        assertEquals(0, t.missingValueCounts().numberColumn(1).get(0), 0.00001);
+        assertEquals(0, t.missingValueCounts().doubleColumn(1).get(0), 0.00001);
     }
 
     @Test
@@ -161,7 +161,7 @@ public class TableTest {
         Table t = Table.create("test");
         t.addColumns(numberColumn);
         Table c = t.copy();
-        NumberColumn doubles = c.numberColumn(0);
+        DoubleColumn doubles = c.doubleColumn(0);
         assertNotNull(doubles);
         assertEquals(1, doubles.size());
     }
@@ -206,12 +206,12 @@ public class TableTest {
     @Test
     public void testDoWithEachRow() throws Exception {
         Table t = Table.read().csv("../data/bush.csv").first(10);
-        Double[] ratingsArray = {53.0, 58.0};
-        List<Double> ratings = Lists.asList(52.0, ratingsArray);
+        Integer[] ratingsArray = {53, 58};
+        List<Integer> ratings = Lists.asList(52, ratingsArray);
 
         Consumer<Row> doable = row -> {
             if (row.getRowNumber() < 5) {
-                assertTrue(ratings.contains(row.getDouble("approval")));
+                assertTrue(ratings.contains(row.getInt("approval")));
             }
         };
         t.doWithRows(doable);
@@ -264,7 +264,6 @@ public class TableTest {
 
     @Test
     public void testPairs2() throws Exception {
-
         Table t = Table.read().csv("../data/bush.csv");
 
         Table.Pairs runningAvg =  new Table.Pairs() {
@@ -273,8 +272,8 @@ public class TableTest {
 
             @Override
             public void doWithPair(Row row1, Row row2) {
-                double r1  = row1.getDouble("approval");
-                double r2  = row2.getDouble("approval");
+                double r1  = row1.getInt("approval");
+                double r2  = row2.getInt("approval");
                 values.add((r1 + r2) / 2.0);
             }
 
@@ -290,13 +289,13 @@ public class TableTest {
     @Test
     public void testRollWithNrows2() throws Exception {
         Table t = Table.read().csv("../data/bush.csv").first(4);
-        NumberColumn approval = t.numberColumn("approval");
+        IntColumn approval = t.intColumn("approval");
 
         List<Integer> sums = new ArrayList<>();
         Consumer<Row[]> rowConsumer = rows -> {
             int sum = 0;
             for (Row row : rows) {
-                sum += row.getDouble("approval");
+                sum += row.getInt("approval");
             }
             sums.add(sum);
         };
@@ -312,8 +311,8 @@ public class TableTest {
 
         @Override
         public void doWithPair(Row row1, Row row2) {
-            double r1  = row1.getDouble("approval");
-            double r2  = row2.getDouble("approval");
+            double r1  = row1.getInt("approval");
+            double r2  = row2.getInt("approval");
             runningAverage.add((r1 + r2) / 2.0);
         }
     }
@@ -321,7 +320,7 @@ public class TableTest {
     @Test
     public void testRowCount() {
         assertEquals(0, table.rowCount());
-        NumberColumn floatColumn = this.f1;
+        DoubleColumn floatColumn = this.f1;
         floatColumn.append(2f);
         assertEquals(1, table.rowCount());
         floatColumn.append(2.2342f);
@@ -360,10 +359,10 @@ public class TableTest {
 
     @Test
     public void testAppendMultipleColumns() {
-        NumberColumn column =  NumberColumn.create("e1");
+        DoubleColumn column =  DoubleColumn.create("e1");
         table.addColumns(column);
-        NumberColumn first = f1.emptyCopy();
-        NumberColumn second = column.emptyCopy();
+        DoubleColumn first = f1.emptyCopy();
+        DoubleColumn second = column.emptyCopy();
         int firstColumnSize = populateColumn(first);
         int secondColumnSize = populateColumn(second);
         Table tableToAppend = Table.create("populated", first, second);
@@ -385,14 +384,14 @@ public class TableTest {
 
     @Test(expected = IllegalStateException.class)
     public void testAppendTableWithAnotherColumnName() {
-        NumberColumn column =  NumberColumn.create("42");
+        DoubleColumn column =  DoubleColumn.create("42");
         Table tableToAppend = Table.create("wrong", column);
         table.append(tableToAppend);
     }
 
     @Test(expected = IllegalStateException.class)
     public void testAppendTableWithDifferentShape() {
-        NumberColumn column =  NumberColumn.create("e1");
+        DoubleColumn column =  DoubleColumn.create("e1");
         table.addColumns(column);
         Table tableToAppend = Table.create("different", column);
         assertEquals(2, table.columns().size());
@@ -402,9 +401,9 @@ public class TableTest {
 
     @Test
     public void testReplaceColumn() {
-        NumberColumn first =  NumberColumn.create("c1", new double[]{1, 2, 3, 4, 5});
-        NumberColumn second =  NumberColumn.create("c2", new double[]{6, 7, 8, 9, 10});
-        NumberColumn replacement =  NumberColumn.create("c2", new double[]{10, 20, 30, 40, 50});
+        DoubleColumn first =  DoubleColumn.create("c1", new double[]{1, 2, 3, 4, 5});
+        DoubleColumn second =  DoubleColumn.create("c2", new double[]{6, 7, 8, 9, 10});
+        DoubleColumn replacement =  DoubleColumn.create("c2", new double[]{10, 20, 30, 40, 50});
 
         Table t = Table.create("populated", first, second);
 
@@ -417,13 +416,13 @@ public class TableTest {
     }
 
     private int appendRandomlyGeneratedColumn(Table table) {
-        NumberColumn column = f1.emptyCopy();
+        DoubleColumn column = f1.emptyCopy();
         populateColumn(column);
         return appendColumn(table, column);
     }
 
     private void appendEmptyColumn(Table table) {
-        NumberColumn column = f1.emptyCopy();
+        DoubleColumn column = f1.emptyCopy();
         appendColumn(table, column);
     }
 
@@ -438,7 +437,7 @@ public class TableTest {
         assertEquals(expected, actual);
     }
 
-    private int populateColumn(NumberColumn floatColumn) {
+    private int populateColumn(DoubleColumn floatColumn) {
         int rowsCount = RANDOM.nextInt(ROWS_BOUNDARY);
         for (int i = 0; i < rowsCount; i++) {
             floatColumn.append(RANDOM.nextFloat());
@@ -449,9 +448,9 @@ public class TableTest {
 
     @Test
     public void testAsMatrix() {
-        NumberColumn first =  NumberColumn.create("c1", new double[]{1L, 2L, 3L, 4L, 5L});
-        NumberColumn second =  NumberColumn.create("c2", new double[]{6.0f, 7.0f, 8.0f, 9.0f, 10.0f});
-        NumberColumn third =  NumberColumn.create("c3", new double[]{10.0, 20.0, 30.0, 40.0, 50.0});
+        DoubleColumn first =  DoubleColumn.create("c1", new double[]{1L, 2L, 3L, 4L, 5L});
+        DoubleColumn second =  DoubleColumn.create("c2", new double[]{6.0f, 7.0f, 8.0f, 9.0f, 10.0f});
+        DoubleColumn third =  DoubleColumn.create("c3", new double[]{10.0, 20.0, 30.0, 40.0, 50.0});
 
         Table t = Table.create("table", first, second, third);
         double[][] matrix = t.as().doubleMatrix();
@@ -467,10 +466,10 @@ public class TableTest {
     public void testRowSort() throws Exception {
         Table bush = Table.read().csv("../data/bush.csv");
 
-        Comparator<Row> rowComparator = Comparator.comparingDouble(o -> o.getDouble("approval"));
+        Comparator<Row> rowComparator = Comparator.comparingDouble(o -> o.getInt("approval"));
 
         Table sorted = bush.sortOn(rowComparator);
-        NumberColumn approval = sorted.nCol("approval");
+        IntColumn approval = sorted.intColumn("approval");
         for (int i = 0; i < bush.rowCount() - 2; i++) {
             assertTrue(approval.get(i) <= approval.get(i + 1));
         }
@@ -485,12 +484,12 @@ public class TableTest {
         }
     }
 
-    private NumberColumn sum(NumberColumn ... columns) {
+    private DoubleColumn sum(DoubleColumn ... columns) {
         int size = columns[0].size();
-        NumberColumn result = NumberColumn.create("sum", size);
+        DoubleColumn result = DoubleColumn.create("sum", size);
         for (int r = 0; r < size; r++) {
             double sum = 0;
-            for (NumberColumn nc : columns) {
+            for (DoubleColumn nc : columns) {
                 sum += nc.get(r);
             }
             result.append(sum);

--- a/core/src/test/java/tech/tablesaw/api/TimeColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TimeColumnTest.java
@@ -248,7 +248,7 @@ public class TimeColumnTest {
     @Test
     public void minuteOfDay() {
         fillLargerColumn();
-        NumberColumn column2 = column1.minuteOfDay();
+        DoubleColumn column2 = column1.minuteOfDay();
         for (int i = 0; i < column1.size() - 2; i++) {
             assertEquals(column2.get(i), getMinuteOfDay(column1.getPackedTime(i)), 0.0001);
         }
@@ -257,7 +257,7 @@ public class TimeColumnTest {
     @Test
     public void secondOfDay() {
         fillLargerColumn();
-        NumberColumn column2 = column1.secondOfDay();
+        DoubleColumn column2 = column1.secondOfDay();
         for (int i = 0; i < column1.size() - 2; i++) {
             assertEquals(column2.get(i), getSecondOfDay(column1.getPackedTime(i)), 0.0001);
         }
@@ -267,7 +267,7 @@ public class TimeColumnTest {
     public void testPlusHours() {
         fillColumn();
         TimeColumn column2 = column1.plusHours(3);
-        NumberColumn numberColumn = column2.differenceInHours(column1);
+        DoubleColumn numberColumn = column2.differenceInHours(column1);
         double expected = -3;
         check(numberColumn, expected);
     }
@@ -312,7 +312,7 @@ public class TimeColumnTest {
     @Test
     public void testSecond() {
         fillColumn();
-        NumberColumn second = column1.second();
+        DoubleColumn second = column1.second();
         assertEquals(2, second.get(0), 0.001);
         assertEquals(30, second.get(1), 0.001);
         assertEquals(DoubleColumnType.missingValueIndicator(), second.get(2), 0.001);
@@ -321,7 +321,7 @@ public class TimeColumnTest {
     @Test
     public void testMinute() {
         fillColumn();
-        NumberColumn minute = column1.minute();
+        DoubleColumn minute = column1.minute();
         assertEquals(4, minute.get(0), 0.001);
         assertEquals(15, minute.get(1), 0.001);
         assertEquals(DoubleColumnType.missingValueIndicator(), minute.get(2), 0.001);
@@ -339,7 +339,7 @@ public class TimeColumnTest {
     public void testMinusHours() {
         fillColumn();
         TimeColumn column2 = column1.minusHours(0);
-        NumberColumn numberColumn = column2.differenceInHours(column1);
+        DoubleColumn numberColumn = column2.differenceInHours(column1);
         double expected = 0;
         check(numberColumn, expected);
     }
@@ -348,7 +348,7 @@ public class TimeColumnTest {
     public void testPlusMinutes() {
         fillColumn();
         TimeColumn column2 = column1.plusMinutes(30);
-        NumberColumn numberColumn = column2.differenceInMinutes(column1);
+        DoubleColumn numberColumn = column2.differenceInMinutes(column1);
         double expected = -30;
         check(numberColumn, expected);
     }
@@ -357,7 +357,7 @@ public class TimeColumnTest {
     public void testMinusMinutes() {
         fillColumn();
         TimeColumn column2 = column1.minusMinutes(30);
-        NumberColumn numberColumn = column2.differenceInMinutes(column1);
+        DoubleColumn numberColumn = column2.differenceInMinutes(column1);
         double expected = 30;
         check(numberColumn, expected);
     }
@@ -366,7 +366,7 @@ public class TimeColumnTest {
     public void testPlusSeconds() {
         fillColumn();
         TimeColumn column2 = column1.plusSeconds(101);
-        NumberColumn numberColumn = column2.differenceInSeconds(column1);
+        DoubleColumn numberColumn = column2.differenceInSeconds(column1);
         double expected = -101;
         check(numberColumn, expected);
     }
@@ -375,7 +375,7 @@ public class TimeColumnTest {
     public void testMinusSeconds() {
         fillColumn();
         TimeColumn column2 = column1.minusSeconds(101);
-        NumberColumn numberColumn = column2.differenceInSeconds(column1);
+        DoubleColumn numberColumn = column2.differenceInSeconds(column1);
         double expected = 101;
         check(numberColumn, expected);
     }
@@ -384,7 +384,7 @@ public class TimeColumnTest {
     public void testPlusMilliseconds() {
         fillColumn();
         TimeColumn column2 = column1.plusMilliseconds(101);
-        NumberColumn numberColumn = column2.differenceInMilliseconds(column1);
+        DoubleColumn numberColumn = column2.differenceInMilliseconds(column1);
         double expected = -101;
         check(numberColumn, expected);
     }
@@ -393,7 +393,7 @@ public class TimeColumnTest {
     public void testMinusMilliseconds() {
         fillColumn();
         TimeColumn column2 = column1.minusMilliseconds(101);
-        NumberColumn numberColumn = column2.differenceInMilliseconds(column1);
+        DoubleColumn numberColumn = column2.differenceInMilliseconds(column1);
         double expected = 101;
         check(numberColumn, expected);
     }
@@ -405,7 +405,7 @@ public class TimeColumnTest {
         assertNull(col.get(0));
     }
 
-    private void check(NumberColumn numberColumn, double expected) {
+    private void check(DoubleColumn numberColumn, double expected) {
         assertEquals(expected, numberColumn.min(), .0001);
         assertEquals(expected, numberColumn.max(), .0001);
     }

--- a/core/src/test/java/tech/tablesaw/columns/AbstractColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/AbstractColumnTest.java
@@ -3,7 +3,7 @@ package tech.tablesaw.columns;
 import org.junit.Assert;
 import org.junit.Test;
 import tech.tablesaw.api.DateColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.numbers.DoubleColumnType;
 
@@ -13,18 +13,18 @@ public class AbstractColumnTest {
 
     @Test
     public void fillMissing_defaultValue() {
-        NumberColumn col1 = NumberColumn.create("col1",
+        DoubleColumn col1 = DoubleColumn.create("col1",
                 new double[]{0.0, 1.0, DoubleColumnType.missingValueIndicator(), 2.0, DoubleColumnType.missingValueIndicator()});
-        NumberColumn expected = NumberColumn.create("expected", new double[]{0.0, 1.0, 7.0, 2.0, 7.0});
+        DoubleColumn expected = DoubleColumn.create("expected", new double[]{0.0, 1.0, 7.0, 2.0, 7.0});
         Assert.assertArrayEquals(expected.asDoubleArray(), col1.fillMissing(7.0).asDoubleArray(), 0.0001);
     }
 
     @Test
     public void fillMissing_columnArg() {
-        NumberColumn col1 = NumberColumn.create("col1",
+        DoubleColumn col1 = DoubleColumn.create("col1",
                 new double[]{0.0, 1.0, DoubleColumnType.missingValueIndicator(), 2.0, DoubleColumnType.missingValueIndicator()});
-        NumberColumn col2 = NumberColumn.create("col1", new double[]{7.0, 7.0, 3.0, 7.0, 4.0});
-        NumberColumn expected = NumberColumn.create("expected", new double[]{0.0, 1.0, 3.0, 2.0, 4.0});
+        DoubleColumn col2 = DoubleColumn.create("col1", new double[]{7.0, 7.0, 3.0, 7.0, 4.0});
+        DoubleColumn expected = DoubleColumn.create("expected", new double[]{0.0, 1.0, 3.0, 2.0, 4.0});
         Assert.assertArrayEquals(expected.asDoubleArray(), col1.fillMissing(col2).asDoubleArray(), 0.0001);
     }
 

--- a/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
@@ -18,7 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.DateColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.csv.CsvReadOptions;
@@ -58,7 +58,7 @@ public class ColumnTest {
         assertEquals(LocalDate.parse("2004-01-07"), first.get(2));
 
         // test with ints
-        NumberColumn first2 = (NumberColumn) table.numberColumn("approval").first(3);
+        DoubleColumn first2 = (DoubleColumn) table.numberColumn("approval").first(3);
         assertEquals(53, first2.get(0), 0.0001);
         assertEquals(53, first2.get(1), 0.0001);
         assertEquals(58, first2.get(2), 0.0001);
@@ -80,7 +80,7 @@ public class ColumnTest {
         assertEquals(LocalDate.parse("2001-02-09"), last.get(2));
 
         // test with ints
-        NumberColumn last2 = (NumberColumn) table.numberColumn("approval").last(3);
+        DoubleColumn last2 = (DoubleColumn) table.numberColumn("approval").last(3);
         assertEquals(52, last2.get(0), 0.0001);
         assertEquals(53, last2.get(1), 0.0001);
         assertEquals(57, last2.get(2), 0.0001);
@@ -123,9 +123,9 @@ public class ColumnTest {
         double[] d1 = {1, 0, -1};
         double[] d2 = {2, -4, 3};
 
-        NumberColumn dc1 = NumberColumn.create("t1", d1);
-        NumberColumn dc2 = NumberColumn.create("t2", d2);
-        NumberColumn dc3 = (NumberColumn) dc1.min(dc2);
+        DoubleColumn dc1 = DoubleColumn.create("t1", d1);
+        DoubleColumn dc2 = DoubleColumn.create("t2", d2);
+        DoubleColumn dc3 = (DoubleColumn) dc1.min(dc2);
         assertTrue(dc3.contains(1));
         assertTrue(dc3.contains(-4));
         assertTrue(dc3.contains(-1));
@@ -136,9 +136,9 @@ public class ColumnTest {
         double[] d1 = {1, 0, -1};
         double[] d2 = {2, -4, 3};
 
-        NumberColumn dc1 = NumberColumn.create("t1", d1);
-        NumberColumn dc2 = NumberColumn.create("t2", d2);
-        NumberColumn dc3 = (NumberColumn) dc1.max(dc2);
+        DoubleColumn dc1 = DoubleColumn.create("t1", d1);
+        DoubleColumn dc2 = DoubleColumn.create("t2", d2);
+        DoubleColumn dc3 = (DoubleColumn) dc1.max(dc2);
         assertTrue(dc3.contains(2));
         assertTrue(dc3.contains(0));
         assertTrue(dc3.contains(3));
@@ -150,35 +150,35 @@ public class ColumnTest {
 
     @Test
     public void testCountAtLeast() {
-        assertEquals(2, NumberColumn.create("t1", new double[] {0, 1, 2}).count(isPositiveOrZero, 2));
-        assertEquals(0, NumberColumn.create("t1", new double[] {0, 1, 2}).count(isNegative, 2));
+        assertEquals(2, DoubleColumn.create("t1", new double[] {0, 1, 2}).count(isPositiveOrZero, 2));
+        assertEquals(0, DoubleColumn.create("t1", new double[] {0, 1, 2}).count(isNegative, 2));
     }
 
     @Test
     public void testCount() {
-        assertEquals(3, NumberColumn.create("t1", new double[] {0, 1, 2}).count(isPositiveOrZero));
-        assertEquals(0, NumberColumn.create("t1", new double[] {0, 1, 2}).count(isNegative));
+        assertEquals(3, DoubleColumn.create("t1", new double[] {0, 1, 2}).count(isPositiveOrZero));
+        assertEquals(0, DoubleColumn.create("t1", new double[] {0, 1, 2}).count(isNegative));
     }
 
     @Test
     public void testAllMatch() {
-        assertTrue(NumberColumn.create("t1", new double[] {0, 1, 2}).allMatch(isPositiveOrZero));
-        assertFalse(NumberColumn.create("t1", new double[] {-1, 0, 1}).allMatch(isPositiveOrZero));
-        assertFalse(NumberColumn.create("t1", new double[] {1, 0, -1}).allMatch(isPositiveOrZero));
+        assertTrue(DoubleColumn.create("t1", new double[] {0, 1, 2}).allMatch(isPositiveOrZero));
+        assertFalse(DoubleColumn.create("t1", new double[] {-1, 0, 1}).allMatch(isPositiveOrZero));
+        assertFalse(DoubleColumn.create("t1", new double[] {1, 0, -1}).allMatch(isPositiveOrZero));
     }
 
     @Test
     public void testAnyMatch() {
-        assertTrue(NumberColumn.create("t1", new double[] {0, 1, 2}).anyMatch(isPositiveOrZero));
-        assertTrue(NumberColumn.create("t1", new double[] {-1, 0, -1}).anyMatch(isPositiveOrZero));
-        assertFalse(NumberColumn.create("t1", new double[] {0, 1, 2}).anyMatch(isNegative));
+        assertTrue(DoubleColumn.create("t1", new double[] {0, 1, 2}).anyMatch(isPositiveOrZero));
+        assertTrue(DoubleColumn.create("t1", new double[] {-1, 0, -1}).anyMatch(isPositiveOrZero));
+        assertFalse(DoubleColumn.create("t1", new double[] {0, 1, 2}).anyMatch(isNegative));
     }
     
     @Test
     public void noneMatch() {
-        assertTrue(NumberColumn.create("t1", new double[] {0, 1, 2}).noneMatch(isNegative));
-        assertFalse(NumberColumn.create("t1", new double[] {-1, 0, 1}).noneMatch(isNegative));
-        assertFalse(NumberColumn.create("t1", new double[] {1, 0, -1}).noneMatch(isNegative));
+        assertTrue(DoubleColumn.create("t1", new double[] {0, 1, 2}).noneMatch(isNegative));
+        assertFalse(DoubleColumn.create("t1", new double[] {-1, 0, 1}).noneMatch(isNegative));
+        assertFalse(DoubleColumn.create("t1", new double[] {1, 0, -1}).noneMatch(isNegative));
     }
     
     private <T> void check(Column<T> column, @SuppressWarnings("unchecked") T... ts) {
@@ -190,7 +190,7 @@ public class ColumnTest {
     
     @Test
     public void testFilter() {
-        Column<Double> filtered = NumberColumn.create("t1", new double[] {-1, 0, 1}).filter(isPositiveOrZero);
+        Column<Double> filtered = DoubleColumn.create("t1", new double[] {-1, 0, 1}).filter(isPositiveOrZero);
         check(filtered, 0.0, 1.0);
     }
     
@@ -198,43 +198,43 @@ public class ColumnTest {
     
     @Test
     public void testMapInto() {
-        check(NumberColumn.create("t1", new double[] {-1, 0, 1}).mapInto(toString, StringColumn.create("result")), "-1.0", "0.0", "1.0");
+        check(DoubleColumn.create("t1", new double[] {-1, 0, 1}).mapInto(toString, StringColumn.create("result")), "-1.0", "0.0", "1.0");
     }
 
     private Function<Double, Double> negate = d -> -d;
     
     @Test
     public void testMap() {
-        check(NumberColumn.create("t1", new double[] {-1, 0, 1}).map(negate), 1.0, -0.0, -1.0);
+        check(DoubleColumn.create("t1", new double[] {-1, 0, 1}).map(negate), 1.0, -0.0, -1.0);
     }
     
     @Test
     public void testMaxComparator() {
-        assertEquals(Double.valueOf(1.0), NumberColumn.create("t1", new double[] {-1, 0, 1}).max(Double::compare).get());
-        assertFalse(NumberColumn.create("t1").max((d1, d2) -> (int) (d1 - d2)).isPresent());
+        assertEquals(Double.valueOf(1.0), DoubleColumn.create("t1", new double[] {-1, 0, 1}).max(Double::compare).get());
+        assertFalse(DoubleColumn.create("t1").max((d1, d2) -> (int) (d1 - d2)).isPresent());
     }
 
     @Test
     public void testMinComparator() {
-        assertEquals(Double.valueOf(-1.0), NumberColumn.create("t1", new double[] {-1, 0, 1}).min(Double::compare).get());
-        assertFalse(NumberColumn.create("t1").min((d1, d2) -> (int) (d1 - d2)).isPresent());
+        assertEquals(Double.valueOf(-1.0), DoubleColumn.create("t1", new double[] {-1, 0, 1}).min(Double::compare).get());
+        assertFalse(DoubleColumn.create("t1").min((d1, d2) -> (int) (d1 - d2)).isPresent());
     }
 
     private BinaryOperator<Double> sum = (d1, d2) -> d1 + d2;
    
     @Test
     public void testReduceTBinaryOperator() {
-        assertEquals(Double.valueOf(1.0), NumberColumn.create("t1", new double[] {-1, 0, 1}).reduce(1.0, sum));
+        assertEquals(Double.valueOf(1.0), DoubleColumn.create("t1", new double[] {-1, 0, 1}).reduce(1.0, sum));
     }
     
     @Test
     public void testReduceBinaryOperator() {
-        assertEquals(Double.valueOf(0.0), NumberColumn.create("t1", new double[] {-1, 0, 1}).reduce(sum).get());
-        assertFalse(NumberColumn.create("t1", new double[] {}).reduce(sum).isPresent());
+        assertEquals(Double.valueOf(0.0), DoubleColumn.create("t1", new double[] {-1, 0, 1}).reduce(sum).get());
+        assertFalse(DoubleColumn.create("t1", new double[] {}).reduce(sum).isPresent());
     }
     
     @Test
     public void sorted() {
-        check(NumberColumn.create("t1", new double[] {1, -1, 0}).sorted(Double::compare), -1.0, 0.0, 1.0);
+        check(DoubleColumn.create("t1", new double[] {1, -1, 0}).sorted(Double::compare), -1.0, 0.0, 1.0);
     }
 }

--- a/core/src/test/java/tech/tablesaw/columns/dates/DateFiltersTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/dates/DateFiltersTest.java
@@ -14,19 +14,25 @@
 
 package tech.tablesaw.columns.dates;
 
-import org.junit.Before;
-import org.junit.Test;
-import tech.tablesaw.api.DateColumn;
-import tech.tablesaw.api.NumberColumn;
-import tech.tablesaw.api.StringColumn;
-import tech.tablesaw.api.Table;
-import tech.tablesaw.selection.Selection;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static tech.tablesaw.columns.dates.PackedLocalDate.asLocalDate;
+import static tech.tablesaw.columns.dates.PackedLocalDate.minusDays;
+import static tech.tablesaw.columns.dates.PackedLocalDate.pack;
+import static tech.tablesaw.columns.dates.PackedLocalDate.plusDays;
 
 import java.time.LocalDate;
 import java.time.Month;
 
-import static org.junit.Assert.*;
-import static tech.tablesaw.columns.dates.PackedLocalDate.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import tech.tablesaw.api.DateColumn;
+import tech.tablesaw.api.IntColumn;
+import tech.tablesaw.api.StringColumn;
+import tech.tablesaw.api.Table;
+import tech.tablesaw.selection.Selection;
 
 
 public class DateFiltersTest {
@@ -103,7 +109,7 @@ public class DateFiltersTest {
         }
 
         StringColumn month = dateColumn.month();
-        NumberColumn monthValue = dateColumn.monthValue();
+        IntColumn monthValue = dateColumn.monthValue();
 
         for (int i = 0; i < months.length; i++) {
             assertEquals(months[i].name(), month.get(i).toUpperCase());
@@ -130,7 +136,7 @@ public class DateFiltersTest {
 
         Table t = Table.create("Test");
         t.addColumns(dateColumn);
-        NumberColumn index = NumberColumn.indexColumn("index", t.rowCount(), 0);
+        IntColumn index = IntColumn.indexColumn("index", t.rowCount(), 0);
         t.addColumns(index);
 
         assertTrue(t.where(t.dateColumn("test").isInJanuary()).numberColumn("index").contains(0.0));
@@ -189,7 +195,7 @@ public class DateFiltersTest {
         assertFalse(dateColumn.isBetweenExcluding(beforeDate, afterDate).contains(2));
         assertFalse(dateColumn.isBetweenExcluding(beforeDate, afterDate).contains(0));
 
-        NumberColumn index = NumberColumn.indexColumn("index", dateColumn.size(), 0);
+        IntColumn index = IntColumn.indexColumn("index", dateColumn.size(), 0);
         Table t = Table.create("test", dateColumn, index);
 
         assertTrue(t.where(dateColumn.isBefore(packed)).nCol("index").contains(0));

--- a/core/src/test/java/tech/tablesaw/columns/datetimes/DateTimeFiltersTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/datetimes/DateTimeFiltersTest.java
@@ -14,18 +14,20 @@
 
 package tech.tablesaw.columns.datetimes;
 
-import org.junit.Before;
-import org.junit.Test;
-import tech.tablesaw.api.DateTimeColumn;
-import tech.tablesaw.api.NumberColumn;
-import tech.tablesaw.api.Table;
-import tech.tablesaw.selection.Selection;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
 
-import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import tech.tablesaw.api.DateTimeColumn;
+import tech.tablesaw.api.IntColumn;
+import tech.tablesaw.api.Table;
+import tech.tablesaw.selection.Selection;
 
 public class DateTimeFiltersTest {
 
@@ -151,7 +153,7 @@ public class DateTimeFiltersTest {
 
         Table t = Table.create("Test");
         t.addColumns(dateTimeColumn);
-        NumberColumn index = NumberColumn.indexColumn("index", t.rowCount(), 0);
+        IntColumn index = IntColumn.indexColumn("index", t.rowCount(), 0);
         t.addColumns(index);
     }
 
@@ -168,7 +170,7 @@ public class DateTimeFiltersTest {
         dateTimeColumn.append(dateTime);
         dateTimeColumn.append(afterDate);
 
-        NumberColumn index = NumberColumn.indexColumn("index", dateTimeColumn.size(), 0);
+        IntColumn index = IntColumn.indexColumn("index", dateTimeColumn.size(), 0);
         Table t = Table.create("test", dateTimeColumn, index);
 
         assertTrue(dateTimeColumn.isOnOrBefore(date).contains(0));

--- a/core/src/test/java/tech/tablesaw/columns/datetimes/DateTimeMapFunctionsTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/datetimes/DateTimeMapFunctionsTest.java
@@ -18,7 +18,7 @@ import com.google.common.base.Strings;
 import org.junit.Test;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DateTimeColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.TimeColumn;
 
@@ -45,7 +45,7 @@ public class DateTimeMapFunctionsTest {
         LocalDateTime stop = start.plus(100_000L, ChronoUnit.MILLIS);
         startCol.append(start);
         stopCol.append(stop);
-        NumberColumn result = startCol.differenceInMilliseconds(stopCol);
+        DoubleColumn result = startCol.differenceInMilliseconds(stopCol);
         assertEquals(100_000L, result.firstElement(),0.01);
     }
 
@@ -56,7 +56,7 @@ public class DateTimeMapFunctionsTest {
         startCol.append(start);
         stopCol.append(stop);
 
-        NumberColumn result = startCol.differenceInSeconds(stopCol);
+        DoubleColumn result = startCol.differenceInSeconds(stopCol);
         assertEquals(100_000L, result.firstElement(), 0.01);
     }
 
@@ -67,7 +67,7 @@ public class DateTimeMapFunctionsTest {
         startCol.append(start);
         stopCol.append(stop);
 
-        NumberColumn result = startCol.differenceInMinutes(stopCol);
+        DoubleColumn result = startCol.differenceInMinutes(stopCol);
         assertEquals(100_000L, result.firstElement(), 0.01);
     }
 
@@ -78,7 +78,7 @@ public class DateTimeMapFunctionsTest {
         startCol.append(start);
         stopCol.append(stop);
 
-        NumberColumn result = startCol.differenceInHours(stopCol);
+        DoubleColumn result = startCol.differenceInHours(stopCol);
         assertEquals(100_000L, result.firstElement(), 0.01);
 
     }
@@ -90,7 +90,7 @@ public class DateTimeMapFunctionsTest {
         startCol.append(start);
         stopCol.append(stop);
 
-        NumberColumn result = startCol.differenceInDays(stopCol);
+        DoubleColumn result = startCol.differenceInDays(stopCol);
         assertEquals(100_000L, result.firstElement(), 0.01);
     }
 
@@ -101,49 +101,49 @@ public class DateTimeMapFunctionsTest {
         startCol.append(start);
         stopCol.append(stop);
 
-        NumberColumn result = startCol.differenceInYears(stopCol);
+        DoubleColumn result = startCol.differenceInYears(stopCol);
         assertEquals(10_000L, result.firstElement(), 0.01);
     }
 
     @Test
     public void testHour() {
         startCol.append(LocalDateTime.of(1984, 12, 12, 7, 30));
-        NumberColumn hour = startCol.hour();
+        DoubleColumn hour = startCol.hour();
         assertEquals(7, hour.firstElement(), 0.0001);
     }
 
     @Test
     public void testYear() {
         startCol.append(LocalDateTime.of(1984, 12, 12, 7, 30));
-        NumberColumn year = startCol.year();
+        DoubleColumn year = startCol.year();
         assertEquals(1984, year.firstElement(), 0.0001);
     }
 
     @Test
     public void testDayOfYear() {
         startCol.append(LocalDateTime.of(1984, 1, 5, 7, 30));
-        NumberColumn dayOfYear = startCol.dayOfYear();
+        DoubleColumn dayOfYear = startCol.dayOfYear();
         assertEquals(5, dayOfYear.firstElement(), 0.0001);
     }
 
     @Test
     public void testDayOfMonth() {
         startCol.append(LocalDateTime.of(1984, 1, 22, 7, 30));
-        NumberColumn dayOfMonth = startCol.dayOfMonth();
+        DoubleColumn dayOfMonth = startCol.dayOfMonth();
         assertEquals(22, dayOfMonth.firstElement(), 0.0001);
     }
 
     @Test
     public void testMinute() {
         startCol.append(LocalDateTime.of(1984, 1, 22, 7, 30));
-        NumberColumn minute = startCol.minute();
+        DoubleColumn minute = startCol.minute();
         assertEquals(30, minute.firstElement(), 0.0001);
     }
 
     @Test
     public void testDayOfWeekValue() {
         startCol.append(LocalDateTime.of(2018, 4, 10, 7, 30));
-        NumberColumn dayOfWeekValue = startCol.dayOfWeekValue();
+        DoubleColumn dayOfWeekValue = startCol.dayOfWeekValue();
         assertEquals(2, dayOfWeekValue.firstElement(), 0.0001);
     }
 
@@ -211,7 +211,7 @@ public class DateTimeMapFunctionsTest {
     public void testMonthValue() {
         LocalDateTime dateTime = LocalDateTime.of(2018, 4, 10, 7, 30);
         startCol.append(dateTime);
-        NumberColumn month = startCol.monthValue();
+        DoubleColumn month = startCol.monthValue();
         assertEquals(4, month.get(0), 0.0001);
     }
 
@@ -219,7 +219,7 @@ public class DateTimeMapFunctionsTest {
     public void testMinuteOfDay() {
         LocalDateTime dateTime = LocalDateTime.of(2018, 4, 10, 7, 30);
         startCol.append(dateTime);
-        NumberColumn minuteOfDay = startCol.minuteOfDay();
+        DoubleColumn minuteOfDay = startCol.minuteOfDay();
         assertEquals((7 * 60) + 30, minuteOfDay.get(0), 0.0001);
     }
 
@@ -227,7 +227,7 @@ public class DateTimeMapFunctionsTest {
     public void testSecondOfDay() {
         LocalDateTime dateTime = LocalDateTime.of(2018, 4, 10, 7, 30);
         startCol.append(dateTime);
-        NumberColumn secondOfDay = startCol.secondOfDay();
+        DoubleColumn secondOfDay = startCol.secondOfDay();
         assertEquals(dateTime.get(ChronoField.SECOND_OF_DAY), secondOfDay.get(0), 0.0001);
     }
 
@@ -255,7 +255,7 @@ public class DateTimeMapFunctionsTest {
             dateTime = dateTime.plusDays(1);
             startCol.append(dateTime);
         }
-        NumberColumn timeWindows = startCol.timeWindow(ChronoUnit.DAYS, 5);
+        DoubleColumn timeWindows = startCol.timeWindow(ChronoUnit.DAYS, 5);
         assertEquals(0, timeWindows.get(0), 0.0001);
         assertEquals(9, timeWindows.max(), 0.0001);
 

--- a/core/src/test/java/tech/tablesaw/columns/numbers/FloatDataWrapperTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/numbers/FloatDataWrapperTest.java
@@ -1,16 +1,17 @@
 package tech.tablesaw.columns.numbers;
 
-import org.junit.Test;
-import tech.tablesaw.api.NumberColumn;
+import static org.junit.Assert.assertEquals;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+
+import tech.tablesaw.api.FloatColumn;
 
 public class FloatDataWrapperTest {
 
     @Test
     public void getInt() {
         float[] data = {1.2f, 1.8f};
-        NumberColumn column = NumberColumn.createWithFloats("test", data);
+        FloatColumn column = FloatColumn.create("test", data);
         assertEquals(1.0, column.getInt(0), 0.00001);
         assertEquals(2.0, column.getInt(1), 0.00001);
     }

--- a/core/src/test/java/tech/tablesaw/columns/numbers/NumberFillersTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/numbers/NumberFillersTest.java
@@ -1,7 +1,7 @@
 package tech.tablesaw.columns.numbers;
 
 import static org.junit.Assert.assertEquals;
-import static tech.tablesaw.api.NumberColumn.create;
+import static tech.tablesaw.api.DoubleColumn.create;
 import static tech.tablesaw.columns.numbers.fillers.DoubleRangeIterable.range;
 
 import org.junit.Test;

--- a/core/src/test/java/tech/tablesaw/columns/numbers/NumberFiltersTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/numbers/NumberFiltersTest.java
@@ -1,7 +1,7 @@
 package tech.tablesaw.columns.numbers;
 
 import org.junit.Test;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.csv.CsvReadOptions;
 import tech.tablesaw.selection.Selection;
@@ -14,7 +14,7 @@ public class NumberFiltersTest {
     @Test
     public void testIsEqualTo() {
         double[] values = {4, 1, 1, 2, 2};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
         Selection selection = doubles.isEqualTo(1.0);
         assertEquals(1, selection.get(0));
         assertEquals(2, selection.get(1));
@@ -24,7 +24,7 @@ public class NumberFiltersTest {
     @Test
     public void testIsNotEqualTo() {
         double[] values = {4, 1, 1, 2, 2};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
         Selection selection = doubles.isNotEqualTo(1.0);
         assertEquals(0, selection.get(0));
         assertEquals(3, selection.get(1));
@@ -35,7 +35,7 @@ public class NumberFiltersTest {
     @Test
     public void testIsZero() {
         double[] values = {4, 0, -1};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
         Selection selection = doubles.isZero();
         assertEquals(1, selection.get(0));
         assertEquals(1, selection.size());
@@ -44,7 +44,7 @@ public class NumberFiltersTest {
     @Test
     public void testIsPositive() {
         double[] values = {4, 0, -1};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
         Selection selection = doubles.isPositive();
         assertEquals(0, selection.get(0));
         assertEquals(1, selection.size());
@@ -53,7 +53,7 @@ public class NumberFiltersTest {
     @Test
     public void testIsNegative() {
         double[] values = {4, 0, -0.00001};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
         Selection selection = doubles.isNegative();
         assertEquals(2, selection.get(0));
         assertEquals(1, selection.size());
@@ -62,7 +62,7 @@ public class NumberFiltersTest {
     @Test
     public void testIsNonNegative() {
         double[] values = {4, 0, -0.00001};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
         Selection selection = doubles.isNonNegative();
         assertEquals(0, selection.get(0));
         assertEquals(1, selection.get(1));
@@ -74,14 +74,14 @@ public class NumberFiltersTest {
         double[] values = {4, 0, -0.00001};
         double[] otherValues = {4, -1.3, 0.00001, NaN};
 
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
 
         Selection selection = doubles.isGreaterThanOrEqualTo(0.0);
         assertEquals(0, selection.get(0));
         assertEquals(1, selection.get(1));
         assertEquals(2, selection.size());
 
-        NumberColumn others = NumberColumn.create("others", otherValues);
+        DoubleColumn others = DoubleColumn.create("others", otherValues);
 
         Selection selection1 = doubles.isGreaterThanOrEqualTo(others);
         assertEquals(0, selection1.get(0));
@@ -95,13 +95,13 @@ public class NumberFiltersTest {
         double[] values = {4, 0, -0.00001};
         double[] otherValues = {4, -1.3, 0.00001, NaN};
 
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
         Selection selection = doubles.isLessThanOrEqualTo(0.0);
         assertEquals(1, selection.get(0));
         assertEquals(2, selection.get(1));
         assertEquals(2, selection.size());
 
-        NumberColumn others = NumberColumn.create("others", otherValues);
+        DoubleColumn others = DoubleColumn.create("others", otherValues);
         Selection selection1 = doubles.isLessThanOrEqualTo(others);
         assertEquals(0, selection1.get(0));
         assertEquals(2, selection1.get(1));
@@ -112,8 +112,8 @@ public class NumberFiltersTest {
     public void testIsLessThan() {
         double[] values = {4, 0, -0.00001, 5.0};
         double[] values2 = {4, 11, -3.00001, 5.1};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
-        NumberColumn doubles2 =  NumberColumn.create("doubles2", values2);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
+        DoubleColumn doubles2 =  DoubleColumn.create("doubles2", values2);
         Selection selection = doubles.isLessThan(doubles2);
         assertEquals(1, selection.get(0));
         assertEquals(3, selection.get(1));
@@ -126,14 +126,14 @@ public class NumberFiltersTest {
         double[] values = {4, 0, -0.00001, 5.0};
         double[] otherValues = {4, -1.3, 0.00001, NaN};
 
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
 
         Selection selection = doubles.isGreaterThan(0);
         assertEquals(0, selection.get(0));
         assertEquals(3, selection.get(1));
         assertEquals(2, selection.size());
 
-        NumberColumn others = NumberColumn.create("others", otherValues);
+        DoubleColumn others = DoubleColumn.create("others", otherValues);
 
         Selection selection1 = doubles.isGreaterThan(others);
         assertEquals(1, selection1.get(0));
@@ -144,8 +144,8 @@ public class NumberFiltersTest {
     public void testIsEqualTo1() {
         double[] values = {4, 0, -0.00001, 5.0, 4.44443};
         double[] values2 = {4, 11, -3.00001, 5.1, 4.44443};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
-        NumberColumn doubles2 =  NumberColumn.create("doubles2", values2);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
+        DoubleColumn doubles2 =  DoubleColumn.create("doubles2", values2);
         Selection selection = doubles.isEqualTo(doubles2);
         assertEquals(0, selection.get(0));
         assertEquals(4, selection.get(1));
@@ -156,8 +156,8 @@ public class NumberFiltersTest {
     public void testIsNotEqualTo1() {
         double[] values = {4, 0, -0.00001, 5.0, 4.44443};
         double[] values2 = {4, 11, -3.00001, 5.1, 4.44443};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
-        NumberColumn doubles2 =  NumberColumn.create("doubles2", values2);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
+        DoubleColumn doubles2 =  DoubleColumn.create("doubles2", values2);
         Selection selection = doubles.isNotEqualTo(doubles2);
         assertEquals(1, selection.get(0));
         assertEquals(2, selection.get(1));
@@ -174,7 +174,7 @@ public class NumberFiltersTest {
     @Test
     public void testIsMissing() {
         double[] values = {4, 1, Double.NaN, 2, 2};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
         Selection selection = doubles.isMissing();
         assertEquals(2, selection.get(0));
         assertEquals(1, selection.size());
@@ -183,7 +183,7 @@ public class NumberFiltersTest {
     @Test
     public void testIsNotMissing() {
         double[] values = {4, 1, Double.NaN, 2, 2};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
         Selection selection = doubles.isNotMissing();
         assertEquals(0, selection.get(0));
         assertEquals(1, selection.get(1));
@@ -193,7 +193,7 @@ public class NumberFiltersTest {
     @Test
     public void testNotIn() {
         double[] values = {4, 1, Double.NaN, 2, 2};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
         double[] comparison = {1, 2};
         Selection selection = doubles.isNotIn(comparison);
         assertEquals(0, selection.get(0));

--- a/core/src/test/java/tech/tablesaw/columns/numbers/NumberMapFunctionsTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/numbers/NumberMapFunctionsTest.java
@@ -1,19 +1,22 @@
 package tech.tablesaw.columns.numbers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
-import tech.tablesaw.api.NumberColumn;
-import tech.tablesaw.api.Table;
 
-import static org.junit.Assert.*;
+import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.IntColumn;
+import tech.tablesaw.api.Table;
 
 public class NumberMapFunctionsTest {
 
     @Test
     public void testNormalize() {
         double[] values = {4, 12, 9, 7, 8, 1, 3, 8, 9, 11};
-        NumberColumn test =  NumberColumn.create("test", values);
-        NumberColumn result = test.normalize();
+        DoubleColumn test =  DoubleColumn.create("test", values);
+        DoubleColumn result = test.normalize();
         assertEquals(0, result.mean(), 0.01);
         assertEquals(1, result.standardDeviation(), 0.01);
     }
@@ -21,8 +24,8 @@ public class NumberMapFunctionsTest {
     @Test
     public void testAsRatio() {
         double[] values = {4, 1, 1, 2, 2};  // sums to 10
-        NumberColumn test =  NumberColumn.create("test", values);
-        NumberColumn result = test.asRatio();
+        DoubleColumn test =  DoubleColumn.create("test", values);
+        DoubleColumn result = test.asRatio();
         assertEquals(.4, result.get(0), 0.01);
         assertEquals(.1, result.get(1), 0.01);
         assertEquals(.2, result.get(3), 0.01);
@@ -31,8 +34,8 @@ public class NumberMapFunctionsTest {
     @Test
     public void testAsPercent() {
         double[] values = {4, 1, 1, 2, 2};  // sums to 10
-        NumberColumn test =  NumberColumn.create("test", values);
-        NumberColumn result = test.asPercent();
+        DoubleColumn test =  DoubleColumn.create("test", values);
+        DoubleColumn result = test.asPercent();
         assertEquals(40, result.get(0), 0.01);
         assertEquals(10, result.get(1), 0.01);
         assertEquals(20, result.get(3), 0.01);
@@ -41,8 +44,8 @@ public class NumberMapFunctionsTest {
     @Test
     public void testAdd() {
         double[] values = {4, 1, 1, 2, 2};
-        NumberColumn test =  NumberColumn.create("test", values);
-        NumberColumn result = test.add(4);
+        DoubleColumn test =  DoubleColumn.create("test", values);
+        DoubleColumn result = test.add(4);
         assertEquals(8, result.get(0), 0.01);
         assertEquals(5, result.get(1), 0.01);
         assertEquals(6, result.get(3), 0.01);
@@ -52,9 +55,9 @@ public class NumberMapFunctionsTest {
     public void testAdd2() {
         double[] values = {4, 1, 1, 2, 2};
         double[] values2 = {4, 1, 1, 2, 2};
-        NumberColumn test =  NumberColumn.create("test", values);
-        NumberColumn test2 =  NumberColumn.create("test2", values2);
-        NumberColumn result = test.add(test2);
+        DoubleColumn test =  DoubleColumn.create("test", values);
+        DoubleColumn test2 =  DoubleColumn.create("test2", values2);
+        DoubleColumn result = test.add(test2);
         assertEquals(8, result.get(0), 0.01);
         assertEquals(2, result.get(1), 0.01);
         assertEquals(4, result.get(3), 0.01);
@@ -63,8 +66,8 @@ public class NumberMapFunctionsTest {
     @Test
     public void testSubtract() {
         double[] values = {4, 1, 1, 2, 2};
-        NumberColumn test =  NumberColumn.create("test", values);
-        NumberColumn result = test.subtract(4);
+        DoubleColumn test =  DoubleColumn.create("test", values);
+        DoubleColumn result = test.subtract(4);
         assertEquals(0, result.get(0), 0.01);
         assertEquals(-3, result.get(1), 0.01);
         assertEquals(-2, result.get(3), 0.01);
@@ -74,9 +77,9 @@ public class NumberMapFunctionsTest {
     public void testSubtract2() {
         double[] values = {4, 1, 1, 2, 2};
         double[] values2 = {4, 1, 1, 2, 2};
-        NumberColumn test =  NumberColumn.create("test", values);
-        NumberColumn test2 =  NumberColumn.create("test2", values2);
-        NumberColumn result = test.subtract(test2);
+        DoubleColumn test =  DoubleColumn.create("test", values);
+        DoubleColumn test2 =  DoubleColumn.create("test2", values2);
+        DoubleColumn result = test.subtract(test2);
         assertEquals(0, result.get(0), 0.01);
         assertEquals(0, result.get(1), 0.01);
         assertEquals(0, result.get(3), 0.01);
@@ -85,8 +88,8 @@ public class NumberMapFunctionsTest {
     @Test
     public void testMultiply() {
         double[] values = {4, 1, 1, 2, 2};
-        NumberColumn test =  NumberColumn.create("test", values);
-        NumberColumn result = test.multiply(4);
+        DoubleColumn test =  DoubleColumn.create("test", values);
+        DoubleColumn result = test.multiply(4);
         assertEquals(16, result.get(0), 0.01);
         assertEquals(4, result.get(1), 0.01);
         assertEquals(8, result.get(3), 0.01);
@@ -96,9 +99,9 @@ public class NumberMapFunctionsTest {
     public void testMultiply2() {
         double[] values = {4, 1, 1, 2, 2};
         double[] values2 = {4, 1, 1, 2, 2};
-        NumberColumn test =  NumberColumn.create("test", values);
-        NumberColumn test2 =  NumberColumn.create("test2", values2);
-        NumberColumn result = test.multiply(test2);
+        DoubleColumn test =  DoubleColumn.create("test", values);
+        DoubleColumn test2 =  DoubleColumn.create("test2", values2);
+        DoubleColumn result = test.multiply(test2);
         assertEquals(16, result.get(0), 0.01);
         assertEquals(1, result.get(1), 0.01);
         assertEquals(4, result.get(3), 0.01);
@@ -107,8 +110,8 @@ public class NumberMapFunctionsTest {
     @Test
     public void testDivide() {
         double[] values = {4, 1, 1, 2, 2};
-        NumberColumn test =  NumberColumn.create("test", values);
-        NumberColumn result = test.divide(2);
+        DoubleColumn test =  DoubleColumn.create("test", values);
+        DoubleColumn result = test.divide(2);
         assertEquals(2, result.get(0), 0.01);
         assertEquals(0.5, result.get(1), 0.01);
         assertEquals(1.0, result.get(3), 0.01);
@@ -118,9 +121,9 @@ public class NumberMapFunctionsTest {
     public void testDivide2() {
         double[] values = {4, 1, 1, 2, 2};
         double[] values2 = {4, 1, 1, 2, 2};
-        NumberColumn test =  NumberColumn.create("test", values);
-        NumberColumn test2 =  NumberColumn.create("test2", values2);
-        NumberColumn result = test.divide(test2);
+        DoubleColumn test =  DoubleColumn.create("test", values);
+        DoubleColumn test2 =  DoubleColumn.create("test2", values2);
+        DoubleColumn result = test.divide(test2);
         assertEquals(1, result.get(0), 0.01);
         assertEquals(1, result.get(1), 0.01);
         assertEquals(1, result.get(3), 0.01);
@@ -128,10 +131,9 @@ public class NumberMapFunctionsTest {
 
     @Test
     public void lag() {
-        NumberColumn n1 = NumberColumn.indexColumn("index", 4, 0);
-        NumberColumn n2 = n1.lag(-2);
+	IntColumn n1 = IntColumn.indexColumn("index", 4, 0);
         Table t = Table.create("tst");
-        t.addColumns(n1, n2);
+        t.addColumns(n1, n1.lag(-2));
         assertEquals("            tst            \n" +
                 " index  |  index lag(-2)  |\n" +
                 "---------------------------\n" +
@@ -143,10 +145,9 @@ public class NumberMapFunctionsTest {
 
     @Test
     public void lead() {
-        NumberColumn n1 = NumberColumn.indexColumn("index", 4, 0);
-        NumberColumn n2 = n1.lead(1);
+	IntColumn n1 = IntColumn.indexColumn("index", 4, 0);
         Table t = Table.create("tst");
-        t.addColumns(n1, n2);
+        t.addColumns(n1, n1.lead(1));
         assertEquals("            tst            \n" +
                 " index  |  index lead(1)  |\n" +
                 "---------------------------\n" +
@@ -158,11 +159,11 @@ public class NumberMapFunctionsTest {
 
     @Test
     public void testNeg() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 100);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 100);
         for (int i = 0; i < 100; i++) {
             doubles.append(RandomUtils.nextDouble(0, 10_000));
         }
-        NumberColumn newDoubles = doubles.neg();
+        DoubleColumn newDoubles = doubles.neg();
         assertFalse(newDoubles.isEmpty());
         assertEquals(0 - doubles.get(0), newDoubles.get(0), 0.0001);
     }
@@ -170,8 +171,8 @@ public class NumberMapFunctionsTest {
     @Test
     public void testRoundInt() {
         double[] values = {4.4, 1.9, 1.5, 2.3, 2.0};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
-        NumberColumn newDoubles = doubles.roundInt();
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
+        DoubleColumn newDoubles = doubles.roundInt();
         assertEquals(4, newDoubles.get(0), 0.0001);
         assertEquals(2, newDoubles.get(1), 0.0001);
         assertEquals(2, newDoubles.get(2), 0.0001);
@@ -183,22 +184,22 @@ public class NumberMapFunctionsTest {
     public void testMod() {
         double[] values = {4, 1, 1, 2, 2};
         double[] values2 = {4, 1, 1, 2, 2};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
-        NumberColumn otherDoubles =  NumberColumn.create("otherDoubles", values2);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
+        DoubleColumn otherDoubles =  DoubleColumn.create("otherDoubles", values2);
 
-        NumberColumn newDoubles = doubles.remainder(otherDoubles);
+        DoubleColumn newDoubles = doubles.remainder(otherDoubles);
         assertEquals(0, newDoubles.get(0), 0.001);
     }
 
     @Test
     public void testSquareAndSqrt() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 100);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 100);
         for (int i = 0; i < 100; i++) {
             doubles.append(RandomUtils.nextDouble(0, 10_000));
         }
 
-        NumberColumn newDoubles = doubles.square();
-        NumberColumn revert = newDoubles.sqrt();
+        DoubleColumn newDoubles = doubles.square();
+        DoubleColumn revert = newDoubles.sqrt();
         for (int i = 0; i < doubles.size(); i++) {
             assertEquals(doubles.get(i), revert.get(i), 0.01);
         }
@@ -206,12 +207,12 @@ public class NumberMapFunctionsTest {
 
     @Test
     public void testCubeAndCbrt() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 100);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 100);
         for (int i = 0; i < 100; i++) {
             doubles.append(RandomUtils.nextDouble(0, 10_000));
         }
-        NumberColumn newDoubles = doubles.cube();
-        NumberColumn revert = newDoubles.cubeRoot();
+        DoubleColumn newDoubles = doubles.cube();
+        DoubleColumn revert = newDoubles.cubeRoot();
         for (int i = 0; i < doubles.size(); i++) {
             assertEquals(doubles.get(i), revert.get(i), 0.01);
         }
@@ -219,19 +220,19 @@ public class NumberMapFunctionsTest {
 
     @Test
     public void testLog1p() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 100);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 100);
         for (int i = 0; i < 100; i++) {
             doubles.append(RandomUtils.nextDouble(0, 10_000));
         }
-        NumberColumn newDoubles = doubles.log1p();
+        DoubleColumn newDoubles = doubles.log1p();
         assertFalse(newDoubles.isEmpty());
     }
 
     @Test
     public void testAbs() {
         double[] values = {4.4, -1.9, -1.5, 2.3, 0.0};
-        NumberColumn doubles =  NumberColumn.create("doubles", values);
-        NumberColumn newDoubles = doubles.abs();
+        DoubleColumn doubles =  DoubleColumn.create("doubles", values);
+        DoubleColumn newDoubles = doubles.abs();
         assertEquals(4.4, newDoubles.get(0), 0.0001);
         assertEquals(1.9, newDoubles.get(1), 0.0001);
         assertEquals(1.5, newDoubles.get(2), 0.0001);
@@ -243,31 +244,31 @@ public class NumberMapFunctionsTest {
 
     @Test
     public void testRound() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 100);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 100);
         for (int i = 0; i < 100; i++) {
             doubles.append(RandomUtils.nextDouble(0, 10_000));
         }
-        NumberColumn newDoubles = doubles.round();
+        DoubleColumn newDoubles = doubles.round();
         assertFalse(newDoubles.isEmpty());
     }
 
     @Test
     public void testLogN() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 100);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 100);
         for (int i = 0; i < 100; i++) {
             doubles.append(RandomUtils.nextDouble(0, 10_000));
         }
-        NumberColumn newDoubles = doubles.logN();
+        DoubleColumn newDoubles = doubles.logN();
         assertFalse(newDoubles.isEmpty());
     }
 
     @Test
     public void testLog10() {
-        NumberColumn doubles =  NumberColumn.create("doubles", 100);
+        DoubleColumn doubles =  DoubleColumn.create("doubles", 100);
         for (int i = 0; i < 100; i++) {
             doubles.append(RandomUtils.nextDouble(0, 10_000));
         }
-        NumberColumn newDoubles = doubles.log10();
+        DoubleColumn newDoubles = doubles.log10();
         assertFalse(newDoubles.isEmpty());
     }
 }

--- a/core/src/test/java/tech/tablesaw/columns/strings/StringFiltersTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/strings/StringFiltersTest.java
@@ -17,7 +17,7 @@ package tech.tablesaw.columns.strings;
 import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 
@@ -257,7 +257,7 @@ public class StringFiltersTest {
     public void testCountWords() {
         final String[] words1 = {"one", "two words"};
         final StringColumn stringColumn1 = StringColumn.create("words", words1);
-        NumberColumn nc = stringColumn1.countTokens(" ");
+        DoubleColumn nc = stringColumn1.countTokens(" ");
         assertEquals( 3, nc.sum(), 0.00001);
     }
 }

--- a/core/src/test/java/tech/tablesaw/conversion/TableConverterTest.java
+++ b/core/src/test/java/tech/tablesaw/conversion/TableConverterTest.java
@@ -15,7 +15,7 @@
 package tech.tablesaw.conversion;
 
 import org.junit.Test;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.Table;
 
 import java.util.Arrays;
@@ -29,8 +29,8 @@ public class TableConverterTest {
         double[] array1 = {0, 1, 2};
         double[] array2 = {0, 1, 2};
 
-        NumberColumn c1 = NumberColumn.create("1", array1);
-        NumberColumn c2 = NumberColumn.create("2", array2);
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
         Table table = Table.create("test", c1, c2);
 
         double[][] expected = {{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}};
@@ -44,9 +44,9 @@ public class TableConverterTest {
         double[] array2 = {0, 1, 2};
         double[] array3 = {0, 1, 3};
 
-        NumberColumn c1 = NumberColumn.create("1", array1);
-        NumberColumn c2 = NumberColumn.create("2", array2);
-        NumberColumn c3 = NumberColumn.create("3", array3);
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
+        DoubleColumn c3 = DoubleColumn.create("3", array3);
         Table table = Table.create("test", c1, c2, c3);
 
         double[][] expected = {{0.0, 0.0}, {1.0, 1.0}, {1.0, 3.0}};
@@ -59,8 +59,8 @@ public class TableConverterTest {
         double[] array1 = {0, 1, 2};
         double[] array2 = {0, 1, 2};
 
-        NumberColumn c1 = NumberColumn.create("1", array1);
-        NumberColumn c2 = NumberColumn.create("2", array2);
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
         Table table = Table.create("test", c1, c2);
 
         int[][] expected = {{0, 0}, {1, 1}, {2, 2}};
@@ -74,9 +74,9 @@ public class TableConverterTest {
         double[] array2 = {0, 1, 2};
         double[] array3 = {0, 1, 3};
 
-        NumberColumn c1 = NumberColumn.create("1", array1);
-        NumberColumn c2 = NumberColumn.create("2", array2);
-        NumberColumn c3 = NumberColumn.create("3", array3);
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
+        DoubleColumn c3 = DoubleColumn.create("3", array3);
         Table table = Table.create("test", c1, c2, c3);
 
         int[][] expected = {{0, 0}, {1, 1}, {1, 3}};
@@ -89,8 +89,8 @@ public class TableConverterTest {
         double[] array1 = {0, 1, 2};
         double[] array2 = {0, 1, 2};
 
-        NumberColumn c1 = NumberColumn.create("1", array1);
-        NumberColumn c2 = NumberColumn.create("2", array2);
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
         Table table = Table.create("test", c1, c2);
 
         float[][] expected = {{0.0f, 0.0f}, {1.0f, 1.0f}, {2.0f, 2.0f}};
@@ -104,9 +104,9 @@ public class TableConverterTest {
         double[] array2 = {0, 1, 2};
         double[] array3 = {0, 1, 3};
 
-        NumberColumn c1 = NumberColumn.create("1", array1);
-        NumberColumn c2 = NumberColumn.create("2", array2);
-        NumberColumn c3 = NumberColumn.create("3", array3);
+        DoubleColumn c1 = DoubleColumn.create("1", array1);
+        DoubleColumn c2 = DoubleColumn.create("2", array2);
+        DoubleColumn c3 = DoubleColumn.create("3", array3);
         Table table = Table.create("test", c1, c2, c3);
 
         float[][] expected = {{0.0f, 0.0f}, {1.0f, 1.0f}, {1.0f, 3.0f}};

--- a/core/src/test/java/tech/tablesaw/filters/SearchPerformanceTest.java
+++ b/core/src/test/java/tech/tablesaw/filters/SearchPerformanceTest.java
@@ -19,7 +19,7 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.text.RandomStringGenerator;
 import tech.tablesaw.api.DateTimeColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.Row;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
@@ -63,8 +63,8 @@ public class SearchPerformanceTest {
         t.setName("Observations");
 
         DateTimeColumn dates = t.dateTimeColumn("date");
-        NumberColumn lowValues = t.numberColumn("lowValue");
-        NumberColumn highValues = t.numberColumn("highValue");
+        DoubleColumn lowValues = t.doubleColumn("lowValue");
+        DoubleColumn highValues = t.doubleColumn("highValue");
 
         System.out.println(dates.summary());
         System.out.println(lowValues.summary());
@@ -113,8 +113,8 @@ public class SearchPerformanceTest {
         t = Table.create("Observations");
         StringColumn conceptId = StringColumn.create("concept");
         DateTimeColumn date = DateTimeColumn.create("date");
-        NumberColumn lowValues = NumberColumn.create("lowValue");
-        NumberColumn highValues = NumberColumn.create("highValue");
+        DoubleColumn lowValues = DoubleColumn.create("lowValue");
+        DoubleColumn highValues = DoubleColumn.create("highValue");
         highValues.setPrintFormatter(NumberColumnFormatter.ints());
         lowValues.setPrintFormatter(NumberColumnFormatter.ints());
 
@@ -152,8 +152,8 @@ public class SearchPerformanceTest {
 
         DateTimeColumn dateColumn = table.dateTimeColumn("date");
         StringColumn conceptColumn = table.stringColumn("concept");
-        NumberColumn lowValues = table.numberColumn("lowValue");
-        NumberColumn highValues = table.numberColumn("highValue");
+        DoubleColumn lowValues = table.doubleColumn("lowValue");
+        DoubleColumn highValues = table.doubleColumn("highValue");
 
         // sample from the pools to write the data
         for (int i = 0; i < observationCount; i++) {

--- a/core/src/test/java/tech/tablesaw/filters/TimeDependentFilteringTest.java
+++ b/core/src/test/java/tech/tablesaw/filters/TimeDependentFilteringTest.java
@@ -22,7 +22,7 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.text.RandomStringGenerator;
 import tech.tablesaw.api.DateColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.dates.PackedLocalDate;
@@ -82,7 +82,7 @@ public class TimeDependentFilteringTest {
         //Non-temporal clause
         Table nt = t.where(concept.isEqualTo(conceptA).and(concept.isNotEqualTo(conceptB)));
 
-        NumberColumn ntPatients = nt.numberColumn("patient");
+        DoubleColumn ntPatients = nt.doubleColumn("patient");
 
         // Group the original table by patient id
         TableSliceGroup patients = StandardTableSliceGroup.create(t, "patient");
@@ -139,8 +139,8 @@ public class TimeDependentFilteringTest {
         t = Table.create("Observations");
         StringColumn conceptId = StringColumn.create("concept");
         DateColumn date = DateColumn.create("date");
-        NumberColumn value =  NumberColumn.create("value");
-        NumberColumn patientId =  NumberColumn.create("patient");
+        DoubleColumn value =  DoubleColumn.create("value");
+        DoubleColumn patientId =  DoubleColumn.create("patient");
         patientId.setPrintFormatter(NumberColumnFormatter.ints());
 
         t.addColumns(conceptId);
@@ -178,8 +178,8 @@ public class TimeDependentFilteringTest {
 
         DateColumn dateColumn = table.dateColumn("date");
         StringColumn conceptColumn = table.stringColumn("concept");
-        NumberColumn valueColumn = table.numberColumn("value");
-        NumberColumn patientColumn = table.numberColumn("patient");
+        DoubleColumn valueColumn = table.doubleColumn("value");
+        DoubleColumn patientColumn = table.doubleColumn("patient");
 
         // sample from the pools to write the data
         for (int i = 0; i < observationCount; i++) {

--- a/core/src/test/java/tech/tablesaw/index/DoubleIndexTest.java
+++ b/core/src/test/java/tech/tablesaw/index/DoubleIndexTest.java
@@ -45,7 +45,7 @@ public class DoubleIndexTest {
                                 ColumnType.STRING,
                                 ColumnType.DOUBLE,
                                 ColumnType.DOUBLE}));
-        index = new DoubleIndex(table.numberColumn("stop_lat"));
+        index = new DoubleIndex(table.doubleColumn("stop_lat"));
     }
 
     @Test

--- a/core/src/test/java/tech/tablesaw/index/IntIndexTest.java
+++ b/core/src/test/java/tech/tablesaw/index/IntIndexTest.java
@@ -28,9 +28,6 @@ import java.time.LocalDate;
 
 import static org.junit.Assert.*;
 
-/**
- *
- */
 public class IntIndexTest {
 
     private ColumnType[] types = {
@@ -46,7 +43,7 @@ public class IntIndexTest {
     @Before
     public void setUp() throws Exception {
         table = Table.read().csv(CsvReadOptions.builder("../data/bush.csv").columnTypes(types));
-        index = new DoubleIndex(table.numberColumn("approval"));
+        index = new DoubleIndex(table.doubleColumn("approval"));
         dateIndex = new IntIndex(table.dateColumn("date"));
     }
 

--- a/core/src/test/java/tech/tablesaw/io/DataFrameWriterTest.java
+++ b/core/src/test/java/tech/tablesaw/io/DataFrameWriterTest.java
@@ -1,7 +1,7 @@
 package tech.tablesaw.io;
 
 import org.junit.Test;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.Table;
 
 import java.io.ByteArrayOutputStream;
@@ -15,8 +15,8 @@ public class DataFrameWriterTest {
     private double[] v1 = {1, 2, 3, 4, 5, NaN};
     private double[] v2 = {1, 2, 3, 4, 5, NaN};
     private Table table = Table.create("t",
-            NumberColumn.create("v", v1),
-            NumberColumn.create("v2", v2)
+            DoubleColumn.create("v", v1),
+            DoubleColumn.create("v2", v2)
     );
 
     @Test

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
@@ -14,15 +14,20 @@
 
 package tech.tablesaw.io.csv;
 
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import tech.tablesaw.api.ColumnType;
-import tech.tablesaw.api.DateColumn;
-import tech.tablesaw.api.DateTimeColumn;
-import tech.tablesaw.api.NumberColumn;
-import tech.tablesaw.api.Table;
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static tech.tablesaw.api.ColumnType.DOUBLE;
+import static tech.tablesaw.api.ColumnType.FLOAT;
+import static tech.tablesaw.api.ColumnType.INTEGER;
+import static tech.tablesaw.api.ColumnType.LOCAL_DATE;
+import static tech.tablesaw.api.ColumnType.LOCAL_DATE_TIME;
+import static tech.tablesaw.api.ColumnType.SKIP;
+import static tech.tablesaw.api.ColumnType.STRING;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -35,10 +40,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
-import static tech.tablesaw.api.ColumnType.*;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import tech.tablesaw.api.ColumnType;
+import tech.tablesaw.api.DateColumn;
+import tech.tablesaw.api.DateTimeColumn;
+import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.IntColumn;
+import tech.tablesaw.api.Table;
 
 /**
  * Tests for CSV Reading
@@ -133,7 +145,7 @@ public class CsvReaderTest {
     public void testMillis() {
 
         long[] times = {1530486314124L, 1530488214124L};
-        NumberColumn d = NumberColumn.create("times", times);
+        DoubleColumn d = DoubleColumn.create("times", times);
         DateTimeColumn column = d.asDateTimes(ZoneOffset.UTC);
         assertEquals(1530486314124L, column.get(0).toInstant(ZoneOffset.UTC).toEpochMilli());
     }
@@ -365,7 +377,7 @@ public class CsvReaderTest {
         // TODO (lwhite): These tests don't fail. What was their intent?
         Table table1 = Table.read().csv("../data/read_failure_test.csv");
         table1.structure(); // just make sure the import completed
-        NumberColumn test = table1.numberColumn("Test");
+        IntColumn test = table1.intColumn("Test");
         //TODO(lwhite): Better tests
         assertNotNull(test.summary());
     }
@@ -374,7 +386,7 @@ public class CsvReaderTest {
     public void testReadFailure2() throws Exception {
         Table table1 = Table.read().csv("../data/read_failure_test2.csv");
         table1.structure(); // just make sure the import completed
-        NumberColumn test = table1.numberColumn("Test");
+        IntColumn test = table1.intColumn("Test");
 
         //TODO(lwhite): Better tests
         assertNotNull(test.summary());

--- a/core/src/test/java/tech/tablesaw/io/string/DataFramePrinterTest.java
+++ b/core/src/test/java/tech/tablesaw/io/string/DataFramePrinterTest.java
@@ -1,7 +1,7 @@
 package tech.tablesaw.io.string;
 
 import org.junit.Test;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.Table;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -11,7 +11,7 @@ public class DataFramePrinterTest {
 
     @Test
     public void printNull() {
-        NumberColumn col = NumberColumn.create("testCol");
+        DoubleColumn col = DoubleColumn.create("testCol");
         col.append(5.0);
         col.appendCell(null);
         col.append(3.0);

--- a/core/src/test/java/tech/tablesaw/table/RollingColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/table/RollingColumnTest.java
@@ -3,7 +3,7 @@ package tech.tablesaw.table;
 import org.junit.Test;
 import tech.tablesaw.api.BooleanColumn;
 import tech.tablesaw.api.DateTimeColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.columns.numbers.DoubleColumnType;
 
 import java.time.LocalDate;
@@ -19,7 +19,7 @@ public class RollingColumnTest {
         double[] data = new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         double missing = DoubleColumnType.missingValueIndicator();
         double[] sma5 = new double[]{missing, missing, missing, missing, 3, 4, 5, 6, 7, 8};
-        NumberColumn result = NumberColumn.create("data", data).rolling(5).mean();
+        DoubleColumn result = DoubleColumn.create("data", data).rolling(5).mean();
         assertArrayEquals(sma5, result.asDoubleArray(), 0.000001);
         assertEquals("dataMean5", result.name());
     }
@@ -50,7 +50,7 @@ public class RollingColumnTest {
     public void testRollingCountTrue() {
         Boolean[] data = new Boolean[]{true, false, false, true, true};
 
-        NumberColumn result = (NumberColumn) BooleanColumn.create("data", data).rolling(2).calc(countTrue);
+        DoubleColumn result = (DoubleColumn) BooleanColumn.create("data", data).rolling(2).calc(countTrue);
 
         assertEquals(Double.NaN, result.getDouble(0), 0.0);
         assertEquals(1, result.getDouble(1), 0.0);

--- a/core/src/test/java/tech/tablesaw/table/SliceBugTests.java
+++ b/core/src/test/java/tech/tablesaw/table/SliceBugTests.java
@@ -3,7 +3,7 @@ package tech.tablesaw.table;
 import org.junit.Assert;
 import org.junit.Test;
 import tech.tablesaw.api.DateTimeColumn;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 
@@ -56,8 +56,8 @@ public class SliceBugTests {
         TableSliceGroup countrySplit = table.splitOn("countries");
 
         for (TableSlice slice : countrySplit) {
-            NumberColumn priceColFromIndex = slice.numberColumn(2);
-            NumberColumn priceColFromName = slice.numberColumn("price");
+            DoubleColumn priceColFromIndex = slice.doubleColumn(2);
+            DoubleColumn priceColFromName = slice.doubleColumn("price");
 
             Assert.assertTrue("Columns should have same data",
                     Arrays.equals(priceColFromName.asDoubleArray(), priceColFromIndex.asDoubleArray()));
@@ -107,7 +107,7 @@ public class SliceBugTests {
     private Table constructTableFromArrays() {
         StringColumn countries = StringColumn.create("countries", categories);
         DateTimeColumn timestamp = DateTimeColumn.create("sale_timestamp", timestamps);
-        NumberColumn values = NumberColumn.create("price", observations);
+        DoubleColumn values = DoubleColumn.create("price", observations);
 
         return Table.create("table_from_arrays", countries, timestamp, values);
     }

--- a/core/src/test/java/tech/tablesaw/table/TableSliceGroupTest.java
+++ b/core/src/test/java/tech/tablesaw/table/TableSliceGroupTest.java
@@ -14,28 +14,27 @@
 
 package tech.tablesaw.table;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
 import org.apache.commons.math3.stat.StatUtils;
 import org.junit.Before;
 import org.junit.Test;
+
 import tech.tablesaw.aggregate.NumericAggregateFunction;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.csv.CsvReadOptions;
 
-import java.util.List;
-
-import static org.junit.Assert.*;
-
-/**
- *
- */
 public class TableSliceGroupTest {
 
     private static NumericAggregateFunction exaggerate = new NumericAggregateFunction("exageration") {
 
         @Override
-        public Double summarize(NumberColumn data) {
+        public Double summarize(NumericColumn<?> data) {
             return StatUtils.max(data.asDoubleArray()) + 1000;
         }
     };

--- a/core/src/test/java/tech/tablesaw/util/DoubleArraysTest.java
+++ b/core/src/test/java/tech/tablesaw/util/DoubleArraysTest.java
@@ -28,7 +28,7 @@ public class DoubleArraysTest {
     @Test
     public void testTo2dArray() throws Exception {
         Table table = Table.read().csv("../data/tornadoes_1950-2014.csv");
-        TableSliceGroup tableSliceGroup = table.splitOn(table.numberColumn("Scale"));
+        TableSliceGroup tableSliceGroup = table.splitOn("Scale");
         int columnNuumber = table.columnIndex("Injuries");
         DoubleArrays.to2dArray(tableSliceGroup, columnNuumber);
     }

--- a/core/src/test/java/tech/tablesaw/util/StatUtilTest.java
+++ b/core/src/test/java/tech/tablesaw/util/StatUtilTest.java
@@ -15,7 +15,7 @@
 package tech.tablesaw.util;
 
 import org.junit.Test;
-import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.DoubleColumn;
 
 import java.util.Random;
 
@@ -30,7 +30,7 @@ public class StatUtilTest {
     public void testSum() {
         Random random = new Random();
         double sum = 0.0f;
-        NumberColumn column =  NumberColumn.create("c1");
+        DoubleColumn column =  DoubleColumn.create("c1");
         for (int i = 0; i < 100; i++) {
             double f = random.nextDouble();
             column.append(f);
@@ -43,7 +43,7 @@ public class StatUtilTest {
     public void testMin() {
         Random random = new Random();
         double min = Double.MAX_VALUE;
-        NumberColumn column =  NumberColumn.create("c1");
+        DoubleColumn column =  DoubleColumn.create("c1");
         for (int i = 0; i < 100; i++) {
             double f = random.nextDouble();
             column.append(f);
@@ -58,7 +58,7 @@ public class StatUtilTest {
     public void testMax() {
         Random random = new Random();
         double max = Double.MIN_VALUE;
-        NumberColumn column =  NumberColumn.create("c1");
+        DoubleColumn column =  DoubleColumn.create("c1");
         for (int i = 0; i < 100; i++) {
             double f = random.nextDouble();
             column.append(f);

--- a/jsplot/src/main/java/tech/tablesaw/plotly/api/Heatmap.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/api/Heatmap.java
@@ -28,7 +28,7 @@ public class Heatmap {
         counts = counts.dropRows(counts.rowCount() - 1);
         List<Column<?>> columns = counts.columns();
         columns.remove(counts.columnCount() - 1);
-        Column yColumn = columns.remove(0);
+        Column<?> yColumn = columns.remove(0);
         double[][] z = DoubleArrays.to2dArray(columns);
 
         List<String> x = counts.columnNames();

--- a/jsplot/src/main/java/tech/tablesaw/plotly/traces/ScatterTrace.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/traces/ScatterTrace.java
@@ -73,11 +73,11 @@ public class ScatterTrace extends AbstractTrace {
     public static ScatterBuilder builder(DateColumn x, Column<? extends Number> y) {
         return new ScatterBuilder(x, y);
     }
-    public static ScatterBuilder builder(Column x, Column<? extends Number> y) {
+    public static ScatterBuilder builder(Column<?> x, Column<? extends Number> y) {
         return new ScatterBuilder(x, y);
     }
 
-    public static ScatterBuilder builder(Column x, Column<? extends Number> open, Column<? extends Number> high, Column<? extends Number> low, Column<? extends Number> close) {
+    public static ScatterBuilder builder(Column<?> x, Column<? extends Number> open, Column<? extends Number> high, Column<? extends Number> low, Column<? extends Number> close) {
         return new ScatterBuilder(x, open, high, low, close);
     }
 
@@ -229,12 +229,12 @@ public class ScatterTrace extends AbstractTrace {
             this.y = y;
         }
 
-        private ScatterBuilder(Column x, Column<? extends Number> y) {
+        private ScatterBuilder(Column<?> x, Column<? extends Number> y) {
             this.x = x.asObjectArray();
             this.y = y.asDoubleArray();
         }
 
-        private ScatterBuilder(Column x, Column<? extends Number> open, Column<? extends Number> high, Column<? extends Number> low, Column<? extends Number> close) {
+        private ScatterBuilder(Column<?> x, Column<? extends Number> open, Column<? extends Number> high, Column<? extends Number> low, Column<? extends Number> close) {
             this.x = x.asObjectArray();
             this.open = open.asDoubleArray();
             this.high = high.asDoubleArray();

--- a/jsplot/src/main/java/tech/tablesaw/plotly/traces/TraceBuilder.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/traces/TraceBuilder.java
@@ -72,7 +72,7 @@ public abstract class TraceBuilder {
         return this;
     }
 
-    static String[] columnToStringArray(Column column) {
+    static String[] columnToStringArray(Column<?> column) {
         String[] x = new String[column.size()];
         for (int i = 0; i < column.size(); i++) {
             x[i] = column.getString(i);


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

These new `IntColumn` and `FloatColumn` classes are tiny (only 150 lines each), so should be easy to maintain. Having top-level classes for these columns has some nice properties. E.g. we can now say that an `IntColumn` is a `CategoricalColumn`, but a `DoubleColumn` and `FloatColumn` are not

I expect we can do some additional cleanup and testing after this, but this is the last major API change I was thinking about for the column types