### PR TITLE
Add standard deviation to rolling column

### DIFF
--- a/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
@@ -417,6 +417,10 @@ public class AggregateFunctions {
         }
       };
 
+  /**
+   * @deprecated use {@link #stdDev} instead
+   */
+  @Deprecated
   public static final NumericAggregateFunction standardDeviation = stdDev;
 
   public static Double percentile(NumericColumn<?> data, Double percentile) {

--- a/core/src/main/java/tech/tablesaw/columns/numbers/NumberRollingColumn.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/NumberRollingColumn.java
@@ -44,6 +44,10 @@ public class NumberRollingColumn extends RollingColumn {
     return (DoubleColumn) calc(AggregateFunctions.countNonMissing);
   }
 
+  public DoubleColumn stdDev() {
+    return (DoubleColumn) calc(AggregateFunctions.stdDev);
+  }
+
   public DoubleColumn variance() {
     return (DoubleColumn) calc(AggregateFunctions.variance);
   }


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

I wanted to this reproduce [this chart from a Quora answer](https://qph.fs.quoracdn.net/main-qimg-a1f8ef78c1f847a1743d328fe03fcfb9.webp)

Added both `stdDev` and `standardDeviation` since they were both present in `AggregateFunctions`. They both do the same thing. Should we just have one and deprecate the other or leave both?