### PR TITLE
Adds plotly config argument. Only config.displayModeBar

### DIFF
--- a/jsplot/src/main/java/tech/tablesaw/plotly/components/Config.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/components/Config.java
@@ -1,0 +1,58 @@
+package tech.tablesaw.plotly.components;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Config extends Component {
+
+  private final Boolean displayModeBar;
+
+  private Config(Builder builder) {
+    this.displayModeBar = builder.displayModeBar;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public String asJavascript() {
+    Writer writer = new StringWriter();
+    PebbleTemplate compiledTemplate;
+
+    try {
+      compiledTemplate = engine.getTemplate("config_template.html");
+      compiledTemplate.evaluate(writer, getContext());
+    } catch (PebbleException | IOException e) {
+      e.printStackTrace();
+    }
+    return writer.toString();
+  }
+
+  private Map<String, Object> getContext() {
+    Map<String, Object> context = new HashMap<>();
+    context.put("displayModeBar", displayModeBar);
+    return context;
+  }
+
+  public static class Builder {
+
+    Boolean displayModeBar;
+
+    private Builder() {}
+
+    public Builder displayModeBar(boolean displayModeBar) {
+      this.displayModeBar = displayModeBar;
+      return this;
+    }
+
+    public Config build() {
+      return new Config(this);
+    }
+  }
+}

--- a/jsplot/src/main/java/tech/tablesaw/plotly/components/Figure.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/components/Figure.java
@@ -42,26 +42,24 @@ public class Figure {
   }
 
   public Figure(Trace... traces) {
-    this.data = traces;
-    this.layout = null;
-    this.config = null;
-    this.eventHandlers = null;
+    this((Layout) null, traces);
   }
 
   public Figure(Layout layout, Trace... traces) {
+    this(layout, (Config) null, traces);
+  }
+
+  public Figure(Layout layout, Config config, Trace... traces) {
     this.data = traces;
     this.layout = layout;
-    this.config = (layout != null && layout.getConfig() != null) ? layout.getConfig() : null;
+    this.config = config;
     this.eventHandlers = null;
   }
 
   /** @deprecated Use the FigureBuilder instead */
   @Deprecated
   public Figure(Layout layout, EventHandler eventHandler, Trace... traces) {
-    this.data = traces;
-    this.layout = layout;
-    this.config = (layout != null && layout.getConfig() != null) ? layout.getConfig() : null;
-    this.eventHandlers = new EventHandler[] {eventHandler};
+    this(layout, new EventHandler[] {eventHandler}, traces);
   }
 
   /** @deprecated Use the FigureBuilder instead */
@@ -182,9 +180,6 @@ public class Figure {
 
     public FigureBuilder layout(Layout layout) {
       this.layout = layout;
-      if (layout.getConfig() != null) {
-        return config(layout.getConfig());
-      }
       return this;
     }
 

--- a/jsplot/src/main/java/tech/tablesaw/plotly/components/Figure.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/components/Figure.java
@@ -27,6 +27,7 @@ public class Figure {
 
   private final Trace[] data;
   private final Layout layout;
+  private final Config config;
   private final EventHandler[] eventHandlers;
 
   private final Map<String, Object> context = new HashMap<>();
@@ -36,18 +37,21 @@ public class Figure {
   public Figure(FigureBuilder builder) {
     this.data = builder.traces();
     this.layout = builder.layout;
+    this.config = builder.config;
     this.eventHandlers = builder.eventHandlers();
   }
 
   public Figure(Trace... traces) {
     this.data = traces;
     this.layout = null;
+    this.config = null;
     this.eventHandlers = null;
   }
 
   public Figure(Layout layout, Trace... traces) {
     this.data = traces;
     this.layout = layout;
+    this.config = (layout != null && layout.getConfig() != null) ? layout.getConfig() : null;
     this.eventHandlers = null;
   }
 
@@ -56,6 +60,7 @@ public class Figure {
   public Figure(Layout layout, EventHandler eventHandler, Trace... traces) {
     this.data = traces;
     this.layout = layout;
+    this.config = (layout != null && layout.getConfig() != null) ? layout.getConfig() : null;
     this.eventHandlers = new EventHandler[] {eventHandler};
   }
 
@@ -64,6 +69,7 @@ public class Figure {
   public Figure(Layout layout, EventHandler[] eventHandlers, Trace... traces) {
     this.data = traces;
     this.layout = layout;
+    this.config = null;
     this.eventHandlers = eventHandlers;
   }
 
@@ -101,6 +107,9 @@ public class Figure {
     if (layout != null) {
       builder.append(layout.asJavascript());
     }
+    if (config != null) {
+      builder.append(config.asJavascript());
+    }
     builder.append(System.lineSeparator());
     for (int i = 0; i < data.length; i++) {
       Trace trace = data[i];
@@ -131,6 +140,10 @@ public class Figure {
     if (layout != null) {
       builder.append(", ");
       builder.append("layout");
+    }
+    if (config != null) {
+      builder.append(", ");
+      builder.append("config");
     }
 
     builder.append(");");
@@ -163,11 +176,20 @@ public class Figure {
   public static class FigureBuilder {
 
     private Layout layout;
+    private Config config;
     private List<Trace> traces = new ArrayList<>();
     private List<EventHandler> eventHandlers = new ArrayList<>();
 
     public FigureBuilder layout(Layout layout) {
       this.layout = layout;
+      if (layout.getConfig() != null) {
+        return config(layout.getConfig());
+      }
+      return this;
+    }
+
+    public FigureBuilder config(Config config) {
+      this.config = config;
       return this;
     }
 

--- a/jsplot/src/main/java/tech/tablesaw/plotly/components/Layout.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/components/Layout.java
@@ -175,10 +175,6 @@ public class Layout {
 
   private final BarMode barMode;
 
-  // XXX: Config is not part of layout in plotly but seems simpler to have a single place for all
-  // these options. Does not get saved to the context!
-  private final Config config;
-
   private Layout(LayoutBuilder builder) {
     this.title = builder.title;
     this.autoSize = builder.autoSize;
@@ -204,11 +200,6 @@ public class Layout {
     this.barMode = builder.barMode;
     this.scene = builder.scene;
     this.grid = builder.grid;
-    this.config = builder.config;
-  }
-
-  public Config getConfig() {
-    return config;
   }
 
   public String getTitle() {
@@ -370,8 +361,6 @@ public class Layout {
     /** Define grid to use when creating subplots */
     private Grid grid;
 
-    private Config config;
-
     public Layout build() {
       return new Layout(this);
     }
@@ -470,11 +459,6 @@ public class Layout {
 
     public LayoutBuilder grid(Grid grid) {
       this.grid = grid;
-      return this;
-    }
-
-    public LayoutBuilder config(Config config) {
-      this.config = config;
       return this;
     }
   }

--- a/jsplot/src/main/java/tech/tablesaw/plotly/components/Layout.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/components/Layout.java
@@ -175,6 +175,10 @@ public class Layout {
 
   private final BarMode barMode;
 
+  // XXX: Config is not part of layout in plotly but seems simpler to have a single place for all
+  // these options. Does not get saved to the context!
+  private final Config config;
+
   private Layout(LayoutBuilder builder) {
     this.title = builder.title;
     this.autoSize = builder.autoSize;
@@ -200,6 +204,11 @@ public class Layout {
     this.barMode = builder.barMode;
     this.scene = builder.scene;
     this.grid = builder.grid;
+    this.config = builder.config;
+  }
+
+  public Config getConfig() {
+    return config;
   }
 
   public String getTitle() {
@@ -361,6 +370,8 @@ public class Layout {
     /** Define grid to use when creating subplots */
     private Grid grid;
 
+    private Config config;
+
     public Layout build() {
       return new Layout(this);
     }
@@ -459,6 +470,11 @@ public class Layout {
 
     public LayoutBuilder grid(Grid grid) {
       this.grid = grid;
+      return this;
+    }
+
+    public LayoutBuilder config(Config config) {
+      this.config = config;
       return this;
     }
   }

--- a/jsplot/src/main/resources/config_template.html
+++ b/jsplot/src/main/resources/config_template.html
@@ -1,0 +1,5 @@
+var config = {
+{% if displayModeBar is not null %}
+    displayModeBar: {{displayModeBar}}
+{% endif %}
+}

--- a/jsplot/src/test/java/tech/tablesaw/plotly/components/ConfigTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/plotly/components/ConfigTest.java
@@ -1,0 +1,25 @@
+package tech.tablesaw.plotly.components;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ConfigTest {
+
+  @Test
+  public void testJavascript() {
+    {
+      Config config = Config.builder().displayModeBar(true).build();
+      assertTrue(config.asJavascript().contains("displayModeBar: true"));
+    }
+    {
+      Config config = Config.builder().displayModeBar(false).build();
+      assertTrue(config.asJavascript().contains("displayModeBar: false"));
+    }
+    {
+      Config config = Config.builder().build();
+      assertFalse(config.asJavascript().contains("displayModeBar"));
+    }
+  }
+}


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Plot.ly has a `config` argument ( https://plot.ly/javascript/configuration-options/ ) as the last argument to `Plotly.plot`. This has many options to customize the UI.

This PR adds the initial way of supporting this `config` object and adds the `displayModeBar` option.

Note that I've made `config` part of the `Layout` object. This isn't how Plot.ly does it but it seems convenient to have a single 'configuration object'. The `config` field is not saved to the context nor serialized to JS by `Layout`. It is the job of `Figure` to do that. If you don't like it I can remove this part.

## Testing

Yes, a basic one.
