### PR TITLE
partial implementation of #638

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -128,6 +128,11 @@
             <version>2.7.5</version>
         </dependency>
         <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>64.2</version>
+        </dependency>
+        <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
             <version>4.8.22</version>

--- a/core/src/test/java/tech/tablesaw/examples/PopulationExample.java
+++ b/core/src/test/java/tech/tablesaw/examples/PopulationExample.java
@@ -1,0 +1,55 @@
+package tech.tablesaw.examples;
+
+import tech.tablesaw.aggregate.AggregateFunctions;
+import tech.tablesaw.api.Table;
+import tech.tablesaw.io.csv.CsvReadOptions;
+
+/**
+ * Implementation of example from
+ * https://medium.com/@thijser/doing-cool-data-science-in-java-how-3-dataframe-libraries-stack-up-5e6ccb7b437
+ *
+ * <p>This is currently the top result if you google java dataframe. It demonstrates
+ * missing-variable handling, filtering, string manipulation, pivoting, mapping, sorting, etc.
+ */
+public class PopulationExample {
+
+  public static void main(String[] args) throws Exception {
+
+    Table data =
+        Table.read()
+            .csv(
+                CsvReadOptions.builderFromFile("../data/urb_cpop1_1_Data.csv")
+                    .missingValueIndicator(":"));
+    Table filtered = data.dropWhere(data.column("Value").isMissing());
+    filtered.addColumns(
+        (filtered.stringColumn("Cities").join(":", filtered.column("INDIC_UR"))).setName("key"));
+    Table cities = filtered.pivot("key", "time", "value", AggregateFunctions.mean);
+
+    // Top 10 cities by pop in 2017:
+    System.out.println(
+        cities
+            .where(
+                cities
+                    .stringColumn("key")
+                    .containsString("January")
+                    .and(cities.stringColumn("key").containsString("total"))
+                    .and(cities.nCol("2017").isNotMissing()))
+            .sortDescendingOn("2017")
+            .first(10));
+
+    // Highest growth cities:
+    cities.addColumns(
+        (cities.nCol("2016").divide(cities.nCol("2010").subtract(1)).multiply(100))
+            .setName("growth"));
+    System.out.println(
+        cities
+            .where(
+                cities
+                    .stringColumn("key")
+                    .containsString("January")
+                    .and(cities.stringColumn("key").containsString("total"))
+                    .and(cities.nCol("growth").isNotMissing()))
+            .sortDescendingOn("growth")
+            .first(10));
+  }
+}


### PR DESCRIPTION
Detects encodings for input text files when possible, and when no encoding is specifically provided as an argument. If the detection confidence is weak, it falls back on the system default charset.

This implementation adds a new dependency to Core, which is undesirable, but getting data into tablesaw correctly is arguably its most important function so I think it's worth it.

Thanks for contributing.

- [ ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

See above

## Testing

Did you add a unit test?
No but there are numerous tests that exercise this functionality

