### PR TITLE
Add rolling window result centering

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/Column.java
+++ b/core/src/main/java/tech/tablesaw/columns/Column.java
@@ -164,6 +164,10 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
     return new RollingColumn(this, windowSize);
   }
 
+  default RollingColumn rolling(final int windowSize, final boolean center) {
+    return new RollingColumn(this, windowSize, center);
+  }
+
   String getUnformattedString(int r);
 
   boolean isMissing(int rowNumber);

--- a/core/src/test/java/tech/tablesaw/table/RollingColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/table/RollingColumnTest.java
@@ -1,9 +1,7 @@
 package tech.tablesaw.table;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static tech.tablesaw.aggregate.AggregateFunctions.countTrue;
-import static tech.tablesaw.aggregate.AggregateFunctions.latestDateTime;
+import static org.junit.jupiter.api.Assertions.*;
+import static tech.tablesaw.aggregate.AggregateFunctions.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -51,5 +49,19 @@ public class RollingColumnTest {
     assertEquals(0, result.getDouble(2), 0.0);
     assertEquals(1, result.getDouble(3), 0.0);
     assertEquals(2, result.getDouble(4), 0.0);
+  }
+
+  @Test
+  public void testCenter() {
+    double[] data = new double[] {1, 2, 3, 4, 5};
+    DoubleColumn doubleColumn = DoubleColumn.create("data", data);
+
+    DoubleColumn result = (DoubleColumn) doubleColumn.rolling(3, true).calc(mean);
+
+    assertEquals(Double.NaN, result.getDouble(0), 0.0);
+    assertNotEquals(Double.NaN, result.getDouble(1), 0.0);
+    assertNotEquals(Double.NaN, result.getDouble(2), 0.0);
+    assertNotEquals(Double.NaN, result.getDouble(3), 0.0);
+    assertEquals(Double.NaN, result.getDouble(4), 0.0);
   }
 }


### PR DESCRIPTION
Pandas-like center parameter; allows centering the result values instead of having a bunch of NaNs at the beginning of the column.

Thanks for contributing.


- [ ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

It adds the option to center the result of a RollingColumn instead of having all the missing values at the beginning, like pandas does.

## Testing

Did you add a unit test?
Yes.
