### PR TITLE
Adds firstAsString aggregate function

### DIFF
--- a/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
@@ -422,8 +422,8 @@ public class AggregateFunctions {
   /** @deprecated use {@link #stdDev} instead */
   @Deprecated public static final NumericAggregateFunction standardDeviation = stdDev;
 
-  public static final AggregateFunction<Column<?>, String> top1 =
-      new AggregateFunction<Column<?>, String>("Top 1") {
+  public static final AggregateFunction<Column<?>, String> firstString =
+      new AggregateFunction<Column<?>, String>("First (as String)") {
 
         @Override
         public String summarize(Column<?> column) {

--- a/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
@@ -422,7 +422,7 @@ public class AggregateFunctions {
   /** @deprecated use {@link #stdDev} instead */
   @Deprecated public static final NumericAggregateFunction standardDeviation = stdDev;
 
-  public static final AggregateFunction<Column<?>, String> firstString =
+  public static final AggregateFunction<Column<?>, String> firstAsString =
       new AggregateFunction<Column<?>, String>("First (as String)") {
 
         @Override

--- a/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
@@ -7,11 +7,13 @@ import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.commons.math3.stat.descriptive.moment.Kurtosis;
 import org.apache.commons.math3.stat.descriptive.moment.Skewness;
 import tech.tablesaw.api.BooleanColumn;
+import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DateTimeColumn;
 import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.columns.numbers.DoubleColumnType;
+import tech.tablesaw.columns.strings.StringColumnType;
 
 public class AggregateFunctions {
 
@@ -419,6 +421,25 @@ public class AggregateFunctions {
 
   /** @deprecated use {@link #stdDev} instead */
   @Deprecated public static final NumericAggregateFunction standardDeviation = stdDev;
+
+  public static final AggregateFunction<Column<?>, String> top1 =
+      new AggregateFunction<Column<?>, String>("Top 1") {
+
+        @Override
+        public String summarize(Column<?> column) {
+          return column.isEmpty() ? StringColumnType.missingValueIndicator() : column.getString(0);
+        }
+
+        @Override
+        public boolean isCompatibleColumn(ColumnType type) {
+          return true;
+        }
+
+        @Override
+        public ColumnType returnType() {
+          return ColumnType.STRING;
+        }
+      };
 
   public static Double percentile(NumericColumn<?> data, Double percentile) {
     return StatUtils.percentile(removeMissing(data), percentile);

--- a/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
+++ b/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
@@ -25,7 +25,7 @@ import static tech.tablesaw.aggregate.AggregateFunctions.countTrue;
 import static tech.tablesaw.aggregate.AggregateFunctions.countUnique;
 import static tech.tablesaw.aggregate.AggregateFunctions.countWithMissing;
 import static tech.tablesaw.aggregate.AggregateFunctions.earliestDate;
-import static tech.tablesaw.aggregate.AggregateFunctions.firstString;
+import static tech.tablesaw.aggregate.AggregateFunctions.firstAsString;
 import static tech.tablesaw.aggregate.AggregateFunctions.latestDate;
 import static tech.tablesaw.aggregate.AggregateFunctions.mean;
 import static tech.tablesaw.aggregate.AggregateFunctions.noneTrue;
@@ -111,7 +111,7 @@ class AggregateFunctionsTest {
   }
 
   @Test
-  void testFirstString() {
+  void testFirstAsString() {
     StringColumn company = StringColumn.create("Company");
     StringColumn sector = StringColumn.create("Sector");
     Table t = Table.create(company, sector);
@@ -125,7 +125,7 @@ class AggregateFunctionsTest {
       r.setString(0, "Facebook");
       r.setString(1, "Technology");
     }
-    Table result = t.summarize("Company", firstString).by("Sector");
+    Table result = t.summarize("Company", firstAsString).by("Sector");
     assertEquals(1, result.rowCount());
     assertEquals("Technology", result.get(0, 0));
     assertEquals("Google", result.get(0, 1));

--- a/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
+++ b/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
@@ -25,6 +25,7 @@ import static tech.tablesaw.aggregate.AggregateFunctions.countTrue;
 import static tech.tablesaw.aggregate.AggregateFunctions.countUnique;
 import static tech.tablesaw.aggregate.AggregateFunctions.countWithMissing;
 import static tech.tablesaw.aggregate.AggregateFunctions.earliestDate;
+import static tech.tablesaw.aggregate.AggregateFunctions.firstString;
 import static tech.tablesaw.aggregate.AggregateFunctions.latestDate;
 import static tech.tablesaw.aggregate.AggregateFunctions.mean;
 import static tech.tablesaw.aggregate.AggregateFunctions.noneTrue;
@@ -36,7 +37,6 @@ import static tech.tablesaw.aggregate.AggregateFunctions.proportionTrue;
 import static tech.tablesaw.aggregate.AggregateFunctions.standardDeviation;
 import static tech.tablesaw.aggregate.AggregateFunctions.stdDev;
 import static tech.tablesaw.aggregate.AggregateFunctions.sum;
-import static tech.tablesaw.aggregate.AggregateFunctions.top1;
 import static tech.tablesaw.api.QuerySupport.and;
 import static tech.tablesaw.api.QuerySupport.date;
 import static tech.tablesaw.api.QuerySupport.num;
@@ -111,7 +111,7 @@ class AggregateFunctionsTest {
   }
 
   @Test
-  void testTop1() {
+  void testFirstString() {
     StringColumn company = StringColumn.create("Company");
     StringColumn sector = StringColumn.create("Sector");
     Table t = Table.create(company, sector);
@@ -125,7 +125,7 @@ class AggregateFunctionsTest {
       r.setString(0, "Facebook");
       r.setString(1, "Technology");
     }
-    Table result = t.summarize("Company", top1).by("Sector");
+    Table result = t.summarize("Company", firstString).by("Sector");
     assertEquals(1, result.rowCount());
     assertEquals("Technology", result.get(0, 0));
     assertEquals("Google", result.get(0, 1));

--- a/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
+++ b/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
@@ -36,6 +36,7 @@ import static tech.tablesaw.aggregate.AggregateFunctions.proportionTrue;
 import static tech.tablesaw.aggregate.AggregateFunctions.standardDeviation;
 import static tech.tablesaw.aggregate.AggregateFunctions.stdDev;
 import static tech.tablesaw.aggregate.AggregateFunctions.sum;
+import static tech.tablesaw.aggregate.AggregateFunctions.top1;
 import static tech.tablesaw.api.QuerySupport.and;
 import static tech.tablesaw.api.QuerySupport.date;
 import static tech.tablesaw.api.QuerySupport.num;
@@ -48,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.BooleanColumn;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.Row;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.csv.CsvReadOptions;
@@ -106,6 +108,27 @@ class AggregateFunctionsTest {
 
     result = table.summarize("approval", mean, AggregateFunctions.count).groupBy(byColumn).apply();
     assertEquals(13, result.rowCount());
+  }
+
+  @Test
+  void testTop1() {
+    StringColumn company = StringColumn.create("Company");
+    StringColumn sector = StringColumn.create("Sector");
+    Table t = Table.create(company, sector);
+    {
+      Row r = t.appendRow();
+      r.setString(0, "Google");
+      r.setString(1, "Technology");
+    }
+    {
+      Row r = t.appendRow();
+      r.setString(0, "Facebook");
+      r.setString(1, "Technology");
+    }
+    Table result = t.summarize("Company", top1).by("Sector");
+    assertEquals(1, result.rowCount());
+    assertEquals("Technology", result.get(0, 0));
+    assertEquals("Google", result.get(0, 1));
   }
 
   @Test


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Added `AggregateFunctions.firstAsString` which is similar to `AggregateFunctions.first` except it returns a `String` value regardless of the column type.

Not sure if fits the overall architecture as aggregate functions seem to be designed for numeric data only, but it does make sense somehow.

I pondered about this while trying to make unique (parent,child) pairs from two columns and `firstAsString` + `groupBy` seemed the most logical thing: `table.summarize(parentCol, firstAsString).by(col)`.

I don't mind if you reject the PR, I know TOP1 is not an aggregate function in SQL.

## Testing

Yes.
