### PR TITLE
Revert "Reduce code duplication"

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/Column.java
+++ b/core/src/main/java/tech/tablesaw/columns/Column.java
@@ -363,7 +363,15 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
    */
   default <R, C extends Column<R>> C map(
       Function<? super T, ? extends R> fun, Function<String, C> creator) {
-    return mapInto(fun, creator.apply(name()));
+    C into = creator.apply(name());
+    for (int i = 0; i < size(); i++) {
+      if (isMissing(i)) {
+        into.appendMissing();
+      } else {
+        into.append(fun.apply(get(i)));
+      }
+    }
+    return into;
   }
 
   Column<T> setMissing(int i);

--- a/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
@@ -293,7 +293,7 @@ public class ColumnTest {
   public void testMap2() {
     StringColumn c =
         DoubleColumn.create("t1", new double[] {-1, 0, 1})
-            .map(String::valueOf, name -> StringColumn.create(name, 3));
+            .map(String::valueOf, StringColumn::create);
     assertContentEquals(c, "-1.0", "0.0", "1.0");
   }
 


### PR DESCRIPTION
This reverts commit 7516c614527e33699f9ced936f34387588c4ace0.

Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Commit 7516c614527e33699f9ced936f34387588c4ace0 changes the semantics of `map`. `map` appends while `mapInto` sets values.

In a project I have this pattern all over the place:

```java
DateTimeColumn update = t.dateTimeColumn("Last Update");
DateColumn date = update.map(d -> d.toLocalDate(), DateColumn::create);
```

the latest Tablesaw update breaks everything as it tries to set values into a column with no rows.

## Testing

None.