### PR TITLE
Add mapToDoubleColumn on Table

### DIFF
--- a/core/src/main/java/tech/tablesaw/table/Relation.java
+++ b/core/src/main/java/tech/tablesaw/table/Relation.java
@@ -32,6 +32,7 @@ import tech.tablesaw.api.IntColumn;
 import tech.tablesaw.api.LongColumn;
 import tech.tablesaw.api.NumberColumn;
 import tech.tablesaw.api.NumericColumn;
+import tech.tablesaw.api.Row;
 import tech.tablesaw.api.ShortColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
@@ -47,7 +48,7 @@ import tech.tablesaw.sorting.comparators.DescendingIntComparator;
  * A tabular data structure like a table in a relational database, but not formally implementing the
  * relational algebra
  */
-public abstract class Relation {
+public abstract class Relation implements Iterable<Row> {
 
   public abstract Relation addColumns(Column<?>... cols);
 

--- a/core/src/main/java/tech/tablesaw/table/TableSlice.java
+++ b/core/src/main/java/tech/tablesaw/table/TableSlice.java
@@ -17,9 +17,11 @@ package tech.tablesaw.table;
 import it.unimi.dsi.fastutil.ints.IntIterable;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import tech.tablesaw.aggregate.NumericAggregateFunction;
 import tech.tablesaw.api.NumberColumn;
+import tech.tablesaw.api.Row;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.selection.BitmapBackedSelection;
@@ -31,7 +33,7 @@ import tech.tablesaw.selection.Selection;
  *
  * <p>A TableSlice is only good until the structure of the underlying table changes.
  */
-public class TableSlice extends Relation implements IntIterable {
+public class TableSlice extends Relation {
 
   private final Selection selection;
   private String name;
@@ -165,30 +167,23 @@ public class TableSlice extends Relation implements IntIterable {
   }
 
   /**
-   * Returns a 0 based int iterator for use with, for example, get(). When it returns 0 for the
-   * first row, get will transform that to the 0th row in the selection, which may not be the 0th
-   * row in the underlying table.
+   * Iterate of a copy of the table.
    */
   @Override
-  public IntIterator iterator() {
+  public Iterator<Row> iterator() {
 
-    return new IntIterator() {
+    return new Iterator<Row>() {
 
-      private int i = 0;
-
-      @Override
-      public int nextInt() {
-        return i++;
-      }
+      private final Row row = new Row(TableSlice.this.asTable());
 
       @Override
-      public int skip(int k) {
-        return i + k;
+      public Row next() {
+        return row.next();
       }
 
       @Override
       public boolean hasNext() {
-        return i < rowCount();
+        return row.hasNext();
       }
     };
   }

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.columns.dates.PackedLocalDate;
+import tech.tablesaw.columns.numbers.DoubleColumnType;
+import tech.tablesaw.columns.numbers.IntColumnType;
 import tech.tablesaw.io.csv.CsvReadOptions;
 
 public class TableTest {
@@ -682,5 +684,28 @@ public class TableTest {
     } catch (Exception e) {
       fail("toString shouldn't throw " + e);
     }
+  }
+
+  @Test
+  public void testMapToDouble() throws IOException {
+    Table table = Table.read().csv(CsvReadOptions.builder("../data/bush.csv"));
+
+    DoubleColumn doubleColumn = table.mapToDoubleColumn("mappedColumn",
+      r -> r.getInt("approval") * 1.0);
+
+    assertEquals("mappedColumn", doubleColumn.name());
+    assertArrayEquals(table.intColumn("approval").asDoubleArray(), doubleColumn.asDoubleArray());
+  }
+
+  @Test
+  public void testMapToDoubleWithMissingRowsSkipped() throws IOException {
+    IntColumn col11 = IntColumn.create("col1", new int[]{1, 2, 3, IntColumnType.missingValueIndicator()});
+    IntColumn col2 = IntColumn.create("col2", new int[]{1, 1, 1, 1});
+    Table t1 = Table.create("t1", col11, col2);
+
+    DoubleColumn doubleColumn = t1.mapToDoubleColumn("mappedColumn",
+      r -> r.getInt("col1") + r.getInt("col2") * 1.0, "col1", "col2");
+
+    assertArrayEquals(new double[]{2, 3, 4, DoubleColumnType.missingValueIndicator()}, doubleColumn.asDoubleArray());
   }
 }

--- a/core/src/test/java/tech/tablesaw/filters/TimeDependentFilteringTest.java
+++ b/core/src/test/java/tech/tablesaw/filters/TimeDependentFilteringTest.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.text.RandomStringGenerator;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.Row;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.dates.PackedLocalDate;
@@ -113,11 +114,11 @@ public class TimeDependentFilteringTest {
       List<LocalDate> eventDates = new ArrayList<>();
 
       // iterate an individual table and find the rows where concept matches the target concept
-      for (int row : patientTable) {
+      for (Row row : patientTable) {
         StringColumn concepts = patientTable.stringColumn("concept");
         DateColumn dates = patientTable.dateColumn("date");
-        if (concepts.get(row).equals(conceptZ)) {
-          eventDates.add(dates.get(row));
+        if(row.getString("concept").equals(conceptZ)) {
+          eventDates.add(row.getDate("date"));
         }
       }
 


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Change TableSliceGroup to iterate over Table rows.

Add MapTo[x] method to Abstract Relation class so they can be used by TableSlice and Table. 

Helps with #538 

If the implementation looks good I can update this PR to include other column types or send another PR.

## Testing

Yes