### PR TITLE
this is a fix for 689.

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
@@ -33,7 +33,6 @@ import it.unimi.dsi.fastutil.ints.IntComparator;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -667,19 +666,6 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
   @Override
   public int compare(Boolean o1, Boolean o2) {
     return Boolean.compare(o1, o2);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    BooleanColumn that = (BooleanColumn) o;
-    return Objects.equals(data, that.data);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(data);
   }
 
   private static class BooleanColumnIterator implements Iterator<Boolean> {

--- a/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.tablesaw.api.BooleanColumn;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DateTimeColumn;
@@ -118,6 +119,16 @@ public class ColumnTest {
     Column<String> c = table.stringColumn("who");
     assertTrue(c.contains("fox"));
     assertFalse(c.contains("foxes"));
+  }
+
+  @Test
+  void testColumnDelete() {
+    final Table table =
+        Table.create(
+            BooleanColumn.create("a"), BooleanColumn.create("b"), BooleanColumn.create("c"));
+    assertEquals(3, table.columnCount());
+    table.removeColumns(table.columnNames().indexOf("b"));
+    assertEquals(2, table.columnCount());
   }
 
   @Test

--- a/core/src/test/java/tech/tablesaw/columns/booleans/BooleanMapUtilsTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/booleans/BooleanMapUtilsTest.java
@@ -5,31 +5,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.BooleanColumn;
 
-public class BooleanMapUtilsTest {
-  private BooleanColumn singleFalse = BooleanColumn.create("", new boolean[] {false});
-  private BooleanColumn singleTrue = BooleanColumn.create("", new boolean[] {true});
+class BooleanMapUtilsTest {
+  private BooleanColumn singleFalse = BooleanColumn.create("", false);
+  private BooleanColumn singleTrue = BooleanColumn.create("", true);
 
   @Test
-  public void testAnd() {
+  void testAnd() {
     BooleanColumn actual = singleTrue.and(singleFalse);
-    assertEquals(singleFalse, actual);
+    assertEquals(singleFalse.get(0), actual.get(0));
   }
 
   @Test
-  public void testOr() {
+  void testOr() {
     BooleanColumn actual = singleFalse.or(singleTrue);
-    assertEquals(singleTrue, actual);
+    assertEquals(singleTrue.get(0), actual.get(0));
   }
 
   @Test
-  public void testAndNot() {
+  void testAndNot() {
     BooleanColumn actual = singleTrue.andNot(singleFalse);
-    assertEquals(singleTrue, actual);
+    assertEquals(singleTrue.get(0), actual.get(0));
   }
 
   @Test
-  public void testAndNot2() {
+  void testAndNot2() {
     BooleanColumn actual = singleFalse.andNot(singleTrue);
-    assertEquals(singleFalse, actual);
+    assertEquals(singleFalse.get(0), actual.get(0));
   }
 }


### PR DESCRIPTION
The issue only affects boolean columns, as boolean columns were the only ones with an explicit equals method. This was removed to rely on identity.

I can't see a reason to not rely on identity here, but i'm open to feedback on this.

Thanks for contributing.

- [ ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

What was changed

## Testing

Did you add a unit test?
