### PR TITLE
Adds custom color scale to Marker

### DIFF
--- a/jsplot/src/main/resources/marker_template.html
+++ b/jsplot/src/main/resources/marker_template.html
@@ -9,7 +9,7 @@
     color: {{colorArray | raw}},
 {% endif %}
 {% if colorScale is not null %}
-    colorscale: '{{colorScale | raw}}',
+    colorscale: {{colorScale | raw}},
 {% endif %}
 {% if colorBar is not null %}
     colorbar: {{colorBar | raw}},

--- a/jsplot/src/test/java/tech/tablesaw/components/MarkerTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/components/MarkerTest.java
@@ -16,4 +16,18 @@ public class MarkerTest {
     assertTrue(x.asJavascript().contains("symbol"));
     assertTrue(x.asJavascript().contains("size"));
   }
+
+  @Test
+  public void testCustomPalette() {
+    Marker palette = Marker.builder().colorScale(Marker.Palette.JET).build();
+    assertTrue(palette.asJavascript().contains("colorscale: 'Jet'"), palette.asJavascript());
+    Marker x = Marker.builder().addColorScale(0, 255, 0, 0).addColorScale(1, 0, 255, 0).build();
+    assertTrue(
+        x.asJavascript()
+            .contains(
+                "colorscale: [\n"
+                    + "['0.0', 'rgb(255,0,0)'],\n"
+                    + "['1.0', 'rgb(0,255,0)']\n"
+                    + "]"));
+  }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Adds `MarkerBuilder.addColorScale(double value, int r, int g, int b)` and related JS generation code which allows custom (non-palette) color scales.

## Testing

Yes.
