### PR TITLE
Fix Inner Join when one table has a single column

### DIFF
--- a/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
+++ b/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
@@ -276,11 +276,10 @@ public class DataFrameJoiner {
             }
 
             Table table2Rows = table2.where(rowBitMapMultiCol);
-            table2Rows.removeColumns(col2Names);
             if (outer && table2Rows.isEmpty()) {
                 withMissingLeftJoin(result, table1Rows);
             } else {
-                crossProduct(result, table1Rows, table2Rows);
+                crossProduct(result, table1Rows, table2Rows, col2Names);
             }
         }
         return result;
@@ -649,10 +648,13 @@ public class DataFrameJoiner {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private void crossProduct(Table destination, Table table1, Table table2) {
+    private void crossProduct(Table destination, Table table1, Table table2, String[] col2Names) {
+        int table2RowCount = table2.rowCount();
+        // Remove join columns
+        table2.removeColumns(col2Names);
         for (int c = 0; c < table1.columnCount() + table2.columnCount(); c++) {
             for (int r1 = 0; r1 < table1.rowCount(); r1++) {
-                for (int r2 = 0; r2 < table2.rowCount(); r2++) {
+                for (int r2 = 0; r2 < table2RowCount; r2++) {
                     if (c < table1.columnCount()) {
                         Column t1Col = table1.column(c);
                         destination.column(c).append(t1Col, r1);

--- a/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerTest.java
+++ b/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerTest.java
@@ -489,6 +489,37 @@ public class DataFrameJoinerTest {
     }
 
     @Test
+    public void innerJoinSingleColumn() {
+        Table joined = SP500.select("Date").joinOn("Date")
+            .inner(ONE_YEAR.select("Date"));
+        assertEquals(5, joined.rowCount());
+        assertEquals(1, joined.columnCount());
+    }
+
+    @Test
+    public void innerJoinSingleColumnOnRight() {
+        Table joined = SP500.joinOn("Date").inner(ONE_YEAR.select("Date"));
+        assertEquals(5, joined.rowCount());
+        assertEquals(2, joined.columnCount());
+    }
+
+    @Test
+    public void innerJoinMultipleColumnsAllColumnsInJoinKey() {
+        Table table1 = Table.create(
+            SP500.dateColumn("Date"),
+            SP500.dateColumn("Date").copy().setName("Date2")
+        );
+        Table table2 = Table.create(
+            ONE_YEAR.dateColumn("Date"),
+            ONE_YEAR.dateColumn("Date").copy().setName("Date2")
+        );
+
+        Table joined = table1.joinOn("Date", "Date2").inner(table2);
+        assertEquals(5, joined.rowCount());
+        assertEquals(2, joined.columnCount());
+    }
+
+    @Test
     public void innerJoinWithBoolean() {
         Table joined = DUPLICATE_COL_NAME_DOGS.joinOn("Good")
                 .inner(true, DUPLICATE_COL_NAME_DOGS.copy());
@@ -571,6 +602,13 @@ public class DataFrameJoinerTest {
         assertEquals(2, joined.column("Name").countMissing());
         assertEquals(8, joined.column("Feed").size());
         assertEquals(2, joined.column("Feed").countMissing());
+    }
+
+    @Test
+    public void fullOuterJoinColTwoOnlyJoinKeys() {
+        Table joined = ANIMAL_FEED.joinOn("Animal").fullOuter(ANIMAL_NAMES.select("Animal"));
+        assertEquals(2, joined.columnCount());
+        assertEquals(8, joined.rowCount());
     }
 
     @Test


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Fix joins when one or both tables only contains join columns. Fixes #381 

## Testing

Added tests for 
* inner join where both tables contain single column
* inner join where only right table contains single column.
* inner join where both tables contain only join keys.
* outer join where right table contains single column.
