### PR TITLE
Fix behavior of INNER and LEFT_OUTER joins with empty left table

### DIFF
--- a/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
+++ b/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
@@ -202,6 +202,14 @@ public class DataFrameJoiner {
     List<Index> table2Indexes = buildIndexesForJoinColumns(table2JoinColumnIndexes, table2);
     validateIndexes(table1Indexes, table2Indexes);
 
+    if (table1.rowCount() == 0 &&
+        (joinType == JoinType.LEFT_OUTER || joinType == JoinType.INNER)) {
+      // Handle special case of empty table here so it doesn't fall through to the behavior
+      // that adds rows for full outer and right outer joins 
+      result.removeColumns(Ints.toArray(resultIgnoreColIndexes));
+      return result;
+    }
+
     Selection table1DoneRows = Selection.with();
     Selection table2DoneRows = Selection.with();
     for (Row row : table1) {

--- a/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerTest.java
+++ b/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerTest.java
@@ -2,12 +2,16 @@ package tech.tablesaw.joining;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.common.base.Joiner;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Joiner;
+
+import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.api.TextColumn;
 import tech.tablesaw.columns.Column;
@@ -1287,5 +1291,29 @@ public class DataFrameJoinerTest {
         () -> {
           table1.joinOn("ID").inner(table2);
         });
+  }
+
+  @Test
+  public void innerJoinEmptyLeftTable() {
+    StringColumn animalColumn = StringColumn.create("Animal");
+    Table leftTable = Table.create(animalColumn);
+    Table rightTable = ANIMAL_NAMES;
+    Table joined = leftTable.joinOn("Animal").inner(rightTable);
+    assertEquals(0, joined.rowCount());
+    for (Column<?> column : joined.columnArray()) {
+      assertEquals(0, column.size());
+    }
+  }
+
+  @Test
+  public void leftOuterJoinEmptyLeftTable() {
+    StringColumn animalColumn = StringColumn.create("Animal");
+    Table leftTable = Table.create(animalColumn);
+    Table rightTable = ANIMAL_NAMES;
+    Table joined = leftTable.joinOn("Animal").leftOuter(rightTable);
+    assertEquals(0, joined.rowCount());
+    for (Column<?> column : joined.columnArray()) {
+      assertEquals(0, column.size());
+    }
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Current behavior of tablesaw behaves like a right outer join or full outer join should behave if the left table is empty. Based on review of the source code, this appears to be the case because the normal termination for left outer join and inner join is within a loop over the rows of the first table. This commit handles the special case of an empty left table for left outer join and inner join, correctly returning an empty table with the appropriate columns.

## Testing

Although it should be fairly simple to test this, I did not take the time to understand your testing framework and add a unit test.