### PR TITLE
added null support for SqlResultSetReader

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
+++ b/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
@@ -16,6 +16,8 @@ package tech.tablesaw.io.jdbc;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+
+import tech.tablesaw.api.BooleanColumn;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.FloatColumn;
@@ -117,6 +119,8 @@ public class SqlResultSetReader {
                 	appendToColumn(column, resultSet, resultSet.getFloat(i));
                 } else if (column instanceof DoubleColumn) {
                 	appendToColumn(column, resultSet, resultSet.getDouble(i));
+                } else if (column instanceof BooleanColumn) {
+                	appendToColumn(column, resultSet, resultSet.getBoolean(i));                
                 } else {
                     column.appendObj(resultSet.getObject(i));
                 }

--- a/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
+++ b/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
@@ -108,21 +108,29 @@ public class SqlResultSetReader {
             for (int i = 1; i <= metaData.getColumnCount(); i++) {
                 Column<?> column = table.column(i - 1); // subtract 1 because results sets originate at 1 not 0
                 if (column instanceof ShortColumn) {
-                    column.appendObj(resultSet.getShort(i));
+                	appendToColumn(column, resultSet, resultSet.getShort(i));
                 } else if (column instanceof IntColumn) {
-                    column.appendObj(resultSet.getInt(i));
+                	appendToColumn(column, resultSet, resultSet.getInt(i));
                 } else if (column instanceof LongColumn) {
-                    column.appendObj(resultSet.getLong(i));
+                	appendToColumn(column, resultSet, resultSet.getLong(i));
                 } else if (column instanceof FloatColumn) {
-                    column.appendObj(resultSet.getFloat(i));
+                	appendToColumn(column, resultSet, resultSet.getFloat(i));
                 } else if (column instanceof DoubleColumn) {
-                    column.appendObj(resultSet.getDouble(i));
+                	appendToColumn(column, resultSet, resultSet.getDouble(i));
                 } else {
                     column.appendObj(resultSet.getObject(i));
                 }
             }
         }
         return table;
+    }
+    
+    protected static void appendToColumn(Column<?> column, ResultSet resultSet, Object value) throws SQLException {
+    	if (resultSet.wasNull()) {
+    		column.appendMissing();
+    	} else {
+    		column.appendObj(value);
+    	}
     }
     
     protected static ColumnType getColumnType(int columnType, int scale, int precision) {

--- a/core/src/test/java/tech/tablesaw/io/jdbc/SqlResultSetReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/jdbc/SqlResultSetReaderTest.java
@@ -65,6 +65,9 @@ public class SqlResultSetReaderTest {
         // Build the OracleNumbers table.
         TestDb.buildNumbersTable(conn);
         
+        // Build the NullValues table.
+        TestDb.buildNullValuesTable(conn);
+        
         try (Statement stmt = conn.createStatement()) {
             String sql;
 
@@ -106,6 +109,20 @@ public class SqlResultSetReaderTest {
                 assertTrue(numbers.column("NumFloat7_7").type() instanceof FloatColumnType);
                 assertTrue(numbers.column("NumDouble7_8").type() instanceof DoubleColumnType);
                 assertTrue(numbers.column("NumDouble7_16").type() instanceof DoubleColumnType);
+            }
+            
+            sql = "SELECT * FROM NullValues";
+            try (ResultSet rs = stmt.executeQuery(sql)) {
+                Table nullValues = SqlResultSetReader.read(rs);
+                assertEquals(8, nullValues.columnCount());
+                assertEquals(3, nullValues.rowCount());
+                assertEquals(2, nullValues.column("StringValue").removeMissing().size());
+                assertEquals(1, nullValues.column("DoubleValue").removeMissing().size());
+                assertEquals(2, nullValues.column("IntegerValue").removeMissing().size());
+                assertEquals(1, nullValues.column("ShortValue").removeMissing().size());
+                assertEquals(1, nullValues.column("LongValue").removeMissing().size());
+                assertEquals(1, nullValues.column("FloatValue").removeMissing().size());
+                assertEquals(1, nullValues.column("BooleanValue").removeMissing().size());
             }
 
         }

--- a/core/src/test/java/tech/tablesaw/util/TestDb.java
+++ b/core/src/test/java/tech/tablesaw/util/TestDb.java
@@ -101,6 +101,14 @@ public class TestDb {
                 // No need to report an error.
                 // The table simply did not exist.
             }
+            
+            try {
+                // Drop the NullValues table.
+                stmt.execute("DROP TABLE NullValues");
+            } catch (SQLException ex) {
+                // No need to report an error.
+                // The table simply did not exist.
+            }
         } catch (SQLException ex) {
             System.out.println("ERROR: " + ex.getMessage());
             ex.printStackTrace();
@@ -390,5 +398,50 @@ public class TestDb {
         }
     }
 
+    /**
+     * The buildNullValues method creates the
+     * NullValues table and adds some rows to it.
+     */
+    public static void buildNullValuesTable(Connection conn) {
+        try {
+            // Get a Statement object.
+            Statement stmt = conn.createStatement();
+
+            // Create the table.
+            stmt.execute("CREATE TABLE NullValues (" +
+                    "StringValue CHAR(25), " +
+                    "PrimaryValue CHAR(10) NOT NULL PRIMARY KEY, " +
+                    "DoubleValue DOUBLE, " +
+                    "IntegerValue INTEGER, " +
+                    "ShortValue SMALLINT, " +
+                    "LongValue BIGINT, " +
+                    "FloatValue FLOAT, " +
+                    "BooleanValue Boolean" +
+                    ")");
+
+            // Insert row #1.
+            stmt.execute("INSERT INTO NullValues VALUES ( " +
+                    "'Non Null Description', " +
+                    "'001', " +
+                    "8.95, " +
+                    "1, " +
+                    "1, " +
+                    "1, " +
+                    "3.14, " +
+                    "TRUE )");
+
+            // Insert row #2.
+            stmt.execute("INSERT INTO NullValues (PrimaryValue, IntegerValue) VALUES ( " +
+                    "'002', " +
+                    "2 )");
+
+            // Insert row #3.
+            stmt.execute("INSERT INTO NullValues (StringValue, PrimaryValue) VALUES ( " +
+                    "'Non Null Description', " +
+                    "'003')");
+        } catch (SQLException ex) {
+            System.out.println("ERROR: " + ex.getMessage());
+        }
+    }
 
 }


### PR DESCRIPTION
Thanks for contributing.

- [x ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

During my use of Tablesaw, I found that when reading from a database, if a nullable double/integer column contained a null, the default value would instead be read into the Table.  After inspecting SqlResultSetReader, I saw that it did not utilize resultSet.wasNull() on the primitive type columns.  I added a separate function to check .wasNull() and utilize column.appendMissing() if it returned true.

Thanks for the great library!  It has helped my work tremendously and I enjoy utilizing it.

## Testing

I expanded SqlResultSetReaderTest.testSqlResultSetReader to include a test on another table ("NullValues" that I created in TestDb.java) that contained sporadic nulls on primitive typed columns.  I then asserted that the appropriate non-missing values existed in the columns.
