### PR TITLE
Add new replaceColumn method

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -264,6 +264,15 @@ public class Table extends Relation implements Iterable<Row> {
     return replaceColumn(colIndex, newColumn);
   }
 
+  /**
+   * Replaces an existing column having the same name of the given column with the given column
+   *
+   * @param newColumn Column to be added
+   */
+  public Table replaceColumn(Column<?> newColumn) {
+    return replaceColumn(newColumn.name(), newColumn);
+  }
+
   /** Sets the name of the table */
   @Override
   public Table setName(String name) {

--- a/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
+++ b/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
@@ -146,5 +146,4 @@ public abstract class AbstractColumn<C extends Column<T>, T> implements Column<T
     }
     return sc;
   }
-
 }


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Most of our methods return copies of columns. That means whenever I want to edit a column in a table I have to call `replaceColumn`. This makes that easier.

Adds a method to allow you to do:

```
table.replaceColumn(table.column("monthlyPriceIndex").interpolate().backfill());
```

Instead of:

```
table.replaceColumn("monthlyPriceIndex", table.column("monthlyPriceIndex").interpolate().backfill());
```