### PR TITLE
Remove unused epoch conversion methods

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/dates/PackedLocalDate.java
+++ b/core/src/main/java/tech/tablesaw/columns/dates/PackedLocalDate.java
@@ -21,12 +21,10 @@ import tech.tablesaw.columns.numbers.IntColumnType;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.Month;
-import java.time.ZoneId;
 import java.time.chrono.IsoChronology;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalField;
 import java.time.temporal.WeekFields;
-import java.util.Date;
 import java.util.Locale;
 
 import static java.time.DayOfWeek.FRIDAY;
@@ -111,10 +109,6 @@ public class PackedLocalDate {
                 (short) date.getYear(),
                 (byte) date.getMonthValue(),
                 (byte) date.getDayOfMonth());
-    }
-
-    public static int pack(Date date) {
-        return pack(date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
     }
 
     public static int pack(short yr, byte m, byte d) {

--- a/core/src/main/java/tech/tablesaw/columns/datetimes/PackedLocalDateTime.java
+++ b/core/src/main/java/tech/tablesaw/columns/datetimes/PackedLocalDateTime.java
@@ -20,20 +20,16 @@ import tech.tablesaw.columns.dates.PackedLocalDate;
 import tech.tablesaw.columns.times.PackedLocalTime;
 
 import java.time.DayOfWeek;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.chrono.IsoChronology;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalUnit;
 import java.time.temporal.WeekFields;
-import java.util.Date;
 import java.util.Locale;
 
 import static tech.tablesaw.columns.datetimes.DateTimeColumnType.missingValueIndicator;
@@ -109,13 +105,6 @@ public class PackedLocalDateTime {
         LocalDate date = dateTime.toLocalDate();
         LocalTime time = dateTime.toLocalTime();
         return (pack(date, time));
-    }
-
-    public static long pack(Date date) {
-        if (date == null) {
-            return missingValueIndicator();
-        }
-        return pack(date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
     }
 
     public static long pack(short yr, byte m, byte d, byte hr, byte min, byte s, byte n) {
@@ -422,17 +411,6 @@ public class PackedLocalDateTime {
 
     public static long create(int date, int time) {
         return (((long) date) << 32) | (time & 0xffffffffL);
-    }
-
-    public static long toEpochMilli(long packedLocalDateTime, ZoneOffset offset) {
-        LocalDateTime dateTime = asLocalDateTime(packedLocalDateTime);
-        Instant instant = dateTime.toInstant(offset);
-        return instant.toEpochMilli();
-    }
-
-    public static long ofEpochMilli(long millisecondsSinceEpoch, ZoneId zoneId) {
-        Instant instant = Instant.ofEpochMilli(millisecondsSinceEpoch);
-        return pack(LocalDateTime.ofInstant(instant, zoneId));
     }
 
     public static int lengthOfYear(long packedDateTime) {

--- a/core/src/test/java/tech/tablesaw/columns/datetimes/PackedLocalDateTimeTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/datetimes/PackedLocalDateTimeTest.java
@@ -28,16 +28,12 @@ import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.getMonthValue;
 import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.getSecond;
 import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.getSecondOfDay;
 import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.getYear;
-import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.ofEpochMilli;
 import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.pack;
 import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.time;
-import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.toEpochMilli;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 
 import org.junit.jupiter.api.Test;
@@ -133,11 +129,4 @@ public class PackedLocalDateTimeTest {
         assertEquals(now.get(ChronoField.DAY_OF_WEEK), getDayOfWeek(pack(now)).getValue());
     }
 
-    @Test
-    public void testToEpochMillis() {
-        long now = pack(LocalDateTime.now());
-        long millis = toEpochMilli(now, ZoneOffset.UTC);
-        long now2 = ofEpochMilli(millis, ZoneId.of("UTC"));
-        assertEquals(now, now2);
-    }
 }


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

I'd like to remove these methods because they are unused and also because they rely on `ZoneId.systemDefault()` which will introduce problems by returning different results on different systems

## Testing

N/A
