### PR TITLE
Implementation change of AbstractColumn.asStringColumn

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
+++ b/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
@@ -58,7 +58,7 @@ public abstract class AbstractColumn<T> implements Column<T> {
   @Override
   public StringColumn asStringColumn() {
     StringColumn sc = StringColumn.create(name() + " strings");
-    for(int i = 0, size = size(); i < size; i++) {
+    for(int i = 0; i < size(); i++) {
     	sc.append(getUnformattedString(i));
     }
     return sc;

--- a/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
+++ b/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
@@ -58,8 +58,8 @@ public abstract class AbstractColumn<T> implements Column<T> {
   @Override
   public StringColumn asStringColumn() {
     StringColumn sc = StringColumn.create(name() + " strings");
-    for (T value : this) {
-      sc.append(String.valueOf(value));
+    for(int i = 0, size = size(); i < size; i++) {
+    	sc.append(getUnformattedString(i));
     }
     return sc;
   }

--- a/core/src/main/java/tech/tablesaw/columns/Column.java
+++ b/core/src/main/java/tech/tablesaw/columns/Column.java
@@ -617,5 +617,10 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
     return where(selectNRowsAtRandom(tableSize, size()));
   }
 
+  /**
+   * Returns a StringColumn consisting of the (unformatted) String representation of this column values
+   * @return a {@link StringColumn} built using the column {@link #getUnformattedString} method
+   */
   StringColumn asStringColumn();
+
 }

--- a/core/src/test/java/tech/tablesaw/api/DateTimeColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DateTimeColumnTest.java
@@ -22,6 +22,8 @@ import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import tech.tablesaw.columns.strings.StringColumnType;
+
 public class DateTimeColumnTest {
 
   private DateTimeColumn column1;
@@ -97,5 +99,16 @@ public class DateTimeColumnTest {
     column1.appendMissing();
 
     assertEquals(3, column1.countUnique());
+  }
+  
+  @Test
+  public void testAsStringColumn() {
+    column1.appendCell("1923-10-20T10:15:30");
+    column1.appendMissing();
+    StringColumn sc = column1.asStringColumn();
+    assertEquals("Game date strings", sc.name());
+    assertEquals(2, sc.size());
+    assertEquals("1923-10-20T10:15:30.000", sc.get(0));
+    assertEquals(StringColumnType.missingValueIndicator(), sc.get(1));
   }
 }

--- a/core/src/test/java/tech/tablesaw/api/NumberColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/NumberColumnTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.columns.numbers.DoubleColumnType;
 import tech.tablesaw.columns.numbers.NumberColumnFormatter;
+import tech.tablesaw.columns.strings.StringColumnType;
 import tech.tablesaw.selection.Selection;
 
 /** Unit tests for the NumberColumn class */
@@ -317,6 +318,28 @@ public class NumberColumnTest {
     StringColumn sc = numberColumn.asStringColumn();
     assertEquals("test strings", sc.name());
     assertEquals("48392.2932", sc.get(0));
+  }
+
+  @Test
+  public void testDoubleColumnAsStringWithMissing() {
+    DoubleColumn numberColumn = DoubleColumn.create("test");
+    numberColumn.append(48392.2932);
+    numberColumn.appendMissing();
+    StringColumn sc = numberColumn.asStringColumn();
+    assertEquals("test strings", sc.name());
+    assertEquals("48392.2932", sc.get(0));
+    assertEquals(StringColumnType.missingValueIndicator(), sc.get(1));
+  }
+
+  @Test
+  public void testIntegerColumnAsStringWithMissing() {
+    IntColumn numberColumn = IntColumn.create("test");
+    numberColumn.append(48392);
+    numberColumn.appendMissing();
+    StringColumn sc = numberColumn.asStringColumn();
+    assertEquals("test strings", sc.name());
+    assertEquals("48392", sc.get(0));
+    assertEquals(StringColumnType.missingValueIndicator(), sc.get(1));
   }
 
   @Test


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

- asStringColumn now uses delegation to the source column getUnformattedString in order to manage missing values
- Added javadoc

## Testing

- Added a couple of tests for DoubleColumn, IntColumn and DateTimeColumn with missing values
