### PR TITLE
Change StringColumn summary to a more useful fixed format #718

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/StringColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/StringColumn.java
@@ -182,7 +182,25 @@ public class StringColumn extends AbstractStringColumn<StringColumn> {
 
   @Override
   public Table summary() {
-    return countByCategory();
+    Table summary = Table.create(this.name());
+    StringColumn measure = StringColumn.create("Measure");
+    StringColumn value = StringColumn.create("Value");
+    summary.addColumns(measure);
+    summary.addColumns(value);
+
+    measure.append("Count");
+    value.append(String.valueOf(size()));
+
+    measure.append("Unique");
+    value.append(String.valueOf(countUnique()));
+
+    Table countByCategory = countByCategory().sortDescendingOn("Count");
+    measure.append("Top");
+    value.append(countByCategory.stringColumn("Category").getString(0));
+
+    measure.append("Top Freq.");
+    value.appendObj(countByCategory.intColumn("Count").getString(0));
+    return summary;
   }
 
   /** */

--- a/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
@@ -716,4 +716,19 @@ class StringColumnTest {
     assertEquals(3, col1.countUnique());
     assertEquals(3, col1.unique().size());
   }
+
+  @Test
+  public void testSummary() {
+    Table summary = column.summary();
+    assertEquals(2, summary.columnCount());
+    assertEquals(4, summary.rowCount());
+    assertEquals("Count", summary.getUnformatted(0, 0));
+    assertEquals("4", summary.getUnformatted(0, 1));
+    assertEquals("Unique", summary.getUnformatted(1, 0));
+    assertEquals("4", summary.getUnformatted(1, 1));
+    assertEquals("Top", summary.getUnformatted(2, 0));
+    assertEquals("Value 4", summary.getUnformatted(2, 1));
+    assertEquals("Top Freq.", summary.getUnformatted(3, 0));
+    assertEquals("1", summary.getUnformatted(3, 1));
+  }
 }


### PR DESCRIPTION

Thanks for contributing.

- [ X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This is a pre-requisite for the larger change to change Relation.summary() to return a Table.
This changes the summary for the StringColumn to provide statistics in a fixed format. This is similar to the Python pandas implementation.

## Testing

Added a test for summary
