### PR TITLE
Add slf4j-api as a dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -134,6 +134,10 @@
             <version>4.8.22</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.haifengl</groupId>
             <artifactId>smile-data</artifactId>
             <version>1.5.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.28</version>
+            </dependency>
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>5.4.0</version>


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Adds slf4j as a dependency for https://github.com/jtablesaw/tablesaw/issues/628. I didn't have anywhere obvious to use it, so it's currently unused. I'll leave it to you guys to figure out where to use it. I thought it might be helpful to contribute this part because I've spent a lot of time working with Java logging in the past and I sometimes see folks add unnecessary dependencies so wanted to help make sure we avoid that.