### PR TITLE
Converting Time to LocalTime in TimeColumn's appendObj()

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/TimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TimeColumn.java
@@ -26,6 +26,7 @@ import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.nio.ByteBuffer;
+import java.sql.Time;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -176,11 +177,15 @@ public class TimeColumn extends AbstractColumn<TimeColumn, LocalTime>
     if (obj == null) {
       return appendMissing();
     }
-    if (!(obj instanceof LocalTime)) {
-      throw new IllegalArgumentException(
-          "Cannot append " + obj.getClass().getName() + " to TimeColumn");
+    if (obj instanceof LocalTime) {
+      return append((LocalTime) obj);
     }
-    return append((LocalTime) obj);
+    if (obj instanceof Time) {
+      Time time = (Time) obj;
+      return append(time.toLocalTime());
+    }
+    throw new IllegalArgumentException(
+          "Cannot append " + obj.getClass().getName() + " to TimeColumn");
   }
 
   @Override

--- a/core/src/test/java/tech/tablesaw/api/TimeColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TimeColumnTest.java
@@ -14,16 +14,13 @@
 
 package tech.tablesaw.api;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static tech.tablesaw.columns.times.PackedLocalTime.getMinuteOfDay;
 import static tech.tablesaw.columns.times.PackedLocalTime.getSecondOfDay;
 import static tech.tablesaw.columns.times.PackedLocalTime.of;
 
 import java.nio.ByteBuffer;
+import java.sql.Time;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -405,6 +402,37 @@ public class TimeColumnTest {
     TimeColumn col = TimeColumn.create("Game time");
     col.appendCell(null);
     assertNull(col.get(0));
+  }
+
+  @Test
+  public void testAppendObjNull() {
+    TimeColumn returned = column1.appendObj(null);
+    assertEquals(column1, returned);
+    assertEquals(1, returned.size());
+    assertTrue(returned.isMissing(0));
+  }
+
+  @Test
+  public void testAppendObjLocalTime() {
+    LocalTime localTime = LocalTime.of(9,10,42);
+    TimeColumn returned = column1.appendObj(localTime);
+    assertEquals(column1, returned);
+    assertEquals(1, returned.size());
+    assertEquals(LocalTime.of(9,10,42), returned.get(0));
+  }
+
+  @Test
+  public void testAppendObjTime() {
+    Time time = Time.valueOf("09:10:42");
+    TimeColumn returned = column1.appendObj(time);
+    assertEquals(column1, returned);
+    assertEquals(1, returned.size());
+    assertEquals(LocalTime.of(9,10,42), returned.get(0));
+  }
+
+  @Test
+  public void testAppendObjIllegal() {
+    assertThrows(IllegalArgumentException.class, () -> column1.appendObj(new Object()));
   }
 
   private void assertMinAndMaxEquals(int expected, IntColumn numberColumn) {


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Fixes #789 by converting java.sql.Time to java.time.LocalTime in TimeColumn's appendObj(obj).

## Testing

Added four tests in TimeColumnTest, which are all green.
