### PR TITLE
Move the Sort prefix logic from Table class to Sort class.

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -530,7 +530,7 @@ public class Table extends Relation implements Iterable<Row> {
    * <p>if column name starts with - then sort that column descending otherwise sort ascending
    */
   public Table sortOn(String... columnNames) {
-    return this.sortOn(Sort.on(this, columnNames));
+    return this.sortOn(Sort.create(this, columnNames));
   }
 
   /**

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -530,45 +530,7 @@ public class Table extends Relation implements Iterable<Row> {
    * <p>if column name starts with - then sort that column descending otherwise sort ascending
    */
   public Table sortOn(String... columnNames) {
-
-    Sort key = null;
-    List<String> names = columnNames().stream().map(String::toUpperCase).collect(toList());
-
-    for (String columnName : columnNames) {
-      Sort.Order order = Sort.Order.ASCEND;
-      if (!names.contains(columnName.toUpperCase())) {
-        // the column name has been annotated with a prefix.
-        // get the prefix which could be - or +
-        String prefix = columnName.substring(0, 1);
-
-        // remove - prefix so provided name matches actual column name
-        columnName = columnName.substring(1, columnName.length());
-
-        order = getOrder(prefix);
-      }
-
-      if (key == null) { // key will be null the first time through
-        key = first(columnName, order);
-      } else {
-        key.next(columnName, order);
-      }
-    }
-    return sortOn(key);
-  }
-
-  private Sort.Order getOrder(String prefix) {
-    Sort.Order order;
-    switch (prefix) {
-      case "+":
-        order = Sort.Order.ASCEND;
-        break;
-      case "-":
-        order = Sort.Order.DESCEND;
-        break;
-      default:
-        throw new IllegalStateException("Column prefix: " + prefix + " is unknown.");
-    }
-    return order;
+    return this.sortOn(Sort.on(this, columnNames));
   }
 
   /**

--- a/core/src/main/java/tech/tablesaw/sorting/Sort.java
+++ b/core/src/main/java/tech/tablesaw/sorting/Sort.java
@@ -71,7 +71,8 @@ public class Sort implements Iterable<Map.Entry<String, Sort.Order>> {
    * @return a {@link #Sort} Object.
    */
   public static Sort create(Table table, String... columnNames) {
-    Preconditions.checkArgument(columnNames.length > 0, "");
+    Preconditions.checkArgument(columnNames.length > 0,
+      "At least one sort column must provided.");
 
     Sort key = null;
     Set<String> names = table.columnNames().stream().map(String::toUpperCase).collect(toSet());

--- a/core/src/main/java/tech/tablesaw/sorting/Sort.java
+++ b/core/src/main/java/tech/tablesaw/sorting/Sort.java
@@ -117,7 +117,6 @@ public class Sort implements Iterable<Map.Entry<String, Sort.Order>> {
   }
 
   private static Optional<Order> getOrder(String prefix) {
-    Sort.Order order = null;
     switch (prefix) {
       case "+":
         return Optional.of(Order.ASCEND);

--- a/core/src/main/java/tech/tablesaw/sorting/Sort.java
+++ b/core/src/main/java/tech/tablesaw/sorting/Sort.java
@@ -62,7 +62,15 @@ public class Sort implements Iterable<Map.Entry<String, Sort.Order>> {
     return sortOrder.size();
   }
 
-  public static Sort on(Table table, String... columnNames) {
+  /**
+   * Create a Sort object from the given table and sort column names. Does not sort the table.
+   *
+   * @param table to sort. Used only to pull the table's schema. Does not modify the table.
+   * @param columnNames The columns to sort on. Can prefix column name with + for ascending, - for descending.
+   * Default to ascending if no prefix is added.
+   * @return a {@link #Sort} Object.
+   */
+  public static Sort create(Table table, String... columnNames) {
     Preconditions.checkArgument(columnNames.length > 0, "");
 
     Sort key = null;

--- a/core/src/test/java/tech/tablesaw/SortTest.java
+++ b/core/src/test/java/tech/tablesaw/SortTest.java
@@ -129,7 +129,7 @@ public class SortTest {
   public void createSortInvalidPrefixColumnExists() {
     Table table = Table.create("t", DoubleColumn.create("col1"));
     Throwable thrown = assertThrows(IllegalStateException.class, () ->
-      Sort.on(table, "<col1"));
+      Sort.create(table, "<col1"));
 
     assertEquals("Column prefix: < is unknown.", thrown.getMessage());
   }
@@ -138,7 +138,7 @@ public class SortTest {
   public void createSortValidPrefixColumnDoesNotExist() {
     Table table = Table.create("t", DoubleColumn.create("col1"));
     Throwable thrown = assertThrows(IllegalStateException.class, () ->
-      Sort.on(table, "+col2"));
+      Sort.create(table, "+col2"));
 
     assertEquals("Column col2 does not exist in table t", thrown.getMessage());
   }
@@ -147,7 +147,7 @@ public class SortTest {
   public void createSortInvalidPrefixColumnDoesNotExist() {
     Table table = Table.create("t", DoubleColumn.create("col1"));
     Throwable thrown = assertThrows(IllegalStateException.class, () ->
-      Sort.on(table, ">col2"));
+      Sort.create(table, ">col2"));
 
     assertEquals("Unrecognized Column: '>col2'", thrown.getMessage());
   }

--- a/core/src/test/java/tech/tablesaw/SortTest.java
+++ b/core/src/test/java/tech/tablesaw/SortTest.java
@@ -15,11 +15,14 @@
 package tech.tablesaw;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.Table;
+import tech.tablesaw.sorting.Sort;
 
 /** Verify sorting functions */
 public class SortTest {
@@ -120,6 +123,33 @@ public class SortTest {
         unsortedTable.sortOn("+" + columnNames[IQ_INDEX], "-" + columnNames[DOB_INDEX]);
     Table expectedResults = TestData.SIMPLE_DATA_WITH_CANONICAL_DATE_FORMAT.getTable();
     assertTablesEquals(expectedResults, sortedTable);
+  }
+
+  @Test
+  public void createSortInvalidPrefixColumnExists() {
+    Table table = Table.create("t", DoubleColumn.create("col1"));
+    Throwable thrown = assertThrows(IllegalStateException.class, () ->
+      Sort.on(table, "<col1"));
+
+    assertEquals("Column prefix: < is unknown.", thrown.getMessage());
+  }
+
+  @Test
+  public void createSortValidPrefixColumnDoesNotExist() {
+    Table table = Table.create("t", DoubleColumn.create("col1"));
+    Throwable thrown = assertThrows(IllegalStateException.class, () ->
+      Sort.on(table, "+col2"));
+
+    assertEquals("Column col2 does not exist in table t", thrown.getMessage());
+  }
+
+  @Test
+  public void createSortInvalidPrefixColumnDoesNotExist() {
+    Table table = Table.create("t", DoubleColumn.create("col1"));
+    Throwable thrown = assertThrows(IllegalStateException.class, () ->
+      Sort.on(table, ">col2"));
+
+    assertEquals("Unrecognized Column: '>col2'", thrown.getMessage());
   }
 
   /**


### PR DESCRIPTION

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

* Move Sort prefix logic (+, -) from Table to Sort, so it can be used elsewhere.
* Improve  error messages when the prefix is invalid or the column does not exist on the table.

## Testing

Yes. Improved testing of error messages.