### PR TITLE
Fixed Smile Nominal Attribute creation and added stratified sampling

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -457,26 +457,24 @@ public class Table extends Relation implements Iterable<Row> {
     
     /**
      * Splits the table into two stratified samples, this uses the specified column to divide the table into groups, randomly assigning records to each according to the proportion given in trainingProportion. 
-     * 
-     *
      * @param column the column to be used for the stratified sampling
      * @param table1Proportion The proportion to go in the first table
      * @return An array two tables, with the first table having the proportion specified in the method parameter,
      * and the second table having the balance of the rows
      */
-    public Table[] stratifiedSampleSplit(CategoricalColumn column, double table1Proportion){
+    public Table[] stratifiedSampleSplit(CategoricalColumn column, double table1Proportion) {
         Preconditions.checkArgument( CategoricalColumn.class.isInstance(this.column(column.name())),
                 "The categorical column must be part of the table, you can create a string column and add it to this table before sampling.");
         final Table first = this.emptyCopy();
         final Table second = this.emptyCopy();
         
         this.splitOn(column).asTableList().forEach(tab-> {
-           Table[] splits = tab.sampleSplit(table1Proportion); 
+            Table[] splits = tab.sampleSplit(table1Proportion); 
             first.append(splits[0]);
             second.append(splits[1]);
         });
         
-        return new Table[]{first, second};
+        return new Table[]{ first, second };
     }
 
     /**

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -463,7 +463,7 @@ public class Table extends Relation implements Iterable<Row> {
      * and the second table having the balance of the rows
      */
     public Table[] stratifiedSampleSplit(CategoricalColumn column, double table1Proportion) {
-        Preconditions.checkArgument( CategoricalColumn.class.isInstance(this.column(column.name())),
+        Preconditions.checkArgument(containsColumn(column),
                 "The categorical column must be part of the table, you can create a string column and add it to this table before sampling.");
         final Table first = this.emptyCopy();
         final Table second = this.emptyCopy();

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -468,7 +468,7 @@ public class Table extends Relation implements Iterable<Row> {
         final Table first = emptyCopy();
         final Table second = emptyCopy();
         
-        this.splitOn(column).asTableList().forEach(tab-> {
+        splitOn(column).asTableList().forEach(tab-> {
             Table[] splits = tab.sampleSplit(table1Proportion); 
             first.append(splits[0]);
             second.append(splits[1]);

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -465,8 +465,8 @@ public class Table extends Relation implements Iterable<Row> {
     public Table[] stratifiedSampleSplit(CategoricalColumn column, double table1Proportion) {
         Preconditions.checkArgument(containsColumn(column),
                 "The categorical column must be part of the table, you can create a string column and add it to this table before sampling.");
-        final Table first = this.emptyCopy();
-        final Table second = this.emptyCopy();
+        final Table first = emptyCopy();
+        final Table second = emptyCopy();
         
         this.splitOn(column).asTableList().forEach(tab-> {
             Table[] splits = tab.sampleSplit(table1Proportion); 

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -454,6 +454,30 @@ public class Table extends Relation implements Iterable<Row> {
         tables[1] = where(table2Selection);
         return tables;
     }
+    
+    /**
+     * Splits the table into two stratified samples, this uses the specified column to divide the table into groups, randomly assigning records to each according to the proportion given in trainingProportion. 
+     * 
+     *
+     * @param column the column to be used for the stratified sampling
+     * @param table1Proportion The proportion to go in the first table
+     * @return An array two tables, with the first table having the proportion specified in the method parameter,
+     * and the second table having the balance of the rows
+     */
+    public Table[] stratifiedSampleSplit(CategoricalColumn column, double table1Proportion){
+        Preconditions.checkArgument( CategoricalColumn.class.isInstance(this.column(column.name())),
+                "The categorical column must be part of the table, you can create a string column and add it to this table before sampling.");
+        final Table first = this.emptyCopy();
+        final Table second = this.emptyCopy();
+        
+        this.splitOn(column).asTableList().forEach(tab-> {
+           Table[] splits = tab.sampleSplit(table1Proportion); 
+            first.append(splits[0]);
+            second.append(splits[1]);
+        });
+        
+        return new Table[]{first, second};
+    }
 
     /**
      * Returns a table consisting of randomly selected records from this table. The sample size is based on the

--- a/core/src/main/java/tech/tablesaw/conversion/smile/SmileConverter.java
+++ b/core/src/main/java/tech/tablesaw/conversion/smile/SmileConverter.java
@@ -110,8 +110,9 @@ public class SmileConverter {
     }
 
     private NominalAttribute colAsNominalAttribute(Column<?> col) {
+        Column<?> unique = col.unique();
         return new NominalAttribute(col.name(),
-            col.unique().mapInto(o -> o.toString(), StringColumn.create(col.name(), col.size())).asObjectArray());
+            unique.mapInto(o -> o.toString(), StringColumn.create(col.name(), unique.size())).asObjectArray());
     }
 
     private static enum AttributeType {

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -214,6 +214,17 @@ public class TableTest {
         Table[] results = t.sampleSplit(.75);
         assertEquals(t.rowCount(), results[0].rowCount() + results[1].rowCount());
     }
+    
+    @Test
+    public void testStratifiedSampleSplit() throws Exception {
+        Table t = Table.read().csv("../data/bush.csv");
+        Table[] results = t.stratifiedSampleSplit(t.stringColumn("who"), .75);
+        assertEquals(t.rowCount(), results[0].rowCount() + results[1].rowCount());
+        int totalFoxCount = t.where(t.stringColumn("who").equalsIgnoreCase("fox")).rowCount();
+        int stratifiedFoxCount = results[0].where(results[0].stringColumn("who").equalsIgnoreCase("fox")).rowCount();
+        
+        assertEquals(.75, (double)stratifiedFoxCount/totalFoxCount, 0.0);
+    }
 
     @Test
     public void testDoWithEachRow() throws Exception {

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -223,7 +223,7 @@ public class TableTest {
         int totalFoxCount = t.where(t.stringColumn("who").equalsIgnoreCase("fox")).rowCount();
         int stratifiedFoxCount = results[0].where(results[0].stringColumn("who").equalsIgnoreCase("fox")).rowCount();
         
-        assertEquals(.75, (double)stratifiedFoxCount/totalFoxCount, 0.0);
+        assertEquals(.75, (double) stratifiedFoxCount/totalFoxCount, 0.0);
     }
 
     @Test

--- a/core/src/test/java/tech/tablesaw/conversion/smile/SmileConverterTest.java
+++ b/core/src/test/java/tech/tablesaw/conversion/smile/SmileConverterTest.java
@@ -37,6 +37,16 @@ public class SmileConverterTest {
         OLS winsModel = new OLS(moneyball.select("W", "RD").smile().numericDataset("RD"));
         assertNotNull(winsModel.toString());
     }
+    
+    @Test
+    public void regressionWithStratifiedSampleTest() throws IOException {
+        Table moneyball = Table.read().csv("../data/baseball.csv");
+        Table[] splits = moneyball.stratifiedSampleSplit(moneyball.stringColumn("Team"), 0.6);
+        Table stratifiedMoneyBall = splits[0];
+        stratifiedMoneyBall.addColumns(stratifiedMoneyBall.numberColumn("RS").subtract(stratifiedMoneyBall.numberColumn("RA")).setName("RD"));
+        OLS winsModel = new OLS(stratifiedMoneyBall.select("W", "RD").smile().numericDataset("RD"));
+        assertNotNull(winsModel.toString());
+    }
 
     @Test
     public void classification() throws IOException {


### PR DESCRIPTION
…column

Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
There was a mistake when creating nominal attribute for smile, it uses the length of the original column and not the unique column. The issue is noticed when you have a reasonable dataset of say 10,000 records and you  are trying to use smile.feature.OneHotEncoder, it creates close to 16,000 columns after encoding from  an original 12 columns and sometimes leading to OutOfMemoryException. 

I added stratified sampling as well

## Testing

For the nominal attribute creation, It already had a unit test  it
For the stratified sampling, I added a test **testStratifiesSampleSplit** to check the  that the proportion of foxes in the split table is equal to the proportion specified for the whole table. 