### PR TITLE
* when table create from ResultSet ,columnName prefer sqlColumn alias…

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
+++ b/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
@@ -102,7 +102,8 @@ public class SqlResultSetReader {
           metaData.getColumnType(i),
           metaData.getColumnName(i));
 
-      Column<?> newColumn = type.create(metaData.getColumnName(i));
+      // prefer alias
+      Column<?> newColumn = type.create(metaData.getColumnLabel(i));
       table.addColumns(newColumn);
     }
 

--- a/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
+++ b/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
@@ -102,7 +102,6 @@ public class SqlResultSetReader {
           metaData.getColumnType(i),
           metaData.getColumnName(i));
 
-      // prefer alias
       Column<?> newColumn = type.create(metaData.getColumnLabel(i));
       table.addColumns(newColumn);
     }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

when table create from ResultSet ,columnName prefer sqlColumn alias instead of sqlColumn itself. (getColumnLabel > getColumnName)

## Testing

no need .  ResultMetaData#getColumnLabel 's default value is ResultMetaData#getColumnName 
