### PR TITLE
fix for #395 It's impossible to parse CSV file with more than 512 columns

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReader.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReader.java
@@ -578,6 +578,7 @@ public class CsvReader {
     private CsvParser csvParser(CsvReadOptions options) {
         CsvParserSettings settings = new CsvParserSettings();
         settings.setFormat(csvFormat(options));
+        settings.setMaxColumns(Integer.MAX_VALUE);
         return new CsvParser(settings);
     }
 


### PR DESCRIPTION
[X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

CSVParser columns size changed from 512 to Integer.MAX_VALUE

## Testing

no need for unit tests in this case
