### PR TITLE
Updates the Column.mapInto javadoc and adds two new Column.map methods

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/Column.java
+++ b/core/src/main/java/tech/tablesaw/columns/Column.java
@@ -348,24 +348,6 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
   }
 
   /**
-   * Maps the function across all rows, appending the results to the supplied Column.
-   *
-   * <p>Example:
-   *
-   * <pre>
-   * DoubleColumn d;
-   * StringColumn s = d.map(String::valueOf, () -> StringColumn.create("x"));
-   * </pre>
-   *
-   * @param fun function to map
-   * @param supplier the supplier for the column where results are appended to
-   * @return the Column with the results
-   */
-  default <R, C extends Column<R>> C map(Function<? super T, ? extends R> fun, Supplier<C> supplier) {
-    return map(fun, (name) -> supplier.get());
-  }
-
-  /**
    * Maps the function across all rows, appending the results to the created Column.
    *
    * <p>Example:

--- a/core/src/main/java/tech/tablesaw/columns/Column.java
+++ b/core/src/main/java/tech/tablesaw/columns/Column.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
@@ -327,11 +328,13 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
   }
 
   /**
-   * Maps the function across all rows, appending the results to the provided Column
+   * Maps the function across all rows, storing the results into the provided Column.
+   *
+   * <p>The target column must have at least the same number of rows.
    *
    * @param fun function to map
-   * @param into Column to which results are appended
-   * @return the provided Column, to which results are appended
+   * @param into Column into which results are set
+   * @return the provided Column
    */
   default <R, C extends Column<R>> C mapInto(Function<? super T, ? extends R> fun, C into) {
     for (int i = 0; i < size(); i++) {
@@ -339,6 +342,52 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
         into.setMissing(i);
       } else {
         into.set(i, fun.apply(get(i)));
+      }
+    }
+    return into;
+  }
+
+  /**
+   * Maps the function across all rows, appending the results to the supplied Column.
+   *
+   * <p>Example:
+   *
+   * <pre>
+   * DoubleColumn d;
+   * StringColumn s = d.map(String::valueOf, () -> StringColumn.create("x"));
+   * </pre>
+   *
+   * @param fun function to map
+   * @param supplier the supplier for the column where results are appended to
+   * @return the Column with the results
+   */
+  default <R, C extends Column<R>> C map(Function<? super T, ? extends R> fun, Supplier<C> supplier) {
+    return map(fun, (name) -> supplier.get());
+  }
+
+  /**
+   * Maps the function across all rows, appending the results to the created Column.
+   *
+   * <p>Example:
+   *
+   * <pre>
+   * DoubleColumn d;
+   * StringColumn s = d.map(String::valueOf, StringColumn::create);
+   * </pre>
+   *
+   * @param fun function to map
+   * @param creator the creator of the Column. Its String argument will be the name of the current
+   *     column (see {@link #name()})
+   * @return the Column with the results
+   */
+  default <R, C extends Column<R>> C map(
+      Function<? super T, ? extends R> fun, Function<String, C> creator) {
+    C into = creator.apply(name());
+    for (int i = 0; i < size(); i++) {
+      if (isMissing(i)) {
+        into.appendMissing();
+      } else {
+        into.append(fun.apply(get(i)));
       }
     }
     return into;

--- a/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
@@ -279,6 +279,14 @@ public class ColumnTest {
   }
 
   @Test
+  public void testMap2() {
+    StringColumn c =
+        DoubleColumn.create("t1", new double[] {-1, 0, 1})
+            .map(String::valueOf, StringColumn::create);
+    assertContentEquals(c, "-1.0", "0.0", "1.0");
+  }
+
+  @Test
   public void testMaxComparator() {
     assertEquals(
         Double.valueOf(1.0),


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This fixed issue #704 by updating the `Column.mapInto` javadoc.

It also adds two new `Column.map` methods which offer a way to append data to a newly created column. The output column is easily created/provided via a `Supplier` or `Function`.

## Testing

Yes.
