### PR TITLE
'fix' for issue 722

### DIFF
--- a/jsplot/src/main/java/tech/tablesaw/plotly/api/TimeSeriesPlot.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/api/TimeSeriesPlot.java
@@ -3,6 +3,7 @@ package tech.tablesaw.plotly.api;
 import java.util.List;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DateTimeColumn;
+import tech.tablesaw.api.InstantColumn;
 import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.plotly.components.Figure;
@@ -51,6 +52,13 @@ public class TimeSeriesPlot {
 
   public static Figure create(
       String title, String xTitle, DateTimeColumn xCol, String yTitle, NumericColumn<?> yCol) {
+    Layout layout = Layout.builder(title, xTitle, yTitle).build();
+    ScatterTrace trace = ScatterTrace.builder(xCol, yCol).mode(ScatterTrace.Mode.LINE).build();
+    return new Figure(layout, trace);
+  }
+
+  public static Figure create(
+      String title, String xTitle, InstantColumn xCol, String yTitle, NumericColumn<?> yCol) {
     Layout layout = Layout.builder(title, xTitle, yTitle).build();
     ScatterTrace trace = ScatterTrace.builder(xCol, yCol).mode(ScatterTrace.Mode.LINE).build();
     return new Figure(layout, trace);

--- a/jsplot/src/test/java/tech/tablesaw/plotly/TimeSeriesTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/plotly/TimeSeriesTest.java
@@ -1,0 +1,27 @@
+package tech.tablesaw.plotly;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import tech.tablesaw.api.Table;
+import tech.tablesaw.plotly.api.TimeSeriesPlot;
+import tech.tablesaw.plotly.components.Figure;
+
+class TimeSeriesTest {
+
+  @Test
+  void testWithInstant() throws IOException {
+
+    Table dateTable = Table.read().csv("../data/dateTimeTestFile.csv");
+    dateTable.addColumns(dateTable.dateTimeColumn(0).asInstantColumn().setName("Instant"));
+    Figure figure =
+        TimeSeriesPlot.create(
+            "Value over time",
+            "time",
+            dateTable.instantColumn("Instant"),
+            "values",
+            dateTable.numberColumn("Value"));
+    assertNotNull(figure);
+  }
+}


### PR DESCRIPTION
adding a method to create a time series using instants.

Note that this could have been done using the ScatterTrace code, so this is more a convenience than a 'fix'. 

Thanks for contributing.

- [ ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

What was changed

## Testing

Did you add a unit test?
