### PR TITLE
Add mapToType Columns

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
+++ b/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
@@ -14,8 +14,24 @@
 
 package tech.tablesaw.columns;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.function.Function;
+import tech.tablesaw.api.BooleanColumn;
 import tech.tablesaw.api.ColumnType;
+import tech.tablesaw.api.DateColumn;
+import tech.tablesaw.api.DateTimeColumn;
+import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.FloatColumn;
+import tech.tablesaw.api.InstantColumn;
+import tech.tablesaw.api.IntColumn;
+import tech.tablesaw.api.LongColumn;
+import tech.tablesaw.api.ShortColumn;
 import tech.tablesaw.api.StringColumn;
+import tech.tablesaw.api.TextColumn;
+import tech.tablesaw.api.TimeColumn;
 
 /**
  * Partial implementation of the {@link Column} interface
@@ -64,5 +80,185 @@ public abstract class AbstractColumn<T> implements Column<T> {
             sc.append(String.valueOf(value));
         }
         return sc;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new BooleanColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into BooleanColumn.
+     * @return BooleanColumn with the results appended.
+     */
+    public BooleanColumn mapToBooleanColumn(String name, Function<? super T, ? extends Boolean> function) {
+        BooleanColumn newColumn = BooleanColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new DateColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into DateColumn.
+     * @return DateColumn with the results appended.
+     */
+    public DateColumn mapToDateColumn(String name, Function<? super T, ? extends LocalDate> function) {
+        DateColumn newColumn = DateColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new DateTimeColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into DateTimeColumn.
+     * @return DateTimeColumn with the results appended.
+     */
+    public DateTimeColumn mapToDateTimeColumn(String name, Function<? super T, ? extends LocalDateTime> function) {
+        DateTimeColumn newColumn = DateTimeColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new DoubleColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into DoubleColumn.
+     * @return DoubleColumn with the results appended.
+     */
+    public DoubleColumn mapToDoubleColumn(String name, Function<? super T, ? extends Double> function) {
+        DoubleColumn newColumn = DoubleColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new FloatColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into FloatColumn.
+     * @return FloatColumn with the results appended.
+     */
+    public FloatColumn mapToFloatColumn(String name, Function<? super T, ? extends Float> function) {
+        FloatColumn newColumn = FloatColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new InstantColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into InstantColumn.
+     * @return InstantColumn with the results appended.
+     */
+    public InstantColumn mapToInstantColumn(String name, Function<? super T, ? extends Instant> function) {
+        InstantColumn newColumn = InstantColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new IntColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into IntColumn.
+     * @return IntColumn with the results appended.
+     */
+    public IntColumn mapToIntColumn(String name, Function<? super T, ? extends Integer> function) {
+        IntColumn newColumn = IntColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new LongColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into LongColumn.
+     * @return LongColumn with the results appended.
+     */
+    public LongColumn mapToLongColumn(String name, Function<? super T, ? extends Long> function) {
+        LongColumn newColumn = LongColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new ShortColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into ShortColumn.
+     * @return ShortColumn with the results appended.
+     */
+    public ShortColumn mapToShortColumn(String name, Function<? super T, ? extends Short> function) {
+        ShortColumn newColumn = ShortColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new StringColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into StringColumn.
+     * @return StringColumn with the results appended.
+     */
+    public StringColumn mapToStringColumn(String name, Function<? super T, ? extends String> function) {
+        StringColumn newColumn = StringColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new TextColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into TextColumn.
+     * @return TextColumn with the results appended.
+     */
+    public TextColumn mapToTextColumn(String name, Function<? super T, ? extends String> function) {
+        TextColumn newColumn = TextColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
+    }
+
+    /**
+     * Maps the function across all rows, appending the results to a new TimeColumn.
+     *
+     * Ignores missing values.
+     *
+     * @param name of the new column.
+     * @param function to map current column into TimeColumn.
+     * @return TimeColumn with the results appended.
+     */
+    public TimeColumn mapToTimeColumn(String name, Function<? super T, ? extends LocalTime> function) {
+        TimeColumn newColumn = TimeColumn.create(name, size());
+        mapInto(function, newColumn);
+        return newColumn;
     }
 }

--- a/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
@@ -14,6 +14,7 @@
 
 package tech.tablesaw.api;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -34,5 +35,17 @@ public class FloatColumnTest {
         final Float floatObject = 2.5f;
         floatColumn.append(floatObject);
         assertEquals(floatObject, floatColumn.get(0));
+    }
+
+    @Test
+    public void testMapToDouble() {
+        FloatColumn column = FloatColumn.create("testing");
+        column.append(1.0f);
+        column.append(2.0f);
+        column.append(3.0f);
+
+        DoubleColumn actual = column.mapToDoubleColumn("doubles", (x) -> 2.0 * x);
+
+        assertArrayEquals(new double[]{2.0, 4.0, 6.0}, actual.asDoubleArray());
     }
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Helps with #538

Added mapToType columns making it easier to map a column to a different type. Such as int -> LocalDate. The mapToType methods are a then wrapper onto the existing mapInto method.

## Testing

Added unit tests for a single type. Can add unit tests for every type if needed.