### PR TITLE
fixes bug #623

### DIFF
--- a/aggregate/pom.xml
+++ b/aggregate/pom.xml
@@ -29,6 +29,7 @@
           <argLine>${argLine} -Xms256m -Xmx2048m</argLine>
           <forkCount>1</forkCount>
           <runOrder>random</runOrder>
+          <printSummary>false</printSummary>
         </configuration>
       </plugin>
       <plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -96,6 +96,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>-Duser.language=en-US -Duser.region=US</argLine>
+                    <printSummary>false</printSummary>
                 </configuration>
             </plugin>
         </plugins>

--- a/core/src/main/java/tech/tablesaw/api/Row.java
+++ b/core/src/main/java/tech/tablesaw/api/Row.java
@@ -43,8 +43,8 @@ public class Row implements Iterator<Row> {
     }
 
     /**
-     * Will get thrown when column name is correct, but used the wrong method get/set is called. E.G. the user called
-     * .getLong on an IntColumn.
+     * Will get thrown when column name is correct, but used the wrong method get/set is called.
+     * E.G. the user called .getLong on an IntColumn.
      */
     private void throwWrongTypeError(String columnName) {
       for (int i = 0; i < columnNames.length; i++) {

--- a/core/src/main/java/tech/tablesaw/columns/AbstractColumnParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/AbstractColumnParser.java
@@ -33,7 +33,7 @@ public abstract class AbstractColumnParser<T> {
     return columnType;
   }
 
-  protected boolean isMissing(String s) {
+  public boolean isMissing(String s) {
     if (s == null) {
       return true;
     }

--- a/core/src/main/java/tech/tablesaw/io/ColumnTypeDetector.java
+++ b/core/src/main/java/tech/tablesaw/io/ColumnTypeDetector.java
@@ -141,7 +141,7 @@ public class ColumnTypeDetector {
   private ColumnType detectType(List<String> valuesList, ReadOptions options) {
 
     CopyOnWriteArrayList<AbstractColumnParser<?>> parsers =
-            new CopyOnWriteArrayList<>(getParserList(typeArray, options));
+        new CopyOnWriteArrayList<>(getParserList(typeArray, options));
 
     CopyOnWriteArrayList<ColumnType> typeCandidates = new CopyOnWriteArrayList<>(typeArray);
 

--- a/core/src/main/java/tech/tablesaw/io/ColumnTypeDetector.java
+++ b/core/src/main/java/tech/tablesaw/io/ColumnTypeDetector.java
@@ -141,19 +141,29 @@ public class ColumnTypeDetector {
   private ColumnType detectType(List<String> valuesList, ReadOptions options) {
 
     CopyOnWriteArrayList<AbstractColumnParser<?>> parsers =
-        new CopyOnWriteArrayList<>(getParserList(typeArray, options));
+            new CopyOnWriteArrayList<>(getParserList(typeArray, options));
 
     CopyOnWriteArrayList<ColumnType> typeCandidates = new CopyOnWriteArrayList<>(typeArray);
 
+    boolean hasNonMissingValues = false;
+
     for (String s : valuesList) {
       for (AbstractColumnParser<?> parser : parsers) {
-        if (!parser.canParse(s)) {
-          typeCandidates.remove(parser.columnType());
-          parsers.remove(parser);
+        if (!parser.isMissing(s)) {
+          hasNonMissingValues = true;
+          if (!parser.canParse(s)) { // we can skip this test if we know the value is missing
+            typeCandidates.remove(parser.columnType());
+            parsers.remove(parser);
+          }
         }
       }
     }
-    return selectType(typeCandidates);
+    if (hasNonMissingValues) {
+      return selectType(typeCandidates);
+    } else {
+      // the last type in the typeArray is the default
+      return typeArray.get(typeArray.size() - 1);
+    }
   }
 
   /**

--- a/core/src/test/java/tech/tablesaw/io/ColumnTypeDetectorTest.java
+++ b/core/src/test/java/tech/tablesaw/io/ColumnTypeDetectorTest.java
@@ -1,0 +1,54 @@
+package tech.tablesaw.io;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+import tech.tablesaw.api.ColumnType;
+import tech.tablesaw.columns.dates.DateColumnType;
+import tech.tablesaw.columns.strings.StringColumnType;
+import tech.tablesaw.columns.strings.TextColumnType;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static tech.tablesaw.api.ColumnType.BOOLEAN;
+import static tech.tablesaw.api.ColumnType.DOUBLE;
+import static tech.tablesaw.api.ColumnType.FLOAT;
+import static tech.tablesaw.api.ColumnType.INTEGER;
+import static tech.tablesaw.api.ColumnType.LOCAL_DATE;
+import static tech.tablesaw.api.ColumnType.LOCAL_DATE_TIME;
+import static tech.tablesaw.api.ColumnType.LOCAL_TIME;
+import static tech.tablesaw.api.ColumnType.LONG;
+import static tech.tablesaw.api.ColumnType.SHORT;
+import static tech.tablesaw.api.ColumnType.STRING;
+import static tech.tablesaw.api.ColumnType.TEXT;
+
+class ColumnTypeDetectorTest {
+
+  @Test
+  void detectColumnTypes() {
+
+    String[][] val =
+            {{"", "2010-05-03", "x"},
+                    {"", "", ""}};
+
+    ArrayList<String[]> dates = Lists.newArrayList(val);
+
+    ColumnTypeDetector detector = new ColumnTypeDetector(Lists.newArrayList(
+            LOCAL_DATE_TIME,
+            LOCAL_TIME,
+            LOCAL_DATE,
+            BOOLEAN,
+            SHORT,
+            INTEGER,
+            LONG,
+            FLOAT,
+            DOUBLE,
+            STRING,
+            TEXT));
+
+    ColumnType[] types = detector.detectColumnTypes(dates.iterator(), new ReadOptions.Builder().build());
+    assertEquals(TextColumnType.instance(), types[0]);
+    assertEquals(DateColumnType.instance(), types[1]);
+    assertEquals(StringColumnType.instance(), types[2]);
+  }
+}

--- a/core/src/test/java/tech/tablesaw/io/ColumnTypeDetectorTest.java
+++ b/core/src/test/java/tech/tablesaw/io/ColumnTypeDetectorTest.java
@@ -1,14 +1,5 @@
 package tech.tablesaw.io;
 
-import com.google.common.collect.Lists;
-import org.junit.jupiter.api.Test;
-import tech.tablesaw.api.ColumnType;
-import tech.tablesaw.columns.dates.DateColumnType;
-import tech.tablesaw.columns.strings.StringColumnType;
-import tech.tablesaw.columns.strings.TextColumnType;
-
-import java.util.ArrayList;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static tech.tablesaw.api.ColumnType.BOOLEAN;
 import static tech.tablesaw.api.ColumnType.DOUBLE;
@@ -22,31 +13,40 @@ import static tech.tablesaw.api.ColumnType.SHORT;
 import static tech.tablesaw.api.ColumnType.STRING;
 import static tech.tablesaw.api.ColumnType.TEXT;
 
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import tech.tablesaw.api.ColumnType;
+import tech.tablesaw.columns.dates.DateColumnType;
+import tech.tablesaw.columns.strings.StringColumnType;
+import tech.tablesaw.columns.strings.TextColumnType;
+
 class ColumnTypeDetectorTest {
 
   @Test
   void detectColumnTypes() {
 
-    String[][] val =
-            {{"", "2010-05-03", "x"},
-                    {"", "", ""}};
+    String[][] val = {{"", "2010-05-03", "x"}, {"", "", ""}};
 
     ArrayList<String[]> dates = Lists.newArrayList(val);
 
-    ColumnTypeDetector detector = new ColumnTypeDetector(Lists.newArrayList(
-            LOCAL_DATE_TIME,
-            LOCAL_TIME,
-            LOCAL_DATE,
-            BOOLEAN,
-            SHORT,
-            INTEGER,
-            LONG,
-            FLOAT,
-            DOUBLE,
-            STRING,
-            TEXT));
+    ColumnTypeDetector detector =
+        new ColumnTypeDetector(
+            Lists.newArrayList(
+                LOCAL_DATE_TIME,
+                LOCAL_TIME,
+                LOCAL_DATE,
+                BOOLEAN,
+                SHORT,
+                INTEGER,
+                LONG,
+                FLOAT,
+                DOUBLE,
+                STRING,
+                TEXT));
 
-    ColumnType[] types = detector.detectColumnTypes(dates.iterator(), new ReadOptions.Builder().build());
+    ColumnType[] types =
+        detector.detectColumnTypes(dates.iterator(), new ReadOptions.Builder().build());
     assertEquals(TextColumnType.instance(), types[0]);
     assertEquals(DateColumnType.instance(), types[1]);
     assertEquals(StringColumnType.instance(), types[2]);

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,9 @@
                     <configuration>
                         <detectOfflineLinks>false</detectOfflineLinks>
                         <failOnError>false</failOnError>
+                        <quiet>true</quiet>
+                        <additionalOptions>-Xdoclint:none</additionalOptions>
+                        <additionalJOption>-Xdoclint:none</additionalJOption>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
but doesn't implement the enhancement.

Empty columns, and columns where all rows sampled have missing values, will get the default type, usually StringColumn or TextColumn, rather than LocalDateTime.

Thanks for contributing.

- [ ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

What was changed

## Testing

Did you add a unit test? Yes
