### PR TITLE
Make dependencies for reading data optional

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,29 +91,9 @@
             <version>25.1-jre</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.wnameless</groupId>
-            <artifactId>json-flattener</artifactId>
-            <version>0.6.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.univocity</groupId>
-            <artifactId>univocity-parsers</artifactId>
-            <version>2.7.5</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <version>3.6.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jsoup</groupId>
-            <artifactId>jsoup</artifactId>
-            <version>1.11.3</version>
         </dependency>
         <dependency>
             <groupId>it.unimi.dsi</groupId>
@@ -126,6 +106,24 @@
             <version>0.7.14</version>
         </dependency>
         <dependency>
+            <groupId>com.univocity</groupId>
+            <artifactId>univocity-parsers</artifactId>
+            <version>2.7.5</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.8</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.github.wnameless</groupId>
+            <artifactId>json-flattener</artifactId>
+            <version>0.6.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.github.haifengl</groupId>
             <artifactId>smile-data</artifactId>
             <version>1.5.2 </version>
@@ -135,6 +133,12 @@
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
             <version>4.0.1</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.11.3</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/core/src/main/java/tech/tablesaw/io/DataFrameReader.java
+++ b/core/src/main/java/tech/tablesaw/io/DataFrameReader.java
@@ -40,10 +40,16 @@ import tech.tablesaw.io.xlsx.XlsxReader;
 
 public class DataFrameReader {
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table csv(String file) throws IOException {
         return csv(CsvReadOptions.builder(file));
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table csv(String contents, String tableName) {
         try {
             return csv(new StringReader(contents), tableName);
@@ -52,26 +58,46 @@ public class DataFrameReader {
         }
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table csv(File file) throws IOException {
         return csv(CsvReadOptions.builder(file));
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table csv(InputStream stream, String tableName) throws IOException {
         return csv(CsvReadOptions.builder(stream, tableName));
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table csv(Reader reader, String tableName) throws IOException {
         return csv(CsvReadOptions.builder(reader, tableName));
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table csv(CsvReadOptions.Builder options) throws IOException {
         return csv(options.build());
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table csv(CsvReadOptions options) throws IOException {
         return new CsvReader().read(options);
     }
 
+    /**
+     * Optional dependencies must be added to call this method:
+     * com.fasterxml.jackson.core:jackson-databind
+     * com.github.wnameless:json-flattener
+     */
     public Table json(String url) throws MalformedURLException, IOException {
         try (Scanner scanner = new Scanner(new URL(url).openStream(), StandardCharsets.UTF_8.toString())) {
             scanner.useDelimiter("\\A");
@@ -79,38 +105,64 @@ public class DataFrameReader {
 	}
     }
 
+    /**
+     * Optional dependencies must be added to call this method:
+     * com.fasterxml.jackson.core:jackson-databind
+     * com.github.wnameless:json-flattener
+     */
     public Table json(Reader contents, String tableName) throws IOException {
 	return new JsonReader().read(ReadOptions.builder(contents, tableName).build());
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table fixedWidth(String file) throws IOException {
         return fixedWidth(FixedWidthReadOptions.builder(file));
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table fixedWidth(String contents, String tableName) {
         try {
             return fixedWidth(new StringReader(contents), tableName);
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new IllegalStateException(e);
         }
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table fixedWidth(File file) throws IOException {
         return fixedWidth(FixedWidthReadOptions.builder(file));
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table fixedWidth(InputStream stream, String tableName) throws IOException {
         return fixedWidth(FixedWidthReadOptions.builder(stream, tableName));
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table fixedWidth(Reader reader, String tableName) throws IOException {
         return fixedWidth(FixedWidthReadOptions.builder(reader, tableName));
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table fixedWidth(FixedWidthReadOptions.Builder options) throws IOException {
         return fixedWidth(options.build());
     }
 
+    /**
+     * Optional dependencies must be added to call this method: com.univocity:univocity-parsers
+     */
     public Table fixedWidth(FixedWidthReadOptions options) throws IOException {
         return new FixedWidthReader().read(options);
     }
@@ -119,19 +171,22 @@ public class DataFrameReader {
         return SqlResultSetReader.read(resultSet, tableName);
     }
 
+    /**
+     * Optional dependencies must be added to call this method: org.jsoup:jsoup
+     */
     public Table html(String url) throws IOException {
         return new HtmlTableReader().read(url);
     }
-    
+
     /**
-     * Modules that call this method must add the optional dependency org.apache.poi:poi-ooxml
+     * Optional dependencies must be added to call this method: org.apache.poi:poi-ooxml
      */
     public List<Table> xlsx(XlsxReadOptions options) throws IOException {
         return new XlsxReader().read(options);
     }
 
     /**
-     * Modules that call this method must add the optional dependency org.apache.poi:poi-ooxml
+     * Optional dependencies must be added to call this method: org.apache.poi:poi-ooxml
      */
     public List<Table> xlsx(XlsxReadOptions.Builder options) throws IOException {
         return xlsx(options.build());

--- a/docs/userguide/importing_data.md
+++ b/docs/userguide/importing_data.md
@@ -3,17 +3,26 @@
 Importing data
 ==============
 
-The most common way to get data into Tablesaw is from a CSV file, and the simplest way to do that is:
+To minimize the size of the core library, the dependencies for each reader are optional. You will need to include them in your project to use the `Table.read()` methods.
+
+See the Javadoc for [DataFrameReader](http://static.javadoc.io/tech.tablesaw/tablesaw-core/0.31.0/tech/tablesaw/io/DataFrameReader.html) for a listing of all the `Table.read()` methods that are available.
+
+## Reading CSV files
+
+Add `univocity-parsers` to your project to read CSV or fixed-width files:
+```
+<dependency>
+  <groupId>com.univocity</groupId>
+  <artifactId>univocity-parsers</artifactId>
+  <version>2.7.5</version>
+</dependency>
+```
+
+The easiest way to load data from a CSV file on disk is to use:
 
 ```Java
 Table t = Table.read().csv("myFile.csv");
 ```
-
-You can also load data from a relational database using a JDBC ResultSet. This option is described below, along with variations on the read().csv() syntax, and some helpful utilities.
-
-## Reading CSV files
-
-As shown above, the easiest way to load data from a CSV file on disk is to use ```Table t = Table.read().csv(aFileName);```.
 
 This method supplies defaults for everything but the filename. We assume that columns are separated by commas, and that the file has a header row, which we use to create column names. If one or more defaults are incorrect, you can customize the loading process using the class CsvReadOptions. 
 
@@ -170,7 +179,7 @@ Table restaurants = Table.read()
 		.csv(CsvReadOptions.builder(reader, "restaurants"));
 ```
 
-## Working with Databases
+## Importing from a Database
 
 It's equally easy to create a table from the results of a database query. In this case, you never need to specify the column types, because they are inferred from the database column types. 
 
@@ -191,8 +200,43 @@ try (Statement stmt = conn.createStatement()) {
 }
 ```
 
-## Working with HTML Tables
+## Importing HTML Tables
 
-Tablesaw supports converting data from well-formed HTML tables into CSV files, when there is a single table on a page. See the Javadoc for [HtmlTableReader](http://www.javadoc.io/page/tech.tablesaw/tablesaw-core/latest/tech/tablesaw/io/html/HtmlTableReader.html) for more info.
+Tablesaw supports importing data from HTML tables into Tablesaw tables, when there is a single table on a page. See the Javadoc for [Table.read().html(...)](http://static.javadoc.io/tech.tablesaw/tablesaw-core/0.31.0/tech/tablesaw/io/DataFrameReader.html) for more info. You will need to add the optional dependency:
 
-That covers the major ways to get data into a Tablesaw data set. 
+```
+<dependency>
+  <groupId>org.jsoup</groupId>
+  <artifactId>jsoup</artifactId>
+  <version>1.11.3</version>
+</dependency>
+```
+
+## Importing JSON
+
+Tablesaw supports importing data from JSON into Tablesaw tables. See the Javadoc for [Table.read().json(...)](http://www.javadoc.io/page/tech.tablesaw/tablesaw-core/latest/tech/tablesaw/io/html/HtmlTableReader.html) for more info. You will need to add the optional dependencies:
+
+```
+<dependency>
+  <groupId>com.fasterxml.jackson.core</groupId>
+  <artifactId>jackson-databind</artifactId>
+  <version>2.9.8</version>
+</dependency>
+<dependency>
+  <groupId>com.github.wnameless</groupId>
+  <artifactId>json-flattener</artifactId>
+  <version>0.6.0</version>
+</dependency>
+```
+
+## Importing data from Excel
+
+Tablesaw supports importing data from Excel spreadsheets into Tablesaw tables. See the Javadoc for [Table.read().xlsx(...)](http://static.javadoc.io/tech.tablesaw/tablesaw-core/0.31.0/tech/tablesaw/io/DataFrameReader.html) for more info. You will need to add the optional dependency:
+
+```
+<dependency>
+  <groupId>org.apache.poi</groupId>
+  <artifactId>poi-ooxml</artifactId>
+  <version>4.0.1</version>
+</dependency>
+```


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

When we added the new XlsxReader in https://github.com/jtablesaw/tablesaw/pull/470 we made it an optional feature so as not to automatically pull in the dependencies

This PR does the same with the other reader types for consistency to keep a small core library