### PR TITLE
Fix inconsistency between column and columns methods on TableSlice

### DIFF
--- a/core/src/main/java/tech/tablesaw/table/TableSlice.java
+++ b/core/src/main/java/tech/tablesaw/table/TableSlice.java
@@ -76,7 +76,7 @@ public class TableSlice extends Relation implements IntIterable {
   public List<Column<?>> columns() {
     List<Column<?>> columns = new ArrayList<>();
     for (int i = 0; i < columnCount(); i++) {
-      columns.add(entireColumn(i));
+      columns.add(column(i));
     }
     return columns;
   }
@@ -140,8 +140,8 @@ public class TableSlice extends Relation implements IntIterable {
 
   public Table asTable() {
     Table table = Table.create(this.name());
-    for (Column<?> column : columns()) {
-      table.addColumns(column.where(selection));
+    for (Column<?> column : this.columns()) {
+      table.addColumns(column);
     }
     return table;
   }

--- a/core/src/test/java/tech/tablesaw/table/TableSliceTest.java
+++ b/core/src/test/java/tech/tablesaw/table/TableSliceTest.java
@@ -53,7 +53,7 @@ public class TableSliceTest {
   @Test
   public void columns() {
     TableSlice slice = new TableSlice(source, Selection.withRange(0, source.rowCount()));
-    assertEquals(source.columns(), slice.columns());
+    assertEquals(source.columns().get(0).size(), slice.columns().get(0).size());
   }
 
   @Test


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

The column and columns methods on TableSlice are inconsistent. One was returning the entire source column the other was returning the view for that slice.

## Testing

Fixed existing unit tests. No longer rely on reference equality.