### PR TITLE
Standardize CSV escaping

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
@@ -31,6 +31,7 @@ public class CsvReadOptions extends ReadOptions {
   private final ColumnType[] columnTypes;
   private final Character separator;
   private final Character quoteChar;
+  private final Character escapeChar;
   private final String lineEnding;
   private final Integer maxNumberOfColumns;
   private final Character commentPrefix;
@@ -42,6 +43,7 @@ public class CsvReadOptions extends ReadOptions {
     columnTypes = builder.columnTypes;
     separator = builder.separator;
     quoteChar = builder.quoteChar;
+    escapeChar = builder.escapeChar;
     lineEnding = builder.lineEnding;
     maxNumberOfColumns = builder.maxNumberOfColumns;
     commentPrefix = builder.commentPrefix;
@@ -111,6 +113,10 @@ public class CsvReadOptions extends ReadOptions {
     return quoteChar;
   }
 
+  public Character escapeChar() {
+    return escapeChar;
+  }
+
   public String lineEnding() {
     return lineEnding;
   }
@@ -137,8 +143,9 @@ public class CsvReadOptions extends ReadOptions {
 
   public static class Builder extends ReadOptions.Builder {
 
-    private Character separator = ',';
+    private Character separator;
     private Character quoteChar;
+    private Character escapeChar;
     private String lineEnding;
     private ColumnType[] columnTypes;
     private Integer maxNumberOfColumns = 10_000;
@@ -178,6 +185,11 @@ public class CsvReadOptions extends ReadOptions {
 
     public Builder quoteChar(Character quoteChar) {
       this.quoteChar = quoteChar;
+      return this;
+    }
+
+    public Builder escapeChar(Character escapeChar) {
+      this.escapeChar = escapeChar;
       return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReader.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReader.java
@@ -160,6 +160,9 @@ public class CsvReader extends FileReader implements DataReader<CsvReadOptions> 
     if (options.quoteChar() != null) {
       format.setQuote(options.quoteChar());
     }
+    if (options.escapeChar() != null) {
+      format.setQuoteEscape(options.escapeChar());
+    }
     if (options.separator() != null) {
       format.setDelimiter(options.separator());
     }

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvWriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvWriteOptions.java
@@ -13,9 +13,9 @@ public class CsvWriteOptions extends WriteOptions {
   private final boolean header;
   private final boolean ignoreLeadingWhitespaces;
   private final boolean ignoreTrailingWhitespaces;
-  private final char separator;
-  private final char quoteChar;
-  private final char escapeChar;
+  private final Character separator;
+  private final Character quoteChar;
+  private final Character escapeChar;
   private final String lineEnd;
   private final boolean quoteAllFields;
 
@@ -43,11 +43,11 @@ public class CsvWriteOptions extends WriteOptions {
     return ignoreTrailingWhitespaces;
   }
 
-  public char separator() {
+  public Character separator() {
     return separator;
   }
 
-  public char escapeChar() {
+  public Character escapeChar() {
     return escapeChar;
   }
 
@@ -55,7 +55,7 @@ public class CsvWriteOptions extends WriteOptions {
     return quoteAllFields;
   }
 
-  public char quoteChar() {
+  public Character quoteChar() {
     return quoteChar;
   }
 
@@ -89,10 +89,10 @@ public class CsvWriteOptions extends WriteOptions {
     private boolean ignoreLeadingWhitespaces = true;
     private boolean ignoreTrailingWhitespaces = true;
     private boolean quoteAllFields = false;
-    private char separator = ',';
+    private Character separator;
     private String lineEnd = System.lineSeparator();
-    private char escapeChar = '\\';
-    private char quoteChar = '"';
+    private Character escapeChar;
+    private Character quoteChar;
 
     protected Builder(String fileName) throws IOException {
       super(Paths.get(fileName).toFile());

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvWriter.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvWriter.java
@@ -73,10 +73,18 @@ public final class CsvWriter implements DataWriter<CsvWriteOptions> {
     CsvWriterSettings settings = new CsvWriterSettings();
     // Sets the character sequence to write for the values that are null.
     settings.setNullValue(nullValue);
-    settings.getFormat().setDelimiter(options.separator());
-    settings.getFormat().setQuote(options.quoteChar());
-    settings.getFormat().setQuoteEscape(options.escapeChar());
-    settings.getFormat().setLineSeparator(options.lineEnd());
+    if (options.separator() != null) {
+      settings.getFormat().setDelimiter(options.separator());
+    }
+    if (options.quoteChar() != null) {
+      settings.getFormat().setQuote(options.quoteChar());
+    }
+    if (options.escapeChar() != null) {
+      settings.getFormat().setQuoteEscape(options.escapeChar());
+    }
+    if (options.lineEnd() != null) {
+      settings.getFormat().setLineSeparator(options.lineEnd());
+    }
     settings.setIgnoreLeadingWhitespaces(options.ignoreLeadingWhitespaces());
     settings.setIgnoreTrailingWhitespaces(options.ignoreTrailingWhitespaces());
     // writes empty lines as well.

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
@@ -38,10 +38,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.nio.file.Paths;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -53,6 +56,7 @@ import tech.tablesaw.api.DateColumn;
 import tech.tablesaw.api.DateTimeColumn;
 import tech.tablesaw.api.LongColumn;
 import tech.tablesaw.api.ShortColumn;
+import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.AddCellToColumnException;
 
@@ -737,5 +741,19 @@ public class CsvReaderTest {
 
     List<Integer> intValues = (List<Integer>) t.column(0).asList();
     assertEquals(true, values.containsAll(intValues));
+  }
+
+  @Test
+  public void preserveQuote() throws IOException {
+    Table table = Table.create("test", StringColumn.create("colName", Arrays.asList("\"")));
+
+    // test CSV writes quote properly
+    Writer writer = new StringWriter();
+    table.write().csv(writer);
+    String string = writer.toString();
+
+    // test CSV reads quote back again
+    Table out = Table.read().csv(new StringReader(string));
+    assertEquals(table.get(0, 0), out.get(0, 0));
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Closes https://github.com/jtablesaw/tablesaw/issues/771

Made `CsvReadOptions` and `CsvWriteOptions` use the same defaults. The options were nullable in `CsvReadOptions` and fell back to the univocity defaults whereas `CsvWriteOptions` was non-nullable and specified its own non-standard defaults. I changed `CsvWriteOptions` to be nullable and fallback to the univocity defaults.

## Testing

Added a unit test