### PR TITLE
Fix apparent typo in docs: CsvReadOptionsBuilder -> CsvReadOptions.Builder

### DIFF
--- a/docs-src/dist/userguide/importing_data.md
+++ b/docs-src/dist/userguide/importing_data.md
@@ -39,7 +39,7 @@ This method supplies defaults for everything but the filename. We assume that co
 You can create an options object with a builder:
 
 ```Java
-CsvReadOptionsBuilder builder = 
+CsvReadOptions.Builder builder = 
 	CsvReadOptions.builder("myFile.csv")
 		.separator('\t')										// table is tab-delimited
 		.header(false)											// no header

--- a/docs-src/main/userguide/importing_data.md
+++ b/docs-src/main/userguide/importing_data.md
@@ -40,7 +40,7 @@ This method supplies defaults for everything but the filename. We assume that co
 You can create an options object with a builder:
 
 ```Java
-CsvReadOptionsBuilder builder = 
+CsvReadOptions.Builder builder = 
 	CsvReadOptions.builder("myFile.csv")
 		.separator('\t')										// table is tab-delimited
 		.header(false)											// no header

--- a/docs/userguide/importing_data.md
+++ b/docs/userguide/importing_data.md
@@ -40,7 +40,7 @@ This method supplies defaults for everything but the filename. We assume that co
 You can create an options object with a builder:
 
 ```Java
-CsvReadOptionsBuilder builder = 
+CsvReadOptions.Builder builder = 
 	CsvReadOptions.builder("myFile.csv")
 		.separator('\t')										// table is tab-delimited
 		.header(false)											// no header


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

`CsvReadOptionsBuilder builder` appeared to be a typo for `CsvReadOptions.Builder builder` (add a dot between `Options` and `Builder`.) 
https://www.javadoc.io/static/tech.tablesaw/tablesaw-core/0.31.0/tech/tablesaw/io/csv/CsvReadOptions.html

## Testing

Did you add a unit test?

No. The documentation examples seem to be untested. Is there a framework to test documentation examples?