### PR TITLE
Corrected ColumnType used for checking missingValue in DateTimeColumnFormatter

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeColumnFormatter.java
+++ b/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeColumnFormatter.java
@@ -5,7 +5,6 @@ import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.asLocalDateTim
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import javax.annotation.concurrent.Immutable;
-import tech.tablesaw.columns.times.TimeColumnType;
 
 @Immutable
 public class DateTimeColumnFormatter {
@@ -27,7 +26,7 @@ public class DateTimeColumnFormatter {
   }
 
   public String format(long value) {
-    if (value == TimeColumnType.missingValueIndicator()) {
+    if (value == DateTimeColumnType.missingValueIndicator()) {
       return missingValueString;
     }
     if (format == null) {

--- a/core/src/test/java/tech/tablesaw/api/DateTimeColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DateTimeColumnTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -97,5 +99,14 @@ public class DateTimeColumnTest {
     column1.appendMissing();
 
     assertEquals(3, column1.countUnique());
+  }
+  
+  @Test
+  public void testFormatter() {
+	  column1.setPrintFormatter(DateTimeFormatter.ISO_LOCAL_DATE_TIME, "NaT");
+	  column1.append(LocalDateTime.of(2000, 1, 1, 0, 0));
+	  column1.appendMissing();
+	  assertEquals("2000-01-01T00:00:00", column1.getString(0));
+	  assertEquals("NaT", column1.getString(1));
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

DateTimeColumnFormatter is using TimeColumnType instead of DateTimeColumnType for checking missing values leading to incorrect identification of missing values by the formatter

## Testing

Added a test of DateTimeColumn formatter including missing value
