### PR TITLE
Escapes quotes when building Javascript string arrays from Java arrays

### DIFF
--- a/jsplot/src/main/java/tech/tablesaw/plotly/Utils.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/Utils.java
@@ -8,16 +8,22 @@ public class Utils {
     return Arrays.toString(data);
   }
 
+  /** @return un-escaped quote of argument */
   public static String quote(String string) {
     return "'" + string + "'";
   }
 
+  private static String escape(String s) {
+    return s.replaceAll("\\'", "\\\\'");
+  }
+
+  /** @return a Javascript array of strings (escaped if needed) */
   public static String dataAsString(Object[] data) {
     StringBuilder builder = new StringBuilder("[");
     for (int i = 0; i < data.length; i++) {
       Object o = data[i];
       builder.append("'");
-      builder.append(o);
+      builder.append(escape(String.valueOf(o)));
       builder.append("'");
       if (i < data.length - 1) {
         builder.append(",");

--- a/jsplot/src/test/java/tech/tablesaw/plotly/UtilsTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/plotly/UtilsTest.java
@@ -1,0 +1,13 @@
+package tech.tablesaw.plotly;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UtilsTest {
+
+  @Test
+  public void testEscapeQuote() {
+    String s = Utils.dataAsString(new String[] {"Bobby's tables"});
+    Assertions.assertTrue(s.contains("\\"));
+  }
+}

--- a/jsplot/src/test/java/tech/tablesaw/plotly/UtilsTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/plotly/UtilsTest.java
@@ -1,6 +1,6 @@
 package tech.tablesaw.plotly;
 
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 public class UtilsTest {
@@ -8,6 +8,6 @@ public class UtilsTest {
   @Test
   public void testEscapeQuote() {
     String s = Utils.dataAsString(new String[] {"Bobby's tables"});
-    Assertions.assertTrue(s.contains("\\"));
+    assertTrue(s.contains("\\"));
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

The generated plot Javascript is not valid if any of the values has a quote ( `'` ) in it. This PR escapes quotes before generating the JS arrays.

## Testing

Yes.
