### PR TITLE
Fix bug in TableSliceGroup.aggregate when aggregating over multiple c…

### DIFF
--- a/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
+++ b/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
@@ -153,16 +153,16 @@ public class TableSliceGroup implements Iterable<TableSlice> {
         Table groupTable = summaryTableName(sourceTable);
         StringColumn groupColumn = StringColumn.create("Group");
         groupTable.addColumns(groupColumn);
+        boolean firstFunction = true;
         for (Map.Entry<String, Collection<AggregateFunction<?,?>>> entry : functions.asMap().entrySet()) {
             String columnName = entry.getKey();
-            int functionCount = 0;
             for (AggregateFunction function : entry.getValue()) {
                 String colName = aggregateColumnName(columnName, function.functionName());
                 ColumnType type = function.returnType();
                 Column resultColumn = type.create(colName);
                 for (TableSlice subTable : getSlices()) {
                     Object result = function.summarize(subTable.column(columnName));
-                    if (functionCount == 0) {
+                    if (firstFunction) {
                         groupColumn.append(subTable.name());
                     }
                     if (result instanceof Number) {
@@ -173,7 +173,7 @@ public class TableSliceGroup implements Iterable<TableSlice> {
                     }
                 }
                 groupTable.addColumns(resultColumn);
-                functionCount++;
+                firstFunction = false;
             }
         }
         return splitGroupingColumn(groupTable);

--- a/core/src/test/java/tech/tablesaw/table/TableSliceGroupTest.java
+++ b/core/src/test/java/tech/tablesaw/table/TableSliceGroupTest.java
@@ -17,6 +17,7 @@ package tech.tablesaw.table;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.ImmutableListMultimap;
 import java.util.List;
 
 import org.apache.commons.math3.stat.StatUtils;
@@ -86,5 +87,21 @@ public class TableSliceGroupTest {
         TableSliceGroup group = StandardTableSliceGroup.create(table, "who");
         List<Table> tables = group.asTableList();
         assertEquals(6, tables.size());
+    }
+
+    @Test
+    public void aggregate() {
+        TableSliceGroup group = StandardTableSliceGroup.create(table, table.categoricalColumn("who"));
+        Table aggregated = group.aggregate("approval", exaggerate);
+        assertEquals(aggregated.rowCount(), group.size());
+    }
+
+    @Test
+    public void aggregateWithMultipleColumns() {
+        table.addColumns(table.categoricalColumn("approval").copy().setName("approval2"));
+        TableSliceGroup group = StandardTableSliceGroup.create(table, table.categoricalColumn("who"));
+
+        Table aggregated = group.aggregate(ImmutableListMultimap.of("approval", exaggerate, "approval2", exaggerate));
+        assertEquals(aggregated.rowCount(), group.size());
     }
 }


### PR DESCRIPTION

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Fixes #557 

TableSliceGroup.aggregate was failing when aggregating over multiple columns.

The slice name was appended to the result table a second time when during the aggregation of the second column. This caused the result column to have to contain twice a many rows and the aggregation to fail.

What was changed
Add the slice name to the result table exactly once.

## Testing

Yes. Added a failing test and then fixed the bug causing the test to pass.