### PR TITLE
Add rolling stream method

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Row.java
+++ b/core/src/main/java/tech/tablesaw/api/Row.java
@@ -39,9 +39,13 @@ public class Row implements Iterator<Row> {
   private int rowNumber;
 
   public Row(Table table) {
+    this(table, -1);
+  }
+
+  public Row(Table table, int rowNumber) {
     this.table = table;
     columnNames = table.columnNames().toArray(new String[0]);
-    rowNumber = -1;
+    this.rowNumber = rowNumber;
     for (Column<?> column : table.columns()) {
       if (column instanceof DoubleColumn) {
         doubleColumnMap.put(column.name(), (DoubleColumn) column);

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -1069,8 +1069,84 @@ public class Table extends Relation implements Iterable<Row> {
     };
   }
 
+  /**
+   * Iterates over rolling sets of rows. I.e. 0 to n-1, 1 to n, 2 to n+1, etc.
+   *
+   * @param n the number of rows to return for each iteration
+   */
+  public Iterator<Row[]> rollingIterator(int n) {
+
+    return new Iterator<Row[]>() {
+
+      private int currRow = 0;
+
+      @Override
+      public Row[] next() {
+        Row[] rows = new Row[n];
+        for (int i = 0; i < n; i++) {
+          rows[i] = new Row(Table.this, currRow + i);
+        }
+        currRow++;
+        return rows;
+      }
+
+      @Override
+      public boolean hasNext() {
+        return currRow + n <= rowCount();
+      }
+    };
+  }
+
+  /**
+   * Streams over stepped sets of rows. I.e. 0 to n-1, n to 2n-1, 2n to 3n-1, etc. Only returns full
+   * sets of rows.
+   *
+   * @param n the number of rows to return for each iteration
+   */
+  public Iterator<Row[]> steppingIterator(int n) {
+
+    return new Iterator<Row[]>() {
+
+      private int currRow = 0;
+
+      @Override
+      public Row[] next() {
+        Row[] rows = new Row[n];
+        for (int i = 0; i < n; i++) {
+          rows[i] = new Row(Table.this, currRow + i);
+        }
+        currRow += n;
+        return rows;
+      }
+
+      @Override
+      public boolean hasNext() {
+        return currRow + n <= rowCount();
+      }
+    };
+  }
+
   public Stream<Row> stream() {
     return Streams.stream(iterator());
+  }
+
+  /**
+   * Streams over stepped sets of rows. I.e. 0 to n-1, n to 2n-1, 2n to 3n-1, etc. Only returns full
+   * sets of rows.
+   *
+   * @param n the number of rows to return for each iteration
+   */
+  public Stream<Row[]> steppingStream(int n) {
+    return Streams.stream(steppingIterator(n));
+  }
+
+  /**
+   * Streams over rolling sets of rows. I.e. 0 to n-1, 1 to n, 2 to n+1, etc.
+   *
+   * @param n the number of rows to return for each iteration
+   */
+  public Stream<Row[]> rollingStream(int n) {
+    return Streams.stream(rollingIterator(n));
   }
 
   /**
@@ -1078,6 +1154,7 @@ public class Table extends Relation implements Iterable<Row> {
    *
    * @deprecated use {@code stream().forEach}
    */
+  @Deprecated
   public void doWithRows(Consumer<Row> doable) {
     stream().forEach(doable);
   }
@@ -1087,84 +1164,36 @@ public class Table extends Relation implements Iterable<Row> {
    *
    * @deprecated use {@code stream().anyMatch}
    */
+  @Deprecated
   public boolean detect(Predicate<Row> predicate) {
     return stream().anyMatch(predicate);
   }
 
-  /** Applies the operation in {@code rowConsumer} to every series of n rows in the table */
+  /** @deprecated use steppingStream(n).forEach(rowConsumer) */
+  @Deprecated
   public void stepWithRows(Consumer<Row[]> rowConsumer, int n) {
-    if (isEmpty()) {
-      return;
-    }
-    Row[] rows = new Row[n];
-    for (int i = 0; i < n; i++) {
-      rows[i] = new Row(this);
-    }
-
-    int max = rowCount() / n;
-
-    for (int i = 0; i < max; i++) { // 0, 1
-      for (int r = 1; r <= n; r++) {
-        int row = i * n + r - 1;
-        rows[r - 1].at(row);
-      }
-      rowConsumer.accept(rows);
-    }
+    steppingStream(n).forEach(rowConsumer);
   }
 
-  /** Applies the function in {@code pairs} to each consecutive pairs of rows in the table */
+  /** @deprecated use stream(2).forEach(rowConsumer) */
+  @Deprecated
   public void doWithRows(Pairs pairs) {
-    if (isEmpty()) {
-      return;
-    }
-    Row row1 = new Row(this);
-    Row row2 = new Row(this);
-    int max = rowCount();
-    for (int i = 1; i < max; i++) {
-      row1.at(i - 1);
-      row2.at(i);
-      pairs.doWithPair(row1, row2);
-    }
+    rollingStream(2).forEach(rows -> pairs.doWithPair(rows[0], rows[1]));
   }
 
-  /** Applies the function in {@code pairConsumer} to each consecutive pairs of rows in the table */
+  /** @deprecated use stream(2).forEach(rowConsumer) */
+  @Deprecated
   public void doWithRowPairs(Consumer<RowPair> pairConsumer) {
-    if (isEmpty()) {
-      return;
-    }
-    Row row1 = new Row(this);
-    Row row2 = new Row(this);
-    RowPair pair = new RowPair(row1, row2);
-    int max = rowCount();
-    for (int i = 1; i < max; i++) {
-      row1.at(i - 1);
-      row2.at(i);
-      pairConsumer.accept(pair);
-    }
+    rollingStream(2).forEach(rows -> pairConsumer.accept(new RowPair(rows[0], rows[1])));
   }
 
-  /**
-   * Applies the function in {@code rowConsumer} to each group of contiguous rows of size n in the
-   * table This can be used, for example, to calculate a running average of in rows
-   */
+  /** @deprecated use stream(n).forEach(rowConsumer) */
+  @Deprecated
   public void rollWithRows(Consumer<Row[]> rowConsumer, int n) {
-    if (isEmpty()) {
-      return;
-    }
-    Row[] rows = new Row[n];
-    for (int i = 0; i < n; i++) {
-      rows[i] = new Row(this);
-    }
-
-    int max = rowCount() - (n - 2);
-    for (int i = 1; i < max; i++) {
-      for (int r = 0; r < n; r++) {
-        rows[r].at(i + r - 1);
-      }
-      rowConsumer.accept(rows);
-    }
+    rollingStream(n).forEach(rowConsumer);
   }
 
+  @Deprecated
   public static class RowPair {
     private final Row first;
     private final Row second;
@@ -1183,6 +1212,7 @@ public class Table extends Relation implements Iterable<Row> {
     }
   }
 
+  @Deprecated
   interface Pairs {
 
     void doWithPair(Row row1, Row row2);

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -318,17 +318,14 @@ for (Row row : table) {
 There are better ways, however. Another approach lets you skip the iteration and just provide a Consumer for each row.
 
 ```java
-// Create a consumer as an object or lambda (show below)
-Consumer<Row> doable = row -> {
-    if (row.getRowNumber() < 5) {
-        System.out.println("On "
-                           + row.getDate("date")
-                           + ": "
-                           + row.getDouble("approval"));
-    }
-};
-// apply the lambda
-table.doWithRows(doable);
+table.stream().forEach(row -> {
+  if (row.getRowNumber() < 5) {
+    System.out.println("On "
+                     + row.getDate("date")
+                     + ": "
+                     + row.getDouble("approval"));
+  }
+});
 ```
 
 If you need to process more than one row at a time, there are several methods to help. 
@@ -336,13 +333,11 @@ If you need to process more than one row at a time, there are several methods to
 ```java
 // work with a sliding window of rows
 // for example 0, 1, and 2, then 1, 2, and 3. etc.
-table.rollWithRows(consumer, 3);		
+table.stream(3).forEach(consumer);
 
 // work with a shifting window of rows
 // for example rows 0 through 4, then 5 through 9, etc.
-table.stepWithRows(consumer, 5);		
-
-table.doWithRowPairs(Pairs)	// easy syntax for working with each pair of rows
+table.steppingStream(5).forEach(consumer);
 ```
 
 See [Rows](https://jtablesaw.github.io/tablesaw/userguide/rows) for more information and other options. 


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This adds a rolling `stream(n)` method which allows us to do many different operations such as `forEach`, `map`, `filter`, `anyMatch`, `allMatch`, etc. on rolling groups of rows. `rollWithRows(Consumer<Row[]> rows, int n)` is the same as `stream(n).forEach(consumer)`, so I've deprecated it since it's the same thing, but less powerful

@ryancerf depending on which PR is merged first (i.e. this one or https://github.com/jtablesaw/tablesaw/pull/579) either you or I might need to rebase to put this method on `Relation`

## Testing

Existing unit tests cover this functionality. They're effective too because they caught a bug in my initial implementation.