### PR TITLE
fix for bug.

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Row.java
+++ b/core/src/main/java/tech/tablesaw/api/Row.java
@@ -12,6 +12,13 @@ import java.util.NoSuchElementException;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.table.TableSlice;
 
+/**
+ * Represents a row in a Relation (either a Table or TableSlice), allowing iteration ofover the
+ * relation.
+ *
+ * <p>Implementation Note: The row is always implemented over a TableSlice. If the constructor
+ * argument is a table, it is wrapped by a slice over the whole table.
+ */
 public class Row implements Iterator<Row> {
 
   /**
@@ -448,7 +455,7 @@ public class Row implements Iterator<Row> {
   }
 
   public double getNumber(String columnName) {
-    return numericColumnMap.get(columnName).getDouble(rowNumber);
+    return numericColumnMap.get(columnName).getDouble(getIndex(rowNumber));
   }
 
   public ColumnType getColumnType(String columnName) {

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -1365,15 +1365,13 @@ public class Table extends Relation implements Iterable<Row> {
 
     TableSliceGroup slices = splitOn(idVariables.toArray(new String[0]));
     for (TableSlice slice : slices) {
-      // TODO: This is inefficient, but it looks like there is a bug in row iteration on slices
-      Table temp = slice.asTable();
-
-      for (Row row : temp) {
+      for (Row row : slice) {
         for (String colName : measureColumnNames) {
           if (!dropMissing || !row.isMissing(colName)) {
             writeIdVariables(idVariables, result, row);
             result.stringColumn(MELT_VARIABLE_COLUMN_NAME).append(colName);
-            result.doubleColumn(MELT_VALUE_COLUMN_NAME).append(row.getNumber(colName));
+            double value = row.getNumber(colName);
+            result.doubleColumn(MELT_VALUE_COLUMN_NAME).append(value);
           }
         }
       }
@@ -1382,6 +1380,7 @@ public class Table extends Relation implements Iterable<Row> {
     return result;
   }
 
+  /** Writes one row of id variables into the result table */
   private void writeIdVariables(List<String> idVariables, Table result, Row row) {
     for (String id : idVariables) {
       Column<?> resultColumn = result.column(id);


### PR DESCRIPTION
Row.getNumber() lacked the call to getIndex() that converts a nominal row number for a slice into the correct value in the backing table.

Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

adds code that converts nominal row number into true row number in one method where it was missing. 

## Testing

Did you add a unit test?
There's already one that covers this case, which gets executed now that the main code has been changed.
