### PR TITLE
Reads a specific JSON subtree based on the JSON Pointer expression from path()

### DIFF
--- a/json/src/main/java/tech/tablesaw/io/json/JsonReadOptions.java
+++ b/json/src/main/java/tech/tablesaw/io/json/JsonReadOptions.java
@@ -13,8 +13,11 @@ import tech.tablesaw.io.Source;
 
 public class JsonReadOptions extends ReadOptions {
 
+  private final String path;
+
   protected JsonReadOptions(Builder builder) {
     super(builder);
+    this.path = builder.path;
   }
 
   public static Builder builder(Source source) {
@@ -67,7 +70,13 @@ public class JsonReadOptions extends ReadOptions {
     return new Builder(reader);
   }
 
+  public String path() {
+    return path;
+  }
+
   public static class Builder extends ReadOptions.Builder {
+
+    private String path;
 
     protected Builder(Source source) {
       super(source);
@@ -167,6 +176,12 @@ public class JsonReadOptions extends ReadOptions {
     @Override
     public Builder minimizeColumnSizes() {
       super.minimizeColumnSizes();
+      return this;
+    }
+
+    /** @param path the JSON Pointer path used to select a sub-tree in the main document */
+    public Builder path(String path) {
+      this.path = path;
       return this;
     }
   }

--- a/json/src/main/java/tech/tablesaw/io/json/JsonReader.java
+++ b/json/src/main/java/tech/tablesaw/io/json/JsonReader.java
@@ -34,6 +34,9 @@ public class JsonReader implements DataReader<JsonReadOptions> {
   @Override
   public Table read(JsonReadOptions options) throws IOException {
     JsonNode jsonObj = mapper.readTree(options.source().createReader(null));
+    if (options.path() != null) {
+      jsonObj = jsonObj.at(options.path());
+    }
     if (!jsonObj.isArray()) {
       throw new IllegalStateException(
           "Only reading a json array or arrays or objects is currently supported");


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Allow a JSON Pointer Expression in JsonReadOptions.path() which selects a subtree to load. This seems to allow easy parsing of more JSON files.

For example, you could have an object:
```
{ "title": "Hello",
  "items": [...]
}
```
and parse it by specifying the "/items" path.

## Testing

Manual test.
