### PR TITLE
Pr instant column min max

### DIFF
--- a/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/AggregateFunctions.java
@@ -1,14 +1,17 @@
 package tech.tablesaw.aggregate;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.apache.commons.math3.stat.StatUtils;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.commons.math3.stat.descriptive.moment.Kurtosis;
 import org.apache.commons.math3.stat.descriptive.moment.Skewness;
+
 import tech.tablesaw.api.BooleanColumn;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DateTimeColumn;
+import tech.tablesaw.api.InstantColumn;
 import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.columns.numbers.DoubleColumnType;
@@ -48,6 +51,21 @@ public class AggregateFunctions {
         @Override
         public LocalDateTime summarize(DateTimeColumn column) {
           return column.max();
+        }
+      };
+
+  public static InstantAggregateFunction maxInstant =
+      new InstantAggregateFunction("Max Instant") {
+        @Override
+        public Instant summarize(InstantColumn column) {
+          return column.max();
+        }
+      };
+  public static InstantAggregateFunction minInstant =
+      new InstantAggregateFunction("Min Instant") {
+        @Override
+        public Instant summarize(InstantColumn column) {
+          return column.min();
         }
       };
 

--- a/core/src/main/java/tech/tablesaw/aggregate/InstantAggregateFunction.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/InstantAggregateFunction.java
@@ -1,0 +1,25 @@
+package tech.tablesaw.aggregate;
+
+import java.time.Instant;
+import tech.tablesaw.api.ColumnType;
+import tech.tablesaw.api.InstantColumn;
+
+/** A partial implementation of aggregate functions to summarize over an instant column */
+public abstract class InstantAggregateFunction extends AggregateFunction<InstantColumn, Instant> {
+
+  public InstantAggregateFunction(String name) {
+    super(name);
+  }
+
+  public abstract Instant summarize(InstantColumn column);
+
+  @Override
+  public boolean isCompatibleColumn(ColumnType type) {
+    return type.equals(ColumnType.INSTANT);
+  }
+
+  @Override
+  public ColumnType returnType() {
+    return ColumnType.INSTANT;
+  }
+}

--- a/core/src/main/java/tech/tablesaw/api/InstantColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/InstantColumn.java
@@ -486,19 +486,18 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
   }
 
   public Instant max() {
-    long max;
-    if (!isEmpty()) {
-      max = getPackedDateTime(0);
-    } else {
+    if (isEmpty()) {
       return null;
     }
+    long max = Long.MIN_VALUE;
+    boolean allMissing = true;
     for (long aData : data) {
       if (InstantColumnType.missingValueIndicator() != aData) {
-        max = (max > aData) ? max : aData;
+        max = Math.max(max , aData);
+        allMissing = false;
       }
     }
-
-    if (InstantColumnType.missingValueIndicator() == max) {
+    if (allMissing) {
       return null;
     }
     return PackedInstant.asInstant(max);
@@ -512,19 +511,18 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
 
   @Override
   public Instant min() {
-    long min;
-
-    if (!isEmpty()) {
-      min = getPackedDateTime(0);
-    } else {
+    if (isEmpty()) {
       return null;
     }
+    long min = Long.MAX_VALUE;
+    boolean allMissing = true;
     for (long aData : data) {
       if (InstantColumnType.missingValueIndicator() != aData) {
-        min = (min < aData) ? min : aData;
+        min = Math.min(min, aData);
+        allMissing = false;
       }
     }
-    if (Integer.MIN_VALUE == min) {
+    if (allMissing) {
       return null;
     }
     return PackedInstant.asInstant(min);

--- a/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
+++ b/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
@@ -93,7 +93,7 @@ class AggregateFunctionsTest {
     Instant i3 = Instant.ofEpochMilli(30_000L);
     Instant i4 = null;
 
-    // Explicitly test havin
+    // Explicitly test having a first value of missing 
     InstantColumn ic = InstantColumn.create("instants", 5);
     ic.appendMissing();
     ic.append(i3);

--- a/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
+++ b/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
@@ -41,6 +41,7 @@ import static tech.tablesaw.api.QuerySupport.date;
 import static tech.tablesaw.api.QuerySupport.num;
 import static tech.tablesaw.api.QuerySupport.str;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import org.apache.commons.math3.stat.StatUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.BooleanColumn;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.InstantColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.csv.CsvReadOptions;
@@ -82,6 +84,66 @@ class AggregateFunctionsTest {
     Table result = table.summarize("approval", "date", mean, earliestDate).by(byColumn);
     assertEquals(3, result.columnCount());
     assertEquals(13, result.rowCount());
+  }
+
+  @Test
+  void testInstantMinMax() {
+    Instant i1 = Instant.ofEpochMilli(10_000L);
+    Instant i2 = Instant.ofEpochMilli(20_000L);
+    Instant i3 = Instant.ofEpochMilli(30_000L);
+    Instant i4 = null;
+
+    // Explicitly test havin
+    InstantColumn ic = InstantColumn.create("instants", 5);
+    ic.appendMissing();
+    ic.append(i3);
+    ic.append(i1);
+    ic.append(i2);
+    ic.appendMissing();
+    ic.append(i4);
+    Table test = Table.create("testInstantMath", ic);
+    Table minI = test.summarize("instants", AggregateFunctions.minInstant).apply();
+    Table maxI = test.summarize("instants", AggregateFunctions.maxInstant).apply();
+    assertEquals(i1, minI.get(0, 0));
+    assertEquals(i3, maxI.get(0, 0));
+  }
+
+  @Test
+  void testInstantMinWorksWithLeadingNull() {
+    Instant i1 = null;
+    Instant i2 = Instant.ofEpochMilli(20_000L);
+    Instant i3 = Instant.ofEpochMilli(30_000L);
+
+    InstantColumn ic1 = InstantColumn.create("instants", 3);
+    ic1.append(i1);
+    ic1.append(i2);
+    ic1.append(i3);
+    assertEquals(i2, ic1.min());
+
+    InstantColumn ic2 = InstantColumn.create("instants", 3);
+    ic2.appendMissing();
+    ic2.append(i2);
+    ic2.append(i3);
+    assertEquals(i2, ic2.min());
+  }
+
+  @Test
+  void testInstantMaxWorksWithLeadingNull() {
+    Instant i1 = null;
+    Instant i2 = Instant.ofEpochMilli(20_000L);
+    Instant i3 = Instant.ofEpochMilli(30_000L);
+
+    InstantColumn ic1 = InstantColumn.create("instants", 3);
+    ic1.append(i1);
+    ic1.append(i2);
+    ic1.append(i3);
+    assertEquals(i3, ic1.max());
+
+    InstantColumn ic2 = InstantColumn.create("instants", 3);
+    ic2.appendMissing();
+    ic2.append(i2);
+    ic2.append(i3);
+    assertEquals(i3, ic2.max());
   }
 
   @Test


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
What changed:

1) Fixed a bug in InstantColumn where min would be null if the first value in the column was missing.
2) Update AggregationFunctions to provide a minInstant, maxInstant method for rolling up InstantColumns

## Testing

Did you add a unit test?
Yes: See AggregateFunctionsTest
