### PR TITLE
Adds ReadOptions.percentage which parses percentage-like strings as doubles

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/numbers/DoubleParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/DoubleParser.java
@@ -7,6 +7,8 @@ import tech.tablesaw.io.ReadOptions;
 
 public class DoubleParser extends AbstractColumnParser<Double> {
 
+  private boolean percentage = false;
+
   public DoubleParser(ColumnType columnType) {
     super(columnType);
   }
@@ -16,15 +18,13 @@ public class DoubleParser extends AbstractColumnParser<Double> {
     if (readOptions.missingValueIndicator() != null) {
       missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicator());
     }
+    percentage = readOptions.percentage();
   }
 
   @Override
   public boolean canParse(String s) {
-    if (isMissing(s)) {
-      return true;
-    }
     try {
-      Double.parseDouble(AbstractColumnParser.remove(s, ','));
+      parseDouble(s);
       return true;
     } catch (NumberFormatException e) {
       // it's all part of the plan
@@ -42,6 +42,12 @@ public class DoubleParser extends AbstractColumnParser<Double> {
     if (isMissing(s)) {
       return DoubleColumnType.missingValueIndicator();
     }
-    return Double.parseDouble(AbstractColumnParser.remove(s, ','));
+    boolean isPercentage = false;
+    if (percentage && s.endsWith("%")) {
+      isPercentage = true;
+      s = s.substring(0, s.length() - 1);
+    }
+    double d = Double.parseDouble(AbstractColumnParser.remove(s, ','));
+    return isPercentage ? d / 100.0 : d;
   }
 }

--- a/core/src/main/java/tech/tablesaw/io/ReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/ReadOptions.java
@@ -79,6 +79,7 @@ public class ReadOptions {
   protected final DateTimeFormatter dateFormatter;
   protected final DateTimeFormatter dateTimeFormatter;
   protected final DateTimeFormatter timeFormatter;
+  protected final boolean percentage;
 
   protected final boolean header;
 
@@ -104,6 +105,7 @@ public class ReadOptions {
     } else {
       locale = builder.locale;
     }
+    percentage = builder.percentage;
   }
 
   public Source source() {
@@ -169,6 +171,10 @@ public class ReadOptions {
     return DateTimeFormatter.ofPattern(dateFormat, locale);
   }
 
+  public boolean percentage() {
+    return percentage;
+  }
+
   protected static class Builder {
 
     protected final Source source;
@@ -186,6 +192,7 @@ public class ReadOptions {
     protected boolean minimizeColumnSizes = false;
     protected boolean header = true;
     protected int maxCharsPerColumn = 4096;
+    protected boolean percentage = false;
 
     protected Builder() {
       source = null;
@@ -291,6 +298,15 @@ public class ReadOptions {
      */
     public Builder minimizeColumnSizes() {
       this.columnTypesToDetect = EXTENDED_TYPES;
+      return this;
+    }
+
+    /**
+     * @param b if true, reads strings that appear as percentages (eg. 10%) as numbers (0.1)
+     * @return
+     */
+    public Builder percentage(boolean b) {
+      this.percentage = b;
       return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/io/ReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/ReadOptions.java
@@ -301,10 +301,7 @@ public class ReadOptions {
       return this;
     }
 
-    /**
-     * @param b if true, reads strings that appear as percentages (eg. 10%) as numbers (0.1)
-     * @return
-     */
+    /** @param b if true, reads strings that appear as percentages (eg. 10%) as numbers (0.1) */
     public Builder percentage(boolean b) {
       this.percentage = b;
       return this;

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
@@ -282,10 +282,8 @@ public class CsvReadOptions extends ReadOptions {
       return this;
     }
 
-    /**
-     * @param b if true, reads strings that appear as percentages (eg. 10%) as numbers (0.1)
-     * @return
-     */
+    /** @param b if true, reads strings that appear as percentages (eg. 10%) as numbers (0.1) */
+    @Override
     public Builder percentage(boolean b) {
       super.percentage(b);
       return this;

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
@@ -281,5 +281,14 @@ public class CsvReadOptions extends ReadOptions {
       super.minimizeColumnSizes();
       return this;
     }
+
+    /**
+     * @param b if true, reads strings that appear as percentages (eg. 10%) as numbers (0.1)
+     * @return
+     */
+    public Builder percentage(boolean b) {
+      super.percentage(b);
+      return this;
+    }
   }
 }

--- a/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthReadOptions.java
@@ -292,5 +292,12 @@ public class FixedWidthReadOptions extends ReadOptions {
       super.minimizeColumnSizes();
       return this;
     }
+
+    /** @param b if true, reads strings that appear as percentages (eg. 10%) as numbers (0.1) */
+    @Override
+    public Builder percentage(boolean b) {
+      super.percentage(b);
+      return this;
+    }
   }
 }

--- a/core/src/test/java/tech/tablesaw/columns/numbers/DoubleParserTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/numbers/DoubleParserTest.java
@@ -1,0 +1,22 @@
+package tech.tablesaw.columns.numbers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import tech.tablesaw.api.Table;
+import tech.tablesaw.io.csv.CsvReadOptions;
+import tech.tablesaw.io.csv.CsvReader;
+
+public class DoubleParserTest {
+
+  @Test
+  public void testPercentage() throws IOException {
+    Table table =
+        new CsvReader().read(CsvReadOptions.builder("../data/growth.csv").percentage(true).build());
+    assertEquals("Coffee", table.get(0, 0));
+    assertEquals(0.25, table.get(0, 1));
+    assertEquals("Bread", table.get(1, 0));
+    assertEquals(0.05, table.get(1, 1));
+  }
+}

--- a/data/growth.csv
+++ b/data/growth.csv
@@ -1,0 +1,3 @@
+Product,Growth
+Coffee,25%
+Bread,5%

--- a/excel/src/main/java/tech/tablesaw/io/xlsx/XlsxReadOptions.java
+++ b/excel/src/main/java/tech/tablesaw/io/xlsx/XlsxReadOptions.java
@@ -158,5 +158,12 @@ public class XlsxReadOptions extends ReadOptions {
       this.sheetIndex = sheetIndex;
       return this;
     }
+
+    /** @param b if true, reads strings that appear as percentages (eg. 10%) as numbers (0.1) */
+    @Override
+    public Builder percentage(boolean b) {
+      super.percentage(b);
+      return this;
+    }
   }
 }

--- a/html/src/main/java/tech/tablesaw/io/html/HtmlReadOptions.java
+++ b/html/src/main/java/tech/tablesaw/io/html/HtmlReadOptions.java
@@ -184,5 +184,12 @@ public class HtmlReadOptions extends ReadOptions {
       this.tableIndex = tableIndex;
       return this;
     }
+
+    /** @param b if true, reads strings that appear as percentages (eg. 10%) as numbers (0.1) */
+    @Override
+    public Builder percentage(boolean b) {
+      super.percentage(b);
+      return this;
+    }
   }
 }

--- a/json/src/main/java/tech/tablesaw/io/json/JsonReadOptions.java
+++ b/json/src/main/java/tech/tablesaw/io/json/JsonReadOptions.java
@@ -184,5 +184,12 @@ public class JsonReadOptions extends ReadOptions {
       this.path = path;
       return this;
     }
+
+    /** @param b if true, reads strings that appear as percentages (eg. 10%) as numbers (0.1) */
+    @Override
+    public Builder percentage(boolean b) {
+      super.percentage(b);
+      return this;
+    }
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Adds flag to parse percentage strings (10%) as doubles (0.1).

## Testing

Yes.
