### PR TITLE
Adds AutoCorrelation support

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/NumericColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/NumericColumn.java
@@ -1,17 +1,7 @@
 package tech.tablesaw.api;
 
-import static tech.tablesaw.aggregate.AggregateFunctions.*;
-import static tech.tablesaw.columns.numbers.NumberPredicates.*;
-
 import it.unimi.dsi.fastutil.doubles.DoubleComparator;
 import it.unimi.dsi.fastutil.doubles.DoubleRBTreeSet;
-import java.text.NumberFormat;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.BiPredicate;
-import java.util.function.DoubleBinaryOperator;
-import java.util.function.DoubleFunction;
-import java.util.function.DoublePredicate;
 import org.apache.commons.math3.exception.NotANumberException;
 import org.apache.commons.math3.stat.correlation.KendallsCorrelation;
 import org.apache.commons.math3.stat.correlation.PearsonsCorrelation;
@@ -19,14 +9,21 @@ import org.apache.commons.math3.stat.correlation.SpearmansCorrelation;
 import tech.tablesaw.aggregate.AggregateFunctions;
 import tech.tablesaw.aggregate.NumericAggregateFunction;
 import tech.tablesaw.columns.Column;
-import tech.tablesaw.columns.numbers.NumberColumnFormatter;
-import tech.tablesaw.columns.numbers.NumberFilters;
-import tech.tablesaw.columns.numbers.NumberInterpolator;
-import tech.tablesaw.columns.numbers.NumberMapFunctions;
-import tech.tablesaw.columns.numbers.NumberRollingColumn;
-import tech.tablesaw.columns.numbers.Stats;
+import tech.tablesaw.columns.numbers.*;
 import tech.tablesaw.selection.BitmapBackedSelection;
 import tech.tablesaw.selection.Selection;
+
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleFunction;
+import java.util.function.DoublePredicate;
+
+import static tech.tablesaw.aggregate.AggregateFunctions.*;
+import static tech.tablesaw.columns.numbers.NumberPredicates.isMissing;
+import static tech.tablesaw.columns.numbers.NumberPredicates.isNotMissing;
 
 public interface NumericColumn<T extends Number>
     extends Column<T>, NumberMapFunctions, NumberFilters {
@@ -379,18 +376,18 @@ public interface NumericColumn<T extends Number>
     return new PearsonsCorrelation().correlation(x, y);
   }
 
-  default double autoCorrelation(){
+  default double autoCorrelation() {
     int defaultLag = 1;
     return autoCorrelation(defaultLag);
   }
 
-  default double autoCorrelation(int lag){
+  default double autoCorrelation(int lag) {
     int slice = this.size() - lag;
-    if(slice <= 1){
+    if (slice <= 1) {
       return Double.NaN;
     }
-    NumericColumn<?> x = (NumericColumn<?>)this.first(slice);
-    NumericColumn<?> y = (NumericColumn<?>)this.last(slice);
+    NumericColumn<?> x = (NumericColumn<?>) this.first(slice);
+    NumericColumn<?> y = (NumericColumn<?>) this.last(slice);
     return new PearsonsCorrelation().correlation(x.asDoubleArray(), y.asDoubleArray());
   }
 

--- a/core/src/main/java/tech/tablesaw/api/NumericColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/NumericColumn.java
@@ -379,6 +379,21 @@ public interface NumericColumn<T extends Number>
     return new PearsonsCorrelation().correlation(x, y);
   }
 
+  default double autoCorrelation(){
+    int defaultLag = 1;
+    return autoCorrelation(defaultLag);
+  }
+
+  default double autoCorrelation(int lag){
+    int slice = this.size() - lag;
+    if(slice <= 1){
+      return Double.NaN;
+    }
+    NumericColumn<?> x = (NumericColumn<?>)this.first(slice);
+    NumericColumn<?> y = (NumericColumn<?>)this.last(slice);
+    return new PearsonsCorrelation().correlation(x.asDoubleArray(), y.asDoubleArray());
+  }
+
   /**
    * Returns the Spearman's Rank correlation between the receiver and the otherColumn
    *

--- a/core/src/test/java/tech/tablesaw/api/NumericColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/NumericColumnTest.java
@@ -26,4 +26,27 @@ class NumericColumnTest {
     double[] expected = {0, 1, NaN, 5};
     assertArrayEquals(expected, result.asDoubleArray());
   }
+
+  @Test
+  void testAutoCorrelation() {
+    double[] sample = new double[] {0.397,0.157,-0.083,-0.243,-0.323,-0.243,-0.083,0.077,0.347};
+    DoubleColumn x = DoubleColumn.create("x", sample);
+    double roundOff = (double) Math.round(x.autoCorrelation() * 100) / 100;
+    double expected = 0.64;
+    assertEquals(expected, roundOff);
+
+    roundOff = (double) Math.round(x.autoCorrelation(4) * 100) / 100;
+    expected = -0.93;
+    assertEquals(expected, roundOff);
+
+    double actual = x.autoCorrelation(8);
+    expected = NaN;
+    assertEquals(expected, actual);
+
+    double[] sample2 = new double[] {0,0,0,0};
+    DoubleColumn y = DoubleColumn.create("y", sample2);
+    actual = y.autoCorrelation();
+    expected = NaN;
+    assertEquals(expected, actual);
+  }
 }

--- a/core/src/test/java/tech/tablesaw/api/NumericColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/NumericColumnTest.java
@@ -1,11 +1,11 @@
 package tech.tablesaw.api;
 
+import org.junit.jupiter.api.Test;
+import tech.tablesaw.columns.numbers.DoubleColumnType;
+
 import static java.lang.Double.NaN;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.junit.jupiter.api.Test;
-import tech.tablesaw.columns.numbers.DoubleColumnType;
 
 class NumericColumnTest {
 
@@ -29,7 +29,8 @@ class NumericColumnTest {
 
   @Test
   void testAutoCorrelation() {
-    double[] sample = new double[] {0.397,0.157,-0.083,-0.243,-0.323,-0.243,-0.083,0.077,0.347};
+    double[] sample =
+        new double[] {0.397, 0.157, -0.083, -0.243, -0.323, -0.243, -0.083, 0.077, 0.347};
     DoubleColumn x = DoubleColumn.create("x", sample);
     double roundOff = (double) Math.round(x.autoCorrelation() * 100) / 100;
     double expected = 0.64;
@@ -43,7 +44,7 @@ class NumericColumnTest {
     expected = NaN;
     assertEquals(expected, actual);
 
-    double[] sample2 = new double[] {0,0,0,0};
+    double[] sample2 = new double[] {0, 0, 0, 0};
     DoubleColumn y = DoubleColumn.create("y", sample2);
     actual = y.autoCorrelation();
     expected = NaN;


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

1. Added `autocorrelation()` in `NumericColumn` class. 
2. Two methods are added one with `lag` argument and one no arg
3. No argument `autocorrelation()` calculates autocorrelation with lag=1
4. Implementation follows `autocorr()` function of pandas. https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.autocorr.html
5. Fixes #35 

## Testing

Did you add a unit test?
Yes. Added in `NumericColumnTest`
