### PR TITLE
Correct issue #541 : unique values in StringColumns

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/strings/ByteDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/ByteDictionaryMap.java
@@ -90,16 +90,6 @@ public class ByteDictionaryMap implements DictionaryMap {
         return values.getByte(rowIndex);
     }
 
-    /**
-     * Returns true if we have seen this stringValue before, and it hasn't been removed.
-     * <p>
-     * NOTE: An answer of true does not imply that the column still contains the value, only that
-     * it is in the dictionary map
-     */
-    private boolean contains(String stringValue) {
-        return valueToKey.containsKey(stringValue);
-    }
-
     private Set<String> categories() {
         return valueToKey.keySet();
     }
@@ -131,18 +121,8 @@ public class ByteDictionaryMap implements DictionaryMap {
         this.values = new ByteArrayList(elements);
     }
 
-    public int countOccurrences(String value) { // TODO: optimize using new count map
-        if (!contains(value)) {
-            return 0;
-        }
-        byte key = getKeyForValue(value);
-        int count = 0;
-        for (byte k : values) {
-            if (k == key) {
-                count++;
-            }
-        }
-        return count;
+    public int countOccurrences(String value) {
+    	return keyToCount.get(getKeyForValue(value));
     }
 
     public Set<String> asSet() {
@@ -260,6 +240,7 @@ public class ByteDictionaryMap implements DictionaryMap {
         if (keyToCount.addTo(oldKey, -1) == 1) {
         	String obsoleteValue = keyToValue.remove(oldKey);
         	valueToKey.removeByte(obsoleteValue);
+        	keyToCount.remove(oldKey);
         }
     }
 
@@ -279,27 +260,14 @@ public class ByteDictionaryMap implements DictionaryMap {
     /**
      */
     @Override
-    public Table countByCategory(String columnName) { // TODO: optimize with new count map
+    public Table countByCategory(String columnName) {
         Table t = Table.create("Column: " + columnName);
         StringColumn categories = StringColumn.create("Category");
         IntColumn counts = IntColumn.create("Count");
-
-        Byte2IntMap valueToCount = new Byte2IntOpenHashMap();
-
-        for (byte next : values) {
-            if (valueToCount.containsKey(next)) {
-                valueToCount.put(next, valueToCount.get(next) + 1);
-            } else {
-                valueToCount.put(next, 1);
-            }
-        }
-        for (Map.Entry<Byte, Integer> entry : valueToCount.byte2IntEntrySet()) {
+        // Now uses the keyToCount map
+        for (Map.Entry<Byte, Integer> entry : keyToCount.byte2IntEntrySet()) {
             categories.append(getValueForKey(entry.getKey()));
             counts.append(entry.getValue());
-        }
-        if (countMissing() > 0) {
-            categories.append("* missing values");
-            counts.append(countMissing());
         }
         t.addColumns(categories);
         t.addColumns(counts);
@@ -363,14 +331,8 @@ public class ByteDictionaryMap implements DictionaryMap {
      * Returns the count of missing values in this column
      */
     @Override
-    public int countMissing() { // TODO: optimize with new count map
-        int count = 0;
-        for (int i = 0; i < size(); i++) {
-            if (MISSING_VALUE == getKeyForIndex(i)) {
-                count++;
-            }
-        }
-        return count;
+    public int countMissing() {
+    	return keyToCount.get(MISSING_VALUE);
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/columns/strings/ByteDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/ByteDictionaryMap.java
@@ -121,7 +121,7 @@ public class ByteDictionaryMap implements DictionaryMap {
     }
 
     public int countOccurrences(String value) {
-    	return keyToCount.get(getKeyForValue(value));
+        return keyToCount.get(getKeyForValue(value));
     }
 
     public Set<String> asSet() {
@@ -237,9 +237,9 @@ public class ByteDictionaryMap implements DictionaryMap {
         byte oldKey = values.set(rowIndex, valueId);
         keyToCount.addTo(valueId, 1);
         if (keyToCount.addTo(oldKey, -1) == 1) {
-        	String obsoleteValue = keyToValue.remove(oldKey);
-        	valueToKey.removeByte(obsoleteValue);
-        	keyToCount.remove(oldKey);
+            String obsoleteValue = keyToValue.remove(oldKey);
+            valueToKey.removeByte(obsoleteValue);
+            keyToCount.remove(oldKey);
         }
     }
 
@@ -331,7 +331,7 @@ public class ByteDictionaryMap implements DictionaryMap {
      */
     @Override
     public int countMissing() {
-    	return keyToCount.get(MISSING_VALUE);
+        return keyToCount.get(MISSING_VALUE);
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/columns/strings/ByteDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/ByteDictionaryMap.java
@@ -1,6 +1,5 @@
 package tech.tablesaw.columns.strings;
 
-import it.unimi.dsi.fastutil.bytes.Byte2IntMap;
 import it.unimi.dsi.fastutil.bytes.Byte2IntOpenHashMap;
 import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
 import it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap;

--- a/core/src/main/java/tech/tablesaw/columns/strings/IntDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/IntDictionaryMap.java
@@ -125,7 +125,7 @@ public class IntDictionaryMap implements DictionaryMap {
     }
 
     public int countOccurrences(String value) {
-    	return keyToCount.get(getKeyForValue(value));
+        return keyToCount.get(getKeyForValue(value));
     }
 
     public Set<String> asSet() {
@@ -244,9 +244,9 @@ public class IntDictionaryMap implements DictionaryMap {
         int oldKey = values.set(rowIndex, valueId);
         keyToCount.addTo(valueId, 1);
         if (keyToCount.addTo(oldKey, -1) == 1) {
-        	String obsoleteValue = keyToValue.remove(oldKey);
-        	valueToKey.removeInt(obsoleteValue);
-        	keyToCount.remove(oldKey);
+            String obsoleteValue = keyToValue.remove(oldKey);
+            valueToKey.removeInt(obsoleteValue);
+            keyToCount.remove(oldKey);
         }
     }
 
@@ -333,7 +333,7 @@ public class IntDictionaryMap implements DictionaryMap {
      */
     @Override
     public int countMissing() {
-    	return keyToCount.get(MISSING_VALUE);
+        return keyToCount.get(MISSING_VALUE);
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/columns/strings/IntDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/IntDictionaryMap.java
@@ -1,6 +1,5 @@
 package tech.tablesaw.columns.strings;
 
-import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;

--- a/core/src/main/java/tech/tablesaw/columns/strings/ShortDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/ShortDictionaryMap.java
@@ -48,16 +48,19 @@ public class ShortDictionaryMap implements DictionaryMap {
 
     private final AtomicInteger nextIndex = new AtomicInteger(DEFAULT_RETURN_VALUE);
 
-    // we maintain two maps, one from strings to keys, and the second from keys to strings.
+    // we maintain 3 maps, one from strings to keys, one from keys to strings, and one from key to count of values
     private final Short2ObjectMap<String> keyToValue = new Short2ObjectOpenHashMap<>();
 
     private final Object2ShortOpenHashMap<String> valueToKey = new Object2ShortOpenHashMap<>();
+    
+    private final Short2IntOpenHashMap keyToCount = new Short2IntOpenHashMap();
 
     /**
      * Returns a new DictionaryMap that is a deep copy of the original
      */
     ShortDictionaryMap(DictionaryMap original) throws NoKeysAvailableException {
         valueToKey.defaultReturnValue(DEFAULT_RETURN_VALUE);
+        keyToCount.defaultReturnValue(0);
 
         for (int i = 0; i < original.size(); i++) {
             String value = original.getValueForIndex(i);
@@ -136,7 +139,7 @@ public class ShortDictionaryMap implements DictionaryMap {
         this.values = new ShortArrayList(elements);
     }
 
-    public int countOccurrences(String value) {
+    public int countOccurrences(String value) { // TODO: optimize using new count map
         if (!contains(value)) {
             return 0;
         }
@@ -224,6 +227,7 @@ public class ShortDictionaryMap implements DictionaryMap {
             put(key, value);
         }
         values.add(key);
+        keyToCount.addTo(key, 1);
     }
 
     private short getValueId() throws NoKeysAvailableException {
@@ -262,7 +266,12 @@ public class ShortDictionaryMap implements DictionaryMap {
             valueId = getValueId();
             put(valueId, str);
         }
-        values.set(rowIndex, valueId);
+        short oldKey = values.set(rowIndex, valueId);
+        keyToCount.addTo(valueId, 1);
+        if (keyToCount.addTo(oldKey, -1) == 1) {
+        	String obsoleteValue = keyToValue.remove(oldKey);
+        	valueToKey.removeShort(obsoleteValue);
+        }
     }
 
     @Override
@@ -270,12 +279,13 @@ public class ShortDictionaryMap implements DictionaryMap {
         values.clear();
         keyToValue.clear();
         valueToKey.clear();
+        keyToCount.clear();
     }
 
     /**
      */
     @Override
-    public Table countByCategory(String columnName) {
+    public Table countByCategory(String columnName) { // TODO: optimize with new count map
         Table t = Table.create("Column: " + columnName);
         StringColumn categories = StringColumn.create("Category");
         IntColumn counts = IntColumn.create("Count");
@@ -359,7 +369,7 @@ public class ShortDictionaryMap implements DictionaryMap {
      * Returns the count of missing values in this column
      */
     @Override
-    public int countMissing() {
+    public int countMissing() { // TODO: optimize with new count map
         int count = 0;
         for (int i = 0; i < size(); i++) {
             if (MISSING_VALUE == getKeyForIndex(i)) {

--- a/core/src/main/java/tech/tablesaw/columns/strings/ShortDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/ShortDictionaryMap.java
@@ -129,7 +129,7 @@ public class ShortDictionaryMap implements DictionaryMap {
     }
 
     public int countOccurrences(String value) {
-    	return keyToCount.get(getKeyForValue(value));
+        return keyToCount.get(getKeyForValue(value));
     }
 
     public Set<String> asSet() {
@@ -248,9 +248,9 @@ public class ShortDictionaryMap implements DictionaryMap {
         short oldKey = values.set(rowIndex, valueId);
         keyToCount.addTo(valueId, 1);
         if (keyToCount.addTo(oldKey, -1) == 1) {
-        	String obsoleteValue = keyToValue.remove(oldKey);
-        	valueToKey.removeShort(obsoleteValue);
-        	keyToCount.remove(oldKey);
+            String obsoleteValue = keyToValue.remove(oldKey);
+            valueToKey.removeShort(obsoleteValue);
+            keyToCount.remove(oldKey);
         }
     }
 
@@ -337,7 +337,7 @@ public class ShortDictionaryMap implements DictionaryMap {
      */
     @Override
     public int countMissing() {
-    	return keyToCount.get(MISSING_VALUE);
+        return keyToCount.get(MISSING_VALUE);
     }
 
     @Override

--- a/core/src/main/java/tech/tablesaw/columns/strings/ShortDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/ShortDictionaryMap.java
@@ -1,7 +1,6 @@
 package tech.tablesaw.columns.strings;
 
 import it.unimi.dsi.fastutil.objects.Object2ShortOpenHashMap;
-import it.unimi.dsi.fastutil.shorts.Short2IntMap;
 import it.unimi.dsi.fastutil.shorts.Short2IntOpenHashMap;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMap;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;

--- a/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
@@ -529,4 +529,22 @@ TODO: fix
         }
         assertArrayEquals(expected, result, 0.000_000_1);
     }
-}
+
+    @Test
+    public void countUniqueSetEmpty() {
+        StringColumn col = StringColumn.create("col1", 2);
+        col.set(0, "A");
+        col.set(1, "B");
+        assertEquals(2, col.countUnique());
+    }
+
+    @Test
+    public void countUniqueSetAfterAppend() {
+        StringColumn col = StringColumn.create("col1");
+        col.append("A");
+        col.append("B");
+        assertEquals(2, col.countUnique());
+        col.set(0, "C");
+        col.set(1, "D");
+        assertEquals(2, col.countUnique());
+    }}

--- a/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
@@ -531,20 +531,108 @@ TODO: fix
     }
 
     @Test
-    public void countUniqueSetEmpty() {
+    public void countUniqueSetAfterCreateByteDict() {
         StringColumn col = StringColumn.create("col1", 2);
+        assertEquals(1, col.countUnique(), "Wrong number of unique values after StringColumn.create");
+        assertEquals(2, col.countMissing(), "Wrong number of missing values after StringColumn.create");
         col.set(0, "A");
         col.set(1, "B");
-        assertEquals(2, col.countUnique());
+        assertEquals(2, col.countUnique(), "Wrong number of unique values after Column.set");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.set");
+        col.clear();
+        assertEquals(0, col.countUnique(), "Wrong number of unique values after Column.clear");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.clear");
     }
 
     @Test
-    public void countUniqueSetAfterAppend() {
+    public void countUniqueSetAfterAppendByteDict() {
         StringColumn col = StringColumn.create("col1");
+        assertEquals(0, col.countUnique(), "Wrong number of unique values after StringColumn.create");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after StringColumn.create");
         col.append("A");
         col.append("B");
-        assertEquals(2, col.countUnique());
+        assertEquals(2, col.countUnique(), "Wrong number of unique values after Column.set");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.set");
         col.set(0, "C");
         col.set(1, "D");
-        assertEquals(2, col.countUnique());
-    }}
+        assertEquals(2, col.countUnique(), "Wrong number of unique values after Column.set");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.set");
+        col.clear();
+        assertEquals(0, col.countUnique(), "Wrong number of unique values after Column.clear");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.clear");
+    }
+
+    @Test
+    public void countUniqueSetAfterCreateShortDict() {
+        int size = Byte.MAX_VALUE - Byte.MIN_VALUE + 1;
+		StringColumn col = StringColumn.create("col1", size);
+        assertEquals(1, col.countUnique(), "Wrong number of unique values after StringColumn.create");
+        assertEquals(size, col.countMissing(), "Wrong number of missing values after StringColumn.create");
+        for (int i = size; --i >= 0; ) {
+            col.set(i, Integer.toString(i));
+        }
+        assertEquals(size, col.countUnique(), "Wrong number of unique values after Column.set");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.set");
+        col.clear();
+        assertEquals(0, col.countUnique(), "Wrong number of unique values after Column.clear");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.clear");
+    }
+
+    @Test
+    public void countUniqueSetAfterAppendShortDict() {
+        StringColumn col = StringColumn.create("col1");
+        assertEquals(0, col.countUnique(), "Wrong number of unique values after StringColumn.create");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after StringColumn.create");
+        int size = Byte.MAX_VALUE - Byte.MIN_VALUE + 1;
+        for (int i = size; --i >= 0; ) {
+            col.append(Integer.toString(i));
+        }
+        assertEquals(size, col.countUnique(), "Wrong number of unique values after Column.set");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.set");
+        for (int i = size; --i >= 0; ) {
+            col.set(i, "A" + Integer.toString(i));
+        }
+        assertEquals(size, col.countUnique(), "Wrong number of unique values after Column.set");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.set");
+        col.clear();
+        assertEquals(0, col.countUnique(), "Wrong number of unique values after Column.clear");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.clear");
+    }
+
+    @Test
+    public void countUniqueSetAfterCreateIntDict() {
+        int size = Short.MAX_VALUE - Short.MIN_VALUE + 1;
+		StringColumn col = StringColumn.create("col1", size);
+        assertEquals(1, col.countUnique(), "Wrong number of unique values after StringColumn.create");
+        assertEquals(size, col.countMissing(), "Wrong number of missing values after StringColumn.create");
+        for (int i = size; --i >= 0; ) {
+            col.set(i, Integer.toString(i));
+        }
+        assertEquals(size, col.countUnique(), "Wrong number of unique values after Column.set");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.set");
+        col.clear();
+        assertEquals(0, col.countUnique(), "Wrong number of unique values after Column.clear");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.clear");
+    }
+
+    @Test
+    public void countUniqueSetAfterAppendIntDict() {
+        StringColumn col = StringColumn.create("col1");
+        assertEquals(0, col.countUnique(), "Wrong number of unique values after StringColumn.create");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after StringColumn.create");
+        int size = Short.MAX_VALUE - Short.MIN_VALUE + 1;
+        for (int i = size; --i >= 0; ) {
+            col.append(Integer.toString(i));
+        }
+        assertEquals(size, col.countUnique(), "Wrong number of unique values after Column.set");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.set");
+        for (int i = size; --i >= 0; ) {
+            col.set(i, "A" + Integer.toString(i));
+        }
+        assertEquals(size, col.countUnique(), "Wrong number of unique values after Column.set");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.set");
+        col.clear();
+        assertEquals(0, col.countUnique(), "Wrong number of unique values after Column.clear");
+        assertEquals(0, col.countMissing(), "Wrong number of missing values after Column.clear");
+    }
+}


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Implemented instance counting in all DictionaryMap implementations.

key/values are removed from all maps when value count reaches 0, so all operations based on these maps are always correct.
The only modified methods are set(), append() and clear(). There is no impact on other methods.
All count-based methods now uses the count map for performance.

Fixes #541 

## Testing

Added unit tests showing previous issue with StringColumn unique values counting

## Notes

* The new map member references the implementation used instead of the interface so we can use the addTo() method
* Now unused private contains() method was removed