### PR TITLE
Move usage of classes from optional dependency to their own class

### DIFF
--- a/core/src/main/java/tech/tablesaw/conversion/SmileConverter.java
+++ b/core/src/main/java/tech/tablesaw/conversion/SmileConverter.java
@@ -1,0 +1,54 @@
+package tech.tablesaw.conversion;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import smile.data.Attribute;
+import smile.data.AttributeDataset;
+import smile.data.NumericAttribute;
+import tech.tablesaw.api.NumericColumn;
+import tech.tablesaw.table.Relation;
+
+public class SmileConverter {
+
+    private final Relation table;
+
+    public SmileConverter(Relation table) {
+        this.table = table;
+    }
+
+    public AttributeDataset dataset(String responseColName) {
+        return dataset(
+            table.numberColumn(responseColName),
+            table.numericColumns().stream().filter(c -> !c.name().equals(responseColName)).collect(Collectors.toList()));
+    }  
+
+    public AttributeDataset dataset(int responseColIndex, int... variablesColIndices) {
+        return dataset(table.numberColumn(responseColIndex), table.numericColumns(variablesColIndices));
+    }  
+
+    public AttributeDataset dataset(String responseColName, String... variablesColNames) {
+        return dataset(table.numberColumn(responseColName), table.numericColumns(variablesColNames));
+    }
+
+    private AttributeDataset dataset(NumericColumn<?> responseCol, List<NumericColumn<?>> variableCols) {
+        AttributeDataset data = new AttributeDataset(table.name(),
+            variableCols.stream().map(this::colToAttribute).toArray(Attribute[]::new),
+            colToAttribute(responseCol));
+        for (int i = 0; i < responseCol.size(); i++) {
+            final int r = i;
+            double[] x = variableCols.stream().mapToDouble(c -> c.getDouble(r)).toArray();
+            data.add(x, responseCol.getDouble(r));
+        }
+        return data;
+    }
+
+    /**
+     * We convert all numberColumns to NumericAttribute. Smile's AttributeDataset only stores data as double.
+     * While Smile defines NominalAttribute and DateAttribute they appear to be little used.
+     */
+    private Attribute colToAttribute(NumericColumn<?> col) {
+        return new NumericAttribute(col.name());
+    }
+
+}

--- a/core/src/main/java/tech/tablesaw/conversion/TableConverter.java
+++ b/core/src/main/java/tech/tablesaw/conversion/TableConverter.java
@@ -1,14 +1,11 @@
 package tech.tablesaw.conversion;
 
+import java.util.List;
+
 import com.google.common.base.Preconditions;
-import smile.data.Attribute;
-import smile.data.AttributeDataset;
-import smile.data.NumericAttribute;
+
 import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.table.Relation;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class TableConverter {
 
@@ -91,40 +88,6 @@ public class TableConverter {
             }
         }
         return allVals;
-    }
-
-    public AttributeDataset smileDataset(String responseColName) {
-        return smileDataset(
-            table.numberColumn(responseColName),
-            table.numericColumns().stream().filter(c -> !c.name().equals(responseColName)).collect(Collectors.toList()));
-    }  
-
-    public AttributeDataset smileDataset(int responseColIndex, int... variablesColIndices) {
-        return smileDataset(table.numberColumn(responseColIndex), table.numericColumns(variablesColIndices));
-    }  
-
-    public AttributeDataset smileDataset(String responseColName, String... variablesColNames) {
-        return smileDataset(table.numberColumn(responseColName), table.numericColumns(variablesColNames));
-    }
-
-    private AttributeDataset smileDataset(NumericColumn<?> responseCol, List<NumericColumn<?>> variableCols) {
-        AttributeDataset data = new AttributeDataset(table.name(),
-            variableCols.stream().map(this::colToAttribute).toArray(Attribute[]::new),
-            colToAttribute(responseCol));
-        for (int i = 0; i < responseCol.size(); i++) {
-            final int r = i;
-            double[] x = variableCols.stream().mapToDouble(c -> c.getDouble(r)).toArray();
-            data.add(x, responseCol.getDouble(r));
-        }
-        return data;
-    }
-
-    /**
-     * We convert all numberColumns to NumericAttribute. Smile's AttributeDataset only stores data as double.
-     * While Smile defines NominalAttribute and DateAttribute they appear to be little used.
-     */
-    private Attribute colToAttribute(NumericColumn<?> col) {
-        return new NumericAttribute(col.name());
     }
 
 }

--- a/core/src/main/java/tech/tablesaw/table/Relation.java
+++ b/core/src/main/java/tech/tablesaw/table/Relation.java
@@ -32,6 +32,7 @@ import tech.tablesaw.api.Table;
 import tech.tablesaw.api.TextColumn;
 import tech.tablesaw.api.TimeColumn;
 import tech.tablesaw.columns.Column;
+import tech.tablesaw.conversion.SmileConverter;
 import tech.tablesaw.conversion.TableConverter;
 import tech.tablesaw.io.string.DataFramePrinter;
 import tech.tablesaw.sorting.comparators.DescendingIntComparator;
@@ -487,6 +488,10 @@ public abstract class Relation {
 
     public TableConverter as() {
         return new TableConverter(this);
+    }
+
+    public SmileConverter smile() {
+        return new SmileConverter(this);
     }
 
     /**


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

@jrvanalstine @lwhite1 this fixes https://github.com/jtablesaw/tablesaw/issues/393

I didn't realize when I originally implemented the `TableConverter` that it would require all classes to be present. I thought it would only require them to be present if the methods using them were called, but that's not true

I'm not sure about the API. Right now I have:
```
.as().doubleMatrix()
.smile().dataset()
```

Would something like the below be better?
```
.asMatrix().doubles()
.asSmile().dataset()
```