### PR TITLE
Ignore whitespaces option added in CsvWriterOptions.

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/csv/CsvWriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvWriteOptions.java
@@ -132,7 +132,7 @@ public class CsvWriteOptions extends WriteOptions {
       return this;
     }
 
-    public CsvWriteOptions.Builder ignoreLeadingWhiteSpaces(boolean ignoreLeadingWhitespaces) {
+    public CsvWriteOptions.Builder ignoreLeadingWhitespaces(boolean ignoreLeadingWhitespaces) {
       this.ignoreLeadingWhitespaces = ignoreLeadingWhitespaces;
       return this;
     }

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvWriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvWriteOptions.java
@@ -11,6 +11,8 @@ import tech.tablesaw.io.WriteOptions;
 public class CsvWriteOptions extends WriteOptions {
 
   private final boolean header;
+  private final boolean ignoreLeadingWhitespaces;
+  private final boolean ignoreTrailingWhitespaces;
   private final char separator;
   private final char quoteChar;
   private final char escapeChar;
@@ -23,10 +25,20 @@ public class CsvWriteOptions extends WriteOptions {
     this.quoteChar = builder.quoteChar;
     this.escapeChar = builder.escapeChar;
     this.lineEnd = builder.lineEnd;
+    this.ignoreLeadingWhitespaces = builder.ignoreLeadingWhitespaces;
+    this.ignoreTrailingWhitespaces = builder.ignoreTrailingWhitespaces;
   }
 
   public boolean header() {
     return header;
+  }
+
+  public boolean ignoreLeadingWhitespaces() {
+    return ignoreTrailingWhitespaces;
+  }
+
+  public boolean ignoreTrailingWhitespaces() {
+    return ignoreTrailingWhitespaces;
   }
 
   public char separator() {
@@ -68,6 +80,8 @@ public class CsvWriteOptions extends WriteOptions {
   public static class Builder extends WriteOptions.Builder {
 
     private boolean header = true;
+    private boolean ignoreLeadingWhitespaces = true;
+    private boolean ignoreTrailingWhitespaces = true;
     private char separator = ',';
     private String lineEnd = System.lineSeparator();
     private char escapeChar = '\\';
@@ -115,6 +129,16 @@ public class CsvWriteOptions extends WriteOptions {
 
     public CsvWriteOptions.Builder header(boolean header) {
       this.header = header;
+      return this;
+    }
+
+    public CsvWriteOptions.Builder ignoreLeadingWhiteSpaces(boolean ignoreLeadingWhitespaces) {
+      this.ignoreLeadingWhitespaces = ignoreLeadingWhitespaces;
+      return this;
+    }
+
+    public CsvWriteOptions.Builder ignoreTrailingWhitespaces(boolean ignoreTrailingWhitespaces) {
+      this.ignoreTrailingWhitespaces = ignoreTrailingWhitespaces;
       return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvWriter.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvWriter.java
@@ -77,6 +77,8 @@ public final class CsvWriter implements DataWriter<CsvWriteOptions> {
     settings.getFormat().setQuote(options.quoteChar());
     settings.getFormat().setQuoteEscape(options.escapeChar());
     settings.getFormat().setLineSeparator(options.lineEnd());
+    settings.setIgnoreLeadingWhitespaces(options.ignoreLeadingWhitespaces());
+    settings.setIgnoreTrailingWhitespaces(options.ignoreTrailingWhitespaces());
     // writes empty lines as well.
     settings.setSkipEmptyLines(false);
     return settings;

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvWriteOptionsTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvWriteOptionsTest.java
@@ -19,7 +19,7 @@ public class CsvWriteOptionsTest {
             .lineEnd("\r\n")
             .quoteChar('"')
             .separator('.')
-            .ignoreLeadingWhiteSpaces(true)
+            .ignoreLeadingWhitespaces(true)
             .ignoreTrailingWhitespaces(true)
             .build();
     assertEquals('~', options.escapeChar());

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvWriteOptionsTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvWriteOptionsTest.java
@@ -19,11 +19,15 @@ public class CsvWriteOptionsTest {
             .lineEnd("\r\n")
             .quoteChar('"')
             .separator('.')
+            .ignoreLeadingWhiteSpaces(true)
+            .ignoreTrailingWhitespaces(true)
             .build();
     assertEquals('~', options.escapeChar());
     assertTrue(options.header());
     assertEquals('"', options.quoteChar());
     assertEquals('.', options.separator());
+    assertTrue(options.ignoreLeadingWhitespaces());
+    assertTrue(options.ignoreTrailingWhitespaces());
 
     CsvWriterSettings settings = CsvWriter.createSettings(options);
 
@@ -31,5 +35,7 @@ public class CsvWriteOptionsTest {
     assertEquals("\r\n", settings.getFormat().getLineSeparatorString());
     assertEquals('"', settings.getFormat().getQuote());
     assertEquals('.', settings.getFormat().getDelimiter());
+    assertEquals(options.ignoreLeadingWhitespaces(), settings.getIgnoreLeadingWhitespaces());
+    assertEquals(options.ignoreTrailingWhitespaces(), settings.getIgnoreTrailingWhitespaces());
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Options to ignore leading and trailing whitespaces added in CsvWriterOptions. Fix for issue #603.

## Testing

Did you add a unit test?
No.
