### PR TITLE
Clean up unnecessary deprecation and varargs warnings

### DIFF
--- a/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
@@ -213,7 +213,9 @@ public class ColumnTest {
     assertFalse(DoubleColumn.create("t1", new double[] {1, 0, -1}).noneMatch(isNegative));
   }
 
-  private <T> void assertContentEquals(Column<T> column, @SuppressWarnings("unchecked") T... ts) {
+  @SafeVarargs
+  private final <T> void assertContentEquals(
+      Column<T> column, @SuppressWarnings("unchecked") T... ts) {
     assertEquals(ts.length, column.size());
     for (int i = 0; i < ts.length; i++) {
       assertEquals(ts[i], column.get(i));

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
@@ -233,7 +233,7 @@ public class CsvReaderTest {
     CsvReadOptions options =
         CsvReadOptions.builder(reader)
             .header(header)
-            .dateTimeFormat("dd-MMM-yyyy HH:mm:ss")
+            .dateTimeFormat(DateTimeFormatter.ofPattern("dd-MMM-yyyy HH:mm:ss"))
             .build();
 
     final List<ColumnType> actual = asList(new CsvReader().detectColumnTypes(reader, options));
@@ -418,7 +418,7 @@ public class CsvReaderTest {
 
     CsvReadOptions options =
         CsvReadOptions.builder("../data/missing_values.csv")
-            .dateFormat("yyyy.MM.dd")
+            .dateFormat(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
             .header(true)
             .missingValueIndicator("-")
             .build();
@@ -468,7 +468,7 @@ public class CsvReaderTest {
             .header(header)
             .separator(delimiter)
             .sample(useSampling)
-            .dateFormat("yyyy.MM.dd")
+            .dateFormat(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
             .build();
 
     final Table table = Table.read().csv(options);


### PR DESCRIPTION
The remaining warnings are from tests of deprecated code, so they should continue to warn until the code is removed.

Thanks for contributing.

- [ ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

What was changed

## Testing

Did you add a unit test?
