### PR TITLE
Made Component.engine non-static, fixes issue #761

### DIFF
--- a/jsplot/src/main/java/tech/tablesaw/plotly/components/Component.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/components/Component.java
@@ -14,13 +14,18 @@ import java.util.Map;
 
 public abstract class Component {
 
-  protected static final PebbleEngine engine = TemplateUtils.getNewEngine();
   protected static final ObjectMapper mapper = new ObjectMapper();
 
   {
     mapper.enable(SerializationFeature.INDENT_OUTPUT);
     mapper.setSerializationInclusion(Include.NON_NULL);
     mapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+  }
+
+  private final PebbleEngine engine = TemplateUtils.getNewEngine();
+
+  protected PebbleEngine getEngine() {
+    return engine;
   }
 
   @Deprecated
@@ -48,7 +53,7 @@ public abstract class Component {
     PebbleTemplate compiledTemplate;
 
     try {
-      compiledTemplate = engine.getTemplate(filename);
+      compiledTemplate = getEngine().getTemplate(filename);
       compiledTemplate.evaluate(writer, getContext());
     } catch (PebbleException e) {
       throw new IllegalStateException(e);

--- a/jsplot/src/main/java/tech/tablesaw/plotly/components/threeD/Scene.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/components/threeD/Scene.java
@@ -54,7 +54,7 @@ public class Scene extends Component {
     Writer writer = new StringWriter();
     PebbleTemplate compiledTemplate;
     try {
-      compiledTemplate = engine.getTemplate("scene_template.html");
+      compiledTemplate = getEngine().getTemplate("scene_template.html");
       compiledTemplate.evaluate(writer, getContext());
     } catch (PebbleException e) {
       throw new IllegalStateException(e);

--- a/jsplot/src/test/java/tech/tablesaw/components/TemplateUtilsTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/components/TemplateUtilsTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.net.URL;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.plotly.components.Figure;
 import tech.tablesaw.plotly.components.Page;
@@ -29,7 +28,6 @@ public class TemplateUtilsTest {
   }
 
   @Test
-  @Disabled
   public void testCustomTemplateLocation() {
     URL url = this.getClass().getResource(this.getClass().getSimpleName() + ".class");
     assertNotNull(url, "Couldn't locate class (as resource), where template is also found");


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Made Component.engine non-static and added a protected getter, for use in sub-classes, e.g. Scene. Un-disabled test method in TemplateUtilsTest

## Testing

The existing test was un-disabled.