### PR TITLE
Fix #804 ohlc and candlestick plots did not supt datetime cols

### DIFF
--- a/jsplot/src/main/java/tech/tablesaw/plotly/api/CandlestickPlot.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/api/CandlestickPlot.java
@@ -2,10 +2,16 @@ package tech.tablesaw.plotly.api;
 
 import tech.tablesaw.api.Table;
 import tech.tablesaw.plotly.components.Figure;
-import tech.tablesaw.plotly.components.Layout;
-import tech.tablesaw.plotly.traces.ScatterTrace;
 
+/**
+ * Candlestick time series plot typically used to illustrate price trends for stocks and other
+ * exchange-traded products
+ *
+ * @see OHLCPlot
+ */
 public class CandlestickPlot {
+
+  private static final String PLOT_TYPE = "candlestick";
 
   public static Figure create(
       String title,
@@ -15,16 +21,6 @@ public class CandlestickPlot {
       String highCol,
       String lowCol,
       String closeCol) {
-    Layout layout = Layout.builder(title, xCol).build();
-    ScatterTrace trace =
-        ScatterTrace.builder(
-                table.dateColumn(xCol),
-                table.numberColumn(openCol),
-                table.numberColumn(highCol),
-                table.numberColumn(lowCol),
-                table.numberColumn(closeCol))
-            .type("candlestick")
-            .build();
-    return new Figure(layout, trace);
+    return PricePlot.create(title, table, xCol, openCol, highCol, lowCol, closeCol, PLOT_TYPE);
   }
 }

--- a/jsplot/src/main/java/tech/tablesaw/plotly/api/CandlestickPlot.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/api/CandlestickPlot.java
@@ -13,6 +13,7 @@ public class CandlestickPlot {
 
   private static final String PLOT_TYPE = "candlestick";
 
+  /** Returns Figure containing candlestick time series plot with a default layout */
   public static Figure create(
       String title,
       Table table,

--- a/jsplot/src/main/java/tech/tablesaw/plotly/api/OHLCPlot.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/api/OHLCPlot.java
@@ -13,6 +13,7 @@ public class OHLCPlot {
 
   private static final String PLOT_TYPE = "ohlc";
 
+  /** Returns Figure containing Open-High-Low-Close time series plot with a default layout */
   public static Figure create(
       String title,
       Table table,

--- a/jsplot/src/main/java/tech/tablesaw/plotly/api/OHLCPlot.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/api/OHLCPlot.java
@@ -2,10 +2,16 @@ package tech.tablesaw.plotly.api;
 
 import tech.tablesaw.api.Table;
 import tech.tablesaw.plotly.components.Figure;
-import tech.tablesaw.plotly.components.Layout;
-import tech.tablesaw.plotly.traces.ScatterTrace;
 
+/**
+ * Open-High-Low-Close time series plot typically used to illustrate price trends for stocks and
+ * other exchange-traded products
+ *
+ * @see CandlestickPlot
+ */
 public class OHLCPlot {
+
+  private static final String PLOT_TYPE = "ohlc";
 
   public static Figure create(
       String title,
@@ -15,16 +21,6 @@ public class OHLCPlot {
       String highCol,
       String lowCol,
       String closeCol) {
-    Layout layout = Layout.builder(title, xCol).build();
-    ScatterTrace trace =
-        ScatterTrace.builder(
-                table.dateColumn(xCol),
-                table.numberColumn(openCol),
-                table.numberColumn(highCol),
-                table.numberColumn(lowCol),
-                table.numberColumn(closeCol))
-            .type("ohlc")
-            .build();
-    return new Figure(layout, trace);
+    return PricePlot.create(title, table, xCol, openCol, highCol, lowCol, closeCol, PLOT_TYPE);
   }
 }

--- a/jsplot/src/main/java/tech/tablesaw/plotly/api/PricePlot.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/api/PricePlot.java
@@ -1,0 +1,51 @@
+package tech.tablesaw.plotly.api;
+
+import tech.tablesaw.api.ColumnType;
+import tech.tablesaw.api.NumericColumn;
+import tech.tablesaw.api.Table;
+import tech.tablesaw.columns.Column;
+import tech.tablesaw.plotly.components.Figure;
+import tech.tablesaw.plotly.components.Layout;
+import tech.tablesaw.plotly.traces.ScatterTrace;
+
+/** Abstract superclass for time series plots that have open-high-low-close data */
+public abstract class PricePlot {
+
+  public static Figure create(
+      String title,
+      Table table,
+      String xCol,
+      String openCol,
+      String highCol,
+      String lowCol,
+      String closeCol,
+      String plotType) {
+    Layout layout = Layout.builder(title, xCol).build();
+    Column<?> x = table.column(xCol);
+    NumericColumn<?> open = table.numberColumn(openCol);
+    NumericColumn<?> high = table.numberColumn(highCol);
+    NumericColumn<?> low = table.numberColumn(lowCol);
+    NumericColumn<?> close = table.numberColumn(closeCol);
+    ScatterTrace trace;
+    if (x.type() == ColumnType.LOCAL_DATE) {
+      trace =
+          ScatterTrace.builder(table.dateColumn(xCol), open, high, low, close)
+              .type(plotType)
+              .build();
+    } else if (x.type() == ColumnType.LOCAL_DATE_TIME) {
+      trace =
+          ScatterTrace.builder(table.dateTimeColumn(xCol), open, high, low, close)
+              .type(plotType)
+              .build();
+    } else if (x.type() == ColumnType.INSTANT) {
+      trace =
+          ScatterTrace.builder(table.instantColumn(xCol), open, high, low, close)
+              .type(plotType)
+              .build();
+    } else {
+      throw new IllegalArgumentException(
+          "Column containing data for the X-Axis must be of type INSTANT, LOCAL_DATE, or LOCAL_DATE_TIME");
+    }
+    return new Figure(layout, trace);
+  }
+}

--- a/jsplot/src/test/java/tech/tablesaw/examples/TimeSeriesVisualizations.java
+++ b/jsplot/src/test/java/tech/tablesaw/examples/TimeSeriesVisualizations.java
@@ -41,9 +41,20 @@ public class TimeSeriesVisualizations {
     Plot.show(new Figure(layout, trace));
 
     Table priceTable = Table.read().csv("../data/ohlcdata.csv");
+    priceTable.addColumns(
+        priceTable.dateColumn("date").atStartOfDay().setName("date time"),
+        priceTable.dateColumn("date").atStartOfDay().asInstantColumn().setName("instant"));
     priceTable.numberColumn("Volume").setPrintFormatter(NumberColumnFormatter.intsWithGrouping());
+
     Plot.show(OHLCPlot.create("Prices", priceTable, "date", "open", "high", "low", "close"));
+    Plot.show(OHLCPlot.create("Prices", priceTable, "date time", "open", "high", "low", "close"));
+    Plot.show(OHLCPlot.create("Prices", priceTable, "instant", "open", "high", "low", "close"));
+
     Plot.show(CandlestickPlot.create("Prices", priceTable, "date", "open", "high", "low", "close"));
+    Plot.show(
+        CandlestickPlot.create("Prices", priceTable, "date time", "open", "high", "low", "close"));
+    Plot.show(
+        CandlestickPlot.create("Prices", priceTable, "instant", "open", "high", "low", "close"));
 
     // using a datetime column
     Table dateTable = Table.read().csv("../data/dateTimeTestFile.csv");


### PR DESCRIPTION
Thanks for contributing.

- [x Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

What was changed

- Added the ability to display DateTime and Instant columns in OHLC and Candlestick charts. 
- Extracted common code into a new PricePlot class. 
- Added comments

## Testing

Did you add a unit test?
Added to existing test code 