### PR TITLE
remove precondition on aggregate such that empty slices are allowed

### DIFF
--- a/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
+++ b/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
@@ -14,7 +14,6 @@
 
 package tech.tablesaw.table;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
@@ -187,7 +186,6 @@ public class TableSliceGroup implements Iterable<TableSlice> {
    */
   @SuppressWarnings({"unchecked", "rawtypes"})
   public Table aggregate(ListMultimap<String, AggregateFunction<?, ?>> functions) {
-    Preconditions.checkArgument(!getSlices().isEmpty());
     Table groupTable = summaryTableName(sourceTable);
     StringColumn groupColumn = StringColumn.create("Group");
     groupTable.addColumns(groupColumn);


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

A precondition was removed from `tech.tablesaw.table.TableSliceGroup.aggregate(ListMultimap<String, AggregateFunction<?, ?>> functions)` such that the method no longer throws an `IllegalArgumentException` when the table is empty.

This PR has also been discussed in #785 

## Testing

A unit test is included that makes sure that aggregations on an empty table can be done, that the resulting table is also empty and that the table has the expected number of columns.

See `tech.tablesaw.table.TableSliceGroupTest.aggregateWithEmptyResult()`