### PR TITLE
fix NPE that occurs when sorting a boolean column with missing values

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
@@ -62,9 +62,9 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
 
   private final IntComparator comparator =
       (r1, r2) -> {
-        boolean f1 = get(r1);
-        boolean f2 = get(r2);
-        return Boolean.compare(f1, f2);
+        byte f1 = getByte(r1);
+        byte f2 = getByte(r2);
+        return Byte.compare(f1, f2);
       };
 
   private BooleanFormatter formatter = new BooleanFormatter("true", "false", "");

--- a/core/src/test/java/tech/tablesaw/api/BooleanColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/BooleanColumnTest.java
@@ -61,6 +61,15 @@ public class BooleanColumnTest {
   }
 
   @Test
+  public void fixNPESortingWithMissingValues() {
+    assertFalse(column.all());
+    column.appendMissing();
+    column.appendMissing();
+    column.sortAscending(); // Look. No NPE
+    assertEquals(2, column.countMissing());
+  }
+
+  @Test
   public void testNone() {
     assertFalse(column.none());
     BooleanColumn filtered = column.where(column.isFalse());


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

What was changed
Sort using primitives 

## Testing

Did you add a unit test?
yes