### PR TITLE
Add method to apply function to column

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -264,6 +264,30 @@ public class Table extends Relation implements Iterable<Row> {
     return replaceColumn(colIndex, newColumn);
   }
 
+  /**
+   * Replaces an existing column (by index) in this table by applying the given function to it
+   *
+   * @param colIndex Zero-based index of the column to be replaced
+   * @param operation Function to apply to transform the column
+   */
+  public Table replaceColumn(final int colIndex, Function<Column<?>, Column<?>> operation) {
+    Column<?> oldColumn = column(colIndex);
+    Column<?> newColumn = operation.apply(oldColumn);
+    removeColumns(oldColumn);
+    return insertColumn(colIndex, newColumn);
+  }
+
+  /**
+   * Replaces an existing column (by name) in this table by applying the given function to it
+   *
+   * @param columnName String name of the column to be replaced
+   * @param operation Function to apply to transform the column
+   */
+  public Table replaceColumn(final String columnName, Function<Column<?>, Column<?>> operation) {
+    int colIndex = columnIndex(columnName);
+    return replaceColumn(colIndex, operation);
+  }
+  
   /** Sets the name of the table */
   @Override
   public Table setName(String name) {


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Most of our methods return copies of columns. That means whenever I want to edit a column in a table I have to call `replaceColumn`. This makes that easier.

Adds a method to allow you to do:

```
table.replaceColumn("monthlyPriceIndex", col -> col.interpolate().backfill());
```

Instead of:

```
table.replaceColumn("monthlyPriceIndex", table.column("monthlyPriceIndex").interpolate().backfill());
```