### PR TITLE
Add support for nanoseconds on DateTimeColumn & InstantColumn

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
@@ -515,7 +515,8 @@ public class DateTimeColumn extends AbstractColumn<DateTimeColumn, LocalDateTime
     Instant[] output = new Instant[epochSeconds.size()];
     for (int i = 0; i < epochSeconds.size(); i++) {
       LocalDateTime dateTime =
-          LocalDateTime.from(Instant.ofEpochSecond(epochSeconds.getLong(i), secondNanos.getInt(i)));
+          LocalDateTime.ofEpochSecond(
+              epochSeconds.getLong(i), secondNanos.getInt(i), ZoneOffset.UTC);
       if (dateTime == null) {
         output[i] = null;
       } else {

--- a/core/src/main/java/tech/tablesaw/api/InstantColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/InstantColumn.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import tech.tablesaw.columns.AbstractColumn;
 import tech.tablesaw.columns.AbstractColumnParser;
 import tech.tablesaw.columns.Column;
+import tech.tablesaw.columns.datetimes.DateTimeColumnType;
 import tech.tablesaw.columns.instant.InstantColumnFormatter;
 import tech.tablesaw.columns.instant.InstantColumnType;
 import tech.tablesaw.columns.instant.InstantMapFunctions;
@@ -383,6 +384,8 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
   }
 
   public Instant get(int index) {
+    if (epochSeconds.getLong(index) == DateTimeColumnType.missingValueIndicator()) return null;
+
     return Instant.ofEpochSecond(epochSeconds.getLong(index), secondNanos.getInt(index));
   }
 

--- a/core/src/main/java/tech/tablesaw/columns/dates/DateMapFunctions.java
+++ b/core/src/main/java/tech/tablesaw/columns/dates/DateMapFunctions.java
@@ -29,8 +29,8 @@ import tech.tablesaw.api.IntColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.TimeColumn;
 import tech.tablesaw.columns.Column;
-import tech.tablesaw.columns.datetimes.PackedLocalDateTime;
 import tech.tablesaw.columns.numbers.NumberColumnFormatter;
+import tech.tablesaw.columns.times.PackedLocalTime;
 
 /** An interface for mapping operations unique to Date columns */
 public interface DateMapFunctions extends Column<LocalDate> {
@@ -408,7 +408,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
         newColumn.appendMissing();
       } else {
         LocalDate value1 = PackedLocalDate.asLocalDate(c1);
-        newColumn.appendInternal(PackedLocalDateTime.pack(value1, time));
+        newColumn.append(value1.atTime(time));
       }
     }
     return newColumn;
@@ -426,7 +426,7 @@ public interface DateMapFunctions extends Column<LocalDate> {
       if (valueIsMissing(c1) || valueIsMissing(c2)) {
         newColumn.appendMissing();
       } else {
-        newColumn.appendInternal(PackedLocalDateTime.create(c1, c2));
+        newColumn.append(get(r).atTime(PackedLocalTime.asLocalTime(c2)));
       }
     }
     return newColumn;

--- a/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeColumnFormatter.java
+++ b/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeColumnFormatter.java
@@ -1,8 +1,8 @@
 package tech.tablesaw.columns.datetimes;
 
-import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.asLocalDateTime;
-
+import com.google.common.base.Strings;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import javax.annotation.concurrent.Immutable;
 
@@ -25,18 +25,40 @@ public class DateTimeColumnFormatter {
     this.missingValueString = missingValueString;
   }
 
-  public String format(long value) {
-    if (value == DateTimeColumnType.missingValueIndicator()) {
+  public String format(long epochSecond, int secondNanos) {
+    if (epochSecond == DateTimeColumnType.missingValueIndicator()) {
       return missingValueString;
     }
     if (format == null) {
-      return PackedLocalDateTime.toString(value);
+      return defaultFormat(epochSecond, secondNanos);
     }
-    LocalDateTime time = asLocalDateTime(value);
+    LocalDateTime time = LocalDateTime.ofEpochSecond(epochSecond, secondNanos, ZoneOffset.UTC);
     if (time == null) {
       return "";
     }
     return format.format(time);
+  }
+
+  public static String defaultFormat(long epochSecond, int secondNanos) {
+    if (epochSecond == Long.MIN_VALUE) {
+      return "";
+    }
+    LocalDateTime ldt = LocalDateTime.ofEpochSecond(epochSecond, secondNanos, ZoneOffset.UTC);
+
+    return ""
+        + ldt.getYear()
+        + "-"
+        + Strings.padStart(Integer.toString(ldt.getMonthValue()), 2, '0')
+        + "-"
+        + Strings.padStart(Integer.toString(ldt.getDayOfMonth()), 2, '0')
+        + "T"
+        + Strings.padStart(Integer.toString(ldt.getHour()), 2, '0')
+        + ":"
+        + Strings.padStart(Integer.toString(ldt.getMinute()), 2, '0')
+        + ":"
+        + Strings.padStart(Integer.toString(ldt.getSecond()), 2, '0')
+        + "."
+        + Strings.padStart(String.valueOf(ldt.getNano()), 3, '0');
   }
 
   @Override

--- a/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeFilters.java
+++ b/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeFilters.java
@@ -1,6 +1,5 @@
 package tech.tablesaw.columns.datetimes;
 
-import static tech.tablesaw.columns.datetimes.DateTimePredicates.isInYear;
 import static tech.tablesaw.columns.temporal.TemporalPredicates.*;
 
 import java.time.LocalDate;
@@ -253,15 +252,13 @@ public interface DateTimeFilters
   }
 
   default Selection isBetweenIncluding(LocalDateTime lowValue, LocalDateTime highValue) {
-    return eval((Predicate<LocalDateTime>) ldt -> ldt.isBefore(lowValue) || ldt.isEqual(lowValue))
+    return eval((Predicate<LocalDateTime>) ldt -> ldt.isBefore(highValue) || ldt.isEqual(highValue))
         .and(
-            eval(
-                (Predicate<LocalDateTime>)
-                    ldt -> ldt.isAfter(highValue) || ldt.isEqual(highValue)));
+            eval((Predicate<LocalDateTime>) ldt -> ldt.isAfter(lowValue) || ldt.isEqual(lowValue)));
   }
 
   default Selection isInYear(int year) {
-    return eval(isInYear, year);
+    return eval((Predicate<LocalDateTime>) ldt -> ldt.getYear() == year);
   }
 
   @Override

--- a/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeFilters.java
+++ b/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeFilters.java
@@ -249,13 +249,15 @@ public interface DateTimeFilters
   }
 
   default Selection isBetweenExcluding(LocalDateTime lowValue, LocalDateTime highValue) {
-    return isBetweenExcluding(
-        lowValue.toEpochSecond(ZoneOffset.UTC), highValue.toEpochSecond(ZoneOffset.UTC));
+    return eval(LocalDateTime::isAfter, lowValue).and(eval(LocalDateTime::isBefore, highValue));
   }
 
   default Selection isBetweenIncluding(LocalDateTime lowValue, LocalDateTime highValue) {
-    return isBetweenIncluding(
-        lowValue.toEpochSecond(ZoneOffset.UTC), highValue.toEpochSecond(ZoneOffset.UTC));
+    return eval((Predicate<LocalDateTime>) ldt -> ldt.isBefore(lowValue) || ldt.isEqual(lowValue))
+        .and(
+            eval(
+                (Predicate<LocalDateTime>)
+                    ldt -> ldt.isAfter(highValue) || ldt.isEqual(highValue)));
   }
 
   default Selection isInYear(int year) {

--- a/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeFilters.java
+++ b/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeFilters.java
@@ -5,6 +5,9 @@ import static tech.tablesaw.columns.temporal.TemporalPredicates.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.function.Predicate;
 import tech.tablesaw.api.DateTimeColumn;
 import tech.tablesaw.columns.temporal.TemporalFilters;
 import tech.tablesaw.filtering.DateTimeFilterSpec;
@@ -15,7 +18,7 @@ public interface DateTimeFilters
     extends TemporalFilters<LocalDateTime>, DateTimeFilterSpec<Selection> {
 
   default Selection isAfter(LocalDateTime value) {
-    return eval(isGreaterThan, PackedLocalDateTime.pack(value));
+    return eval(isGreaterThan, value.toEpochSecond(ZoneOffset.UTC));
   }
 
   default Selection isAfter(LocalDate value) {
@@ -27,11 +30,11 @@ public interface DateTimeFilters
   }
 
   default Selection isOnOrAfter(LocalDateTime value) {
-    return eval(isGreaterThanOrEqualTo, PackedLocalDateTime.pack(value));
+    return eval(isGreaterThanOrEqualTo, value.toEpochSecond(ZoneOffset.UTC));
   }
 
   default Selection isBefore(LocalDateTime value) {
-    return eval(isLessThan, PackedLocalDateTime.pack(value));
+    return eval(isLessThan, value.toEpochSecond(ZoneOffset.UTC));
   }
 
   default Selection isBefore(LocalDate value) {
@@ -43,7 +46,7 @@ public interface DateTimeFilters
   }
 
   default Selection isOnOrBefore(LocalDateTime value) {
-    return eval(isLessThanOrEqualTo, PackedLocalDateTime.pack(value));
+    return eval(isLessThanOrEqualTo, value.toEpochSecond(ZoneOffset.UTC));
   }
 
   default Selection isAfter(DateTimeColumn column) {
@@ -67,12 +70,12 @@ public interface DateTimeFilters
   }
 
   default Selection isEqualTo(LocalDateTime value) {
-    long packed = PackedLocalDateTime.pack(value);
+    long packed = value.toEpochSecond(ZoneOffset.UTC);
     return eval(isEqualTo, packed);
   }
 
   default Selection isNotEqualTo(LocalDateTime value) {
-    long packed = PackedLocalDateTime.pack(value);
+    long packed = value.toEpochSecond(ZoneOffset.UTC);
     return eval(isNotEqualTo, packed);
   }
 
@@ -102,129 +105,157 @@ public interface DateTimeFilters
   }
 
   default Selection isMonday() {
-    return eval(PackedLocalDateTime::isMonday);
+    return eval(
+        ((Predicate<LocalDateTime>) localDateTime -> localDateTime.getDayOfWeek().getValue() == 1));
   }
 
   default Selection isTuesday() {
-    return eval(PackedLocalDateTime::isTuesday);
+    return eval(
+        ((Predicate<LocalDateTime>) localDateTime -> localDateTime.getDayOfWeek().getValue() == 2));
   }
 
   default Selection isWednesday() {
-    return eval(PackedLocalDateTime::isWednesday);
+    return eval(
+        ((Predicate<LocalDateTime>) localDateTime -> localDateTime.getDayOfWeek().getValue() == 3));
   }
 
   default Selection isThursday() {
-    return eval(PackedLocalDateTime::isThursday);
+    return eval(
+        ((Predicate<LocalDateTime>) localDateTime -> localDateTime.getDayOfWeek().getValue() == 4));
   }
 
   default Selection isFriday() {
-    return eval(PackedLocalDateTime::isFriday);
+    return eval(
+        ((Predicate<LocalDateTime>) localDateTime -> localDateTime.getDayOfWeek().getValue() == 5));
   }
 
   default Selection isSaturday() {
-    return eval(PackedLocalDateTime::isSaturday);
+    return eval(
+        ((Predicate<LocalDateTime>) localDateTime -> localDateTime.getDayOfWeek().getValue() == 6));
   }
 
   default Selection isSunday() {
-    return eval(PackedLocalDateTime::isSunday);
+    return eval(
+        ((Predicate<LocalDateTime>) localDateTime -> localDateTime.getDayOfWeek().getValue() == 7));
   }
 
   default Selection isInJanuary() {
-    return eval(PackedLocalDateTime::isInJanuary);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 1));
   }
 
   default Selection isInFebruary() {
-    return eval(PackedLocalDateTime::isInFebruary);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 2));
   }
 
   default Selection isInMarch() {
-    return eval(PackedLocalDateTime::isInMarch);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 3));
   }
 
   default Selection isInApril() {
-    return eval(PackedLocalDateTime::isInApril);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 4));
   }
 
   default Selection isInMay() {
-    return eval(PackedLocalDateTime::isInMay);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 5));
   }
 
   default Selection isInJune() {
-    return eval(PackedLocalDateTime::isInJune);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 6));
   }
 
   default Selection isInJuly() {
-    return eval(PackedLocalDateTime::isInJuly);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 7));
   }
 
   default Selection isInAugust() {
-    return eval(PackedLocalDateTime::isInAugust);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 8));
   }
 
   default Selection isInSeptember() {
-    return eval(PackedLocalDateTime::isInSeptember);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 9));
   }
 
   default Selection isInOctober() {
-    return eval(PackedLocalDateTime::isInOctober);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 10));
   }
 
   default Selection isInNovember() {
-    return eval(PackedLocalDateTime::isInNovember);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 11));
   }
 
   default Selection isInDecember() {
-    return eval(PackedLocalDateTime::isInDecember);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonthValue() == 12));
   }
 
   default Selection isFirstDayOfMonth() {
-    return eval(PackedLocalDateTime::isFirstDayOfMonth);
+    return eval(((Predicate<LocalDateTime>) localDateTime -> localDateTime.getDayOfMonth() == 1));
   }
 
   default Selection isLastDayOfMonth() {
-    return eval(PackedLocalDateTime::isLastDayOfMonth);
+    return eval(
+        ((Predicate<LocalDateTime>)
+            localDateTime ->
+                localDateTime.getDayOfMonth() == localDateTime.getMonth().maxLength()));
   }
 
   default Selection isInQ1() {
-    return eval(PackedLocalDateTime::isInQ1);
+    return eval(
+        ((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonth().getValue() < 4));
   }
 
   default Selection isInQ2() {
-    return eval(PackedLocalDateTime::isInQ2);
+    return eval(
+        ((Predicate<LocalDateTime>)
+            localDateTime ->
+                localDateTime.getMonth().getValue() > 3
+                    && localDateTime.getMonth().getValue() < 7));
   }
 
   default Selection isInQ3() {
-    return eval(PackedLocalDateTime::isInQ3);
+    return eval(
+        ((Predicate<LocalDateTime>)
+            localDateTime ->
+                localDateTime.getMonth().getValue() > 6
+                    && localDateTime.getMonth().getValue() < 10));
   }
 
   default Selection isInQ4() {
-    return eval(PackedLocalDateTime::isInQ4);
+    return eval(
+        ((Predicate<LocalDateTime>) localDateTime -> localDateTime.getMonth().getValue() > 9));
   }
 
   default Selection isNoon() {
-    return eval(PackedLocalDateTime::isNoon);
+    return eval(
+        ((Predicate<LocalDateTime>)
+            localDateTime -> localDateTime.toLocalTime().equals(LocalTime.NOON)));
   }
 
   default Selection isMidnight() {
-    return eval(PackedLocalDateTime::isMidnight);
+    return eval(
+        ((Predicate<LocalDateTime>)
+            localDateTime -> localDateTime.toLocalTime().equals(LocalTime.MIDNIGHT)));
   }
 
   default Selection isBeforeNoon() {
-    return eval(PackedLocalDateTime::AM);
+    return eval(
+        ((Predicate<LocalDateTime>)
+            localDateTime -> localDateTime.toLocalTime().compareTo(LocalTime.NOON) < 0));
   }
 
   default Selection isAfterNoon() {
-    return eval(PackedLocalDateTime::PM);
+    return eval(
+        ((Predicate<LocalDateTime>)
+            localDateTime -> localDateTime.toLocalTime().compareTo(LocalTime.NOON) > 0));
   }
 
   default Selection isBetweenExcluding(LocalDateTime lowValue, LocalDateTime highValue) {
     return isBetweenExcluding(
-        PackedLocalDateTime.pack(lowValue), PackedLocalDateTime.pack(highValue));
+        lowValue.toEpochSecond(ZoneOffset.UTC), highValue.toEpochSecond(ZoneOffset.UTC));
   }
 
   default Selection isBetweenIncluding(LocalDateTime lowValue, LocalDateTime highValue) {
     return isBetweenIncluding(
-        PackedLocalDateTime.pack(lowValue), PackedLocalDateTime.pack(highValue));
+        lowValue.toEpochSecond(ZoneOffset.UTC), highValue.toEpochSecond(ZoneOffset.UTC));
   }
 
   default Selection isInYear(int year) {

--- a/core/src/main/java/tech/tablesaw/columns/temporal/TemporalColumn.java
+++ b/core/src/main/java/tech/tablesaw/columns/temporal/TemporalColumn.java
@@ -9,5 +9,7 @@ public interface TemporalColumn<T extends Temporal> extends Column<T> {
 
   long getLongInternal(int r);
 
+  int getIntInternal(int r);
+
   TemporalColumn<T> appendInternal(long value);
 }

--- a/core/src/main/java/tech/tablesaw/columns/temporal/TemporalFilters.java
+++ b/core/src/main/java/tech/tablesaw/columns/temporal/TemporalFilters.java
@@ -3,19 +3,18 @@ package tech.tablesaw.columns.temporal;
 import static tech.tablesaw.columns.temporal.TemporalPredicates.*;
 
 import java.time.Instant;
-import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAccessor;
 import java.util.function.BiPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 import tech.tablesaw.api.DateTimeColumn;
 import tech.tablesaw.columns.Column;
-import tech.tablesaw.columns.instant.PackedInstant;
 import tech.tablesaw.filtering.InstantFilterSpec;
 import tech.tablesaw.filtering.predicates.LongBiPredicate;
 import tech.tablesaw.selection.BitmapBackedSelection;
 import tech.tablesaw.selection.Selection;
 
-public interface TemporalFilters<T extends Temporal>
+public interface TemporalFilters<T extends TemporalAccessor>
     extends Column<T>, InstantFilterSpec<Selection> {
 
   default Selection eval(LongPredicate predicate) {
@@ -63,6 +62,8 @@ public interface TemporalFilters<T extends Temporal>
   default Selection eval(Predicate<T> predicate) {
     Selection selection = new BitmapBackedSelection();
     for (int idx = 0; idx < size(); idx++) {
+      if (get(idx) == null) continue;
+
       if (predicate.test(get(idx))) {
         selection.add(idx);
       }
@@ -70,26 +71,16 @@ public interface TemporalFilters<T extends Temporal>
     return selection;
   }
 
-  default Selection isBetweenExcluding(long lowPackedDateTime, long highPackedDateTime) {
-    return eval(PackedInstant::isAfter, lowPackedDateTime)
-        .and(eval(PackedInstant::isBefore, highPackedDateTime));
-  }
-
-  default Selection isBetweenIncluding(long lowPackedDateTime, long highPackedDateTime) {
-    return eval(PackedInstant::isOnOrAfter, lowPackedDateTime)
-        .and(eval(PackedInstant::isOnOrBefore, highPackedDateTime));
-  }
-
   default Selection isAfter(Instant value) {
-    return eval(isGreaterThan, PackedInstant.pack(value));
+    return eval((Predicate<T>) i -> Instant.from(i).isAfter(value));
   }
 
   default Selection isBefore(Instant value) {
-    return eval(isLessThan, PackedInstant.pack(value));
+    return eval((Predicate<T>) i -> Instant.from(i).isBefore(value));
   }
 
   default Selection isEqualTo(Instant value) {
-    return eval(isEqualTo, PackedInstant.pack(value));
+    return eval((Predicate<T>) i -> Instant.from(i).equals(value));
   }
 
   int size();

--- a/core/src/main/java/tech/tablesaw/columns/temporal/TemporalMapFunctions.java
+++ b/core/src/main/java/tech/tablesaw/columns/temporal/TemporalMapFunctions.java
@@ -14,9 +14,8 @@
 
 package tech.tablesaw.columns.temporal;
 
-import static tech.tablesaw.columns.datetimes.PackedLocalDateTime.asLocalDateTime;
-
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalUnit;
@@ -64,10 +63,11 @@ public interface TemporalMapFunctions<T extends Temporal> extends TemporalColumn
       if (this.isMissing(r) || column2.isMissing(r)) {
         newColumn.appendMissing();
       } else {
-        long c1 = this.getLongInternal(r);
-        long c2 = column2.getLongInternal(r);
-        LocalDateTime value1 = asLocalDateTime(c1);
-        LocalDateTime value2 = asLocalDateTime(c2);
+        LocalDateTime value1 =
+            LocalDateTime.ofEpochSecond(getLongInternal(r), getIntInternal(r), ZoneOffset.UTC);
+        LocalDateTime value2 =
+            LocalDateTime.ofEpochSecond(
+                column2.getLongInternal(r), column2.getIntInternal(r), ZoneOffset.UTC);
         if (value1 != null && value2 != null) {
           newColumn.append(unit.between(value1, value2));
         } else {

--- a/saw/src/main/java/tech/tablesaw/io/saw/SawReader.java
+++ b/saw/src/main/java/tech/tablesaw/io/saw/SawReader.java
@@ -296,8 +296,15 @@ public class SawReader {
 
   private DateTimeColumn readLocalDateTimeColumn(
       String fileName, ColumnMetadata metadata, int rowcount) throws IOException {
-    long[] data = readLongValues(fileName, rowcount);
-    return DateTimeColumn.createInternal(metadata.getName(), data);
+    long[] epochSeconds = new long[rowcount];
+    int[] secondNanos = new int[rowcount];
+    try (DataInputStream dis = inputStream(fileName)) {
+      for (int i = 0; i < rowcount; i++) {
+        epochSeconds[i] = dis.readLong();
+        secondNanos[i] = dis.readInt();
+      }
+    }
+    return DateTimeColumn.createInternal(metadata.getName(), epochSeconds, secondNanos);
   }
 
   private long[] readLongValues(String fileName, int rowcount) throws IOException {
@@ -312,7 +319,15 @@ public class SawReader {
 
   private InstantColumn readInstantColumn(String fileName, ColumnMetadata metadata, int rowcount)
       throws IOException {
-    return InstantColumn.createInternal(metadata.getName(), readLongValues(fileName, rowcount));
+    long[] epochSeconds = new long[rowcount];
+    int[] secondNanos = new int[rowcount];
+    try (DataInputStream dis = inputStream(fileName)) {
+      for (int i = 0; i < rowcount; i++) {
+        epochSeconds[i] = dis.readLong();
+        secondNanos[i] = dis.readInt();
+      }
+    }
+    return InstantColumn.createInternal(metadata.getName(), epochSeconds, secondNanos);
   }
 
   private TimeColumn readLocalTimeColumn(String fileName, ColumnMetadata metadata, int rowcount)

--- a/saw/src/main/java/tech/tablesaw/io/saw/SawWriter.java
+++ b/saw/src/main/java/tech/tablesaw/io/saw/SawWriter.java
@@ -526,14 +526,20 @@ public class SawWriter {
 
   private void writeColumn(String fileName, DateTimeColumn column) throws IOException {
     try (DataOutputStream dos = columnOutputStream(fileName)) {
-      writeLongStream(dos, column.longIterator());
+      for (int i = 0; i < column.size(); i++) {
+        dos.writeLong(column.getLongInternal(i));
+        dos.writeInt(column.getIntInternal(i));
+      }
       dos.flush();
     }
   }
 
   private void writeColumn(String fileName, InstantColumn column) throws IOException {
     try (DataOutputStream dos = columnOutputStream(fileName)) {
-      writeLongStream(dos, column.longIterator());
+      for (int i = 0; i < column.size(); i++) {
+        dos.writeLong(column.getLongInternal(i));
+        dos.writeInt(column.getIntInternal(i));
+      }
     }
   }
 


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR aims to add support for nanosecond precision on `DateTimeColum` & `InstantColumn`. This is achieved by storing them internally the same way Java's `Instant` does (long array for epoch-seconds and int array for nanosecond-of-second).

This is just a draft and does not fully eliminate the dependency on `PackedLocalDateTime`/`PackedInstant`. I'll continue to work on it if it's considered worthy.
`DateTimeColumn` & `InstantColumn` now rely on two arrays instead of one as described above, `DateTimeFilters` have also been modified to remove the dependency on `PackedLocalDateTime`/`PackedInstant`.

## Testing

Did you add a unit test?
I will if the idea gets accepted.
