### PR TITLE
implemented optional renaming of duplicate columns

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/ReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/ReadOptions.java
@@ -78,6 +78,7 @@ public class ReadOptions {
   protected final boolean minimizeColumnSizes;
   protected final int maxCharsPerColumn;
   protected final boolean ignoreZeroDecimal;
+  protected final boolean allowDuplicateColumnNames;
 
   protected final DateTimeFormatter dateFormatter;
   protected final DateTimeFormatter dateTimeFormatter;
@@ -103,6 +104,8 @@ public class ReadOptions {
     timeFormatter = builder.timeFormatter;
     dateTimeFormatter = builder.dateTimeFormatter;
 
+    allowDuplicateColumnNames = builder.allowDuplicateColumnNames;
+
     if (builder.locale == null) {
       locale = Locale.getDefault();
     } else {
@@ -116,6 +119,10 @@ public class ReadOptions {
 
   public String tableName() {
     return tableName;
+  }
+
+  public boolean allowDuplicateColumnNames() {
+    return allowDuplicateColumnNames;
   }
 
   public List<ColumnType> columnTypesToDetect() {
@@ -195,6 +202,7 @@ public class ReadOptions {
     protected boolean header = true;
     protected int maxCharsPerColumn = 4096;
     protected boolean ignoreZeroDecimal = DEFAULT_IGNORE_ZERO_DECIMAL;
+    private boolean allowDuplicateColumnNames = false;
 
     protected Builder() {
       source = null;
@@ -241,6 +249,11 @@ public class ReadOptions {
 
     public Builder dateFormat(DateTimeFormatter dateFormat) {
       this.dateFormatter = dateFormat;
+      return this;
+    }
+
+    public Builder allowDuplicateColumnNames(Boolean allow) {
+      this.allowDuplicateColumnNames = allow;
       return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
@@ -240,6 +240,18 @@ public class CsvReadOptions extends ReadOptions {
       return this;
     }
 
+    /**
+     * Enable reading of a table with duplicate column names. After the first appearance of a column
+     * name, subsequent appearances will have a number appended.
+     *
+     * @param allow if true, duplicate names will be allowed
+     */
+    @Override
+    public Builder allowDuplicateColumnNames(Boolean allow) {
+      super.allowDuplicateColumnNames(allow);
+      return this;
+    }
+
     @Override
     public Builder tableName(String tableName) {
       super.tableName(tableName);

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
@@ -64,6 +64,7 @@ import tech.tablesaw.io.AddCellToColumnException;
 public class CsvReaderTest {
 
   private static final String LINE_END = System.lineSeparator();
+  private static final String COMMA = ",";
 
   private final ColumnType[] bus_types = {SHORT, STRING, STRING, FLOAT, FLOAT};
   private final ColumnType[] bus_types_with_SKIP = {SHORT, STRING, SKIP, DOUBLE, DOUBLE};
@@ -121,6 +122,24 @@ public class CsvReaderTest {
     assertEquals(4, table.columnCount());
     // Look at the column names
     assertEquals("[stop_id, stop_name, stop_lat, stop_lon]", table.columnNames().toString());
+  }
+
+  @Test
+  void allowDuplicateColumnNames() throws IOException {
+    final Reader reader1 =
+        new StringReader(
+            "Col1" + COMMA + "Col2" + LINE_END + "\"first\"" + COMMA + "second" + LINE_END);
+    Table noDupes = Table.read().csv(reader1);
+    assertEquals("Col1", noDupes.columnNames().get(0));
+    assertEquals("Col2", noDupes.columnNames().get(1));
+
+    final Reader reader2 =
+        new StringReader(
+            "Col1" + COMMA + "Col1" + LINE_END + "\"first\"" + COMMA + "second" + LINE_END);
+    Table dupes =
+        Table.read().csv(CsvReadOptions.builder(reader2).allowDuplicateColumnNames(true).build());
+    assertEquals("Col1", dupes.columnNames().get(0));
+    assertEquals("Col1-2", dupes.columnNames().get(1));
   }
 
   @Test


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Allows the user to specify that a file containing duplicate column names should be imported, with the duplicate names modified. Current behavior is to throw an exception, forcing the user to modify the file externally. 

## Testing

Did you add a unit test?
yes
