### PR TITLE
Adds domain to pie trace in order to support subplots

### DIFF
--- a/jsplot/src/main/java/tech/tablesaw/plotly/components/Domain.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/components/Domain.java
@@ -1,0 +1,75 @@
+package tech.tablesaw.plotly.components;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Domain extends Component {
+
+  private final Integer row;
+  private final Integer column;
+  private final double[] x;
+  private final double[] y;
+
+  private Domain(DomainBuilder builder) {
+    this.x = builder.x;
+    this.y = builder.y;
+    this.row = builder.row;
+    this.column = builder.column;
+  }
+
+  @Override
+  public String asJavascript() {
+    return asJSON();
+  }
+
+  @Override
+  protected Map<String, Object> getContext() {
+    Map<String, Object> context = new HashMap<>();
+    context.put("column", column);
+    context.put("row", row);
+    context.put("x", x);
+    context.put("y", y);
+    return context;
+  }
+
+  @Override
+  protected Map<String, Object> getJSONContext() {
+    return getContext();
+  }
+
+  public static DomainBuilder builder() {
+    return new DomainBuilder();
+  }
+
+  public static class DomainBuilder {
+
+    private Integer row;
+    private Integer column;
+    private double[] x;
+    private double[] y;
+
+    public DomainBuilder row(int row) {
+      this.row = row;
+      return this;
+    }
+
+    public DomainBuilder column(int column) {
+      this.column = column;
+      return this;
+    }
+
+    public DomainBuilder x(double[] x) {
+      this.x = x;
+      return this;
+    }
+
+    public DomainBuilder y(double[] y) {
+      this.y = y;
+      return this;
+    }
+
+    public Domain build() {
+      return new Domain(this);
+    }
+  }
+}

--- a/jsplot/src/main/java/tech/tablesaw/plotly/traces/PieTrace.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/traces/PieTrace.java
@@ -10,16 +10,19 @@ import java.util.Map;
 import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.plotly.Utils;
+import tech.tablesaw.plotly.components.Domain;
 
 public class PieTrace extends AbstractTrace {
 
   private final double[] values;
   private final Object[] labels;
+  private final Domain domain;
 
   private PieTrace(PieBuilder builder) {
     super(builder);
     this.values = builder.values;
     this.labels = builder.labels;
+    this.domain = builder.domain;
   }
 
   @Override
@@ -46,6 +49,9 @@ public class PieTrace extends AbstractTrace {
     if (labels != null) {
       context.put("labels", Utils.dataAsString(labels));
     }
+    if (domain != null) {
+      context.put("domain", domain.asJavascript());
+    }
     return context;
   }
 
@@ -62,10 +68,16 @@ public class PieTrace extends AbstractTrace {
     private final String type = "pie";
     private final double[] values;
     private final Object[] labels;
+    private Domain domain;
 
     private PieBuilder(Object[] labels, double[] values) {
       this.labels = labels;
       this.values = values;
+    }
+
+    public PieBuilder domain(Domain domain) {
+      this.domain = domain;
+      return this;
     }
 
     public PieTrace build() {

--- a/jsplot/src/main/resources/pie_trace_template.html
+++ b/jsplot/src/main/resources/pie_trace_template.html
@@ -6,6 +6,9 @@ var {{variableName}} =
 {% if values is not null %}
         values: {{values | raw}},
 {% endif %}
+{% if domain is not null %}
+        domain: {{domain | raw}},
+{% endif %}
         type: '{{type}}',
         name: '{{name}}',
  }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Plotly supports pie chart [subplots](https://plot.ly/javascript/pie-charts/#pie-chart-subplots). This is doable by adding the `domain` info.

## Testing

Manual testing. With this:

```java
        PieTrace trace = PieTrace.builder(new Object[]{"A","B"}, new double[]{2.0, 1})
                .domain(Domain.builder().row(0).column(0).build())
                .build();
        PieTrace trace2 = PieTrace.builder(new Object[]{"A","B"}, new double[]{12.0, 21})
                .domain(Domain.builder().row(0).column(1).build())
                .build();
        PieTrace trace3 = PieTrace.builder(new Object[]{"A","B"}, new double[]{20.0, 10})
                .domain(Domain.builder().row(1).column(1).build())
                .build();

        Layout layout = Layout.builder()
                .grid(Grid.builder().rows(2).columns(2).build())
                .build();

        Figure f = new Figure(layout, trace, trace2, trace3);
```

we get this:

<img width="587" alt="Screenshot 2020-03-10 at 12 17 31" src="https://user-images.githubusercontent.com/991554/76302716-26f8a780-62c9-11ea-9b8a-c628765eb521.png">
