### PR TITLE
Allow reading of malformed CSV

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/FileReader.java
+++ b/core/src/main/java/tech/tablesaw/io/FileReader.java
@@ -181,7 +181,9 @@ public abstract class FileReader {
         (nextLine = reader.parseNext()) != null;
         rowNumber++) {
       // validation
-      if (options.ignoreInvalidRows() && nextLine.length != types.length) {
+      if (options.skipRowsWithInvalidColumnCount()
+          && options.header()
+          && nextLine.length != types.length) {
         continue;
       }
       if (nextLine.length < types.length) {

--- a/core/src/main/java/tech/tablesaw/io/FileReader.java
+++ b/core/src/main/java/tech/tablesaw/io/FileReader.java
@@ -181,6 +181,9 @@ public abstract class FileReader {
         (nextLine = reader.parseNext()) != null;
         rowNumber++) {
       // validation
+      if (options.ignoreInvalidRows() && nextLine.length != types.length) {
+        continue;
+      }
       if (nextLine.length < types.length) {
         if (nextLine.length == 1 && Strings.isNullOrEmpty(nextLine[0])) {
           logger.error("Warning: Invalid file. Row " + rowNumber + " is empty. Continuing.");

--- a/core/src/main/java/tech/tablesaw/io/ReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/ReadOptions.java
@@ -42,6 +42,7 @@ import tech.tablesaw.api.ColumnType;
 public class ReadOptions {
 
   public static final boolean DEFAULT_IGNORE_ZERO_DECIMAL = true;
+  public static final boolean DEFAULT_IGNORE_INVALID_ROWS = false;
 
   private static final List<ColumnType> DEFAULT_TYPES =
       Lists.newArrayList(
@@ -80,6 +81,7 @@ public class ReadOptions {
   protected final int maxCharsPerColumn;
   protected final boolean ignoreZeroDecimal;
   protected final boolean allowDuplicateColumnNames;
+  protected final boolean ignoreInvalidRows;
 
   protected final DateTimeFormatter dateFormatter;
   protected final DateTimeFormatter dateTimeFormatter;
@@ -100,6 +102,7 @@ public class ReadOptions {
     header = builder.header;
     maxCharsPerColumn = builder.maxCharsPerColumn;
     ignoreZeroDecimal = builder.ignoreZeroDecimal;
+    ignoreInvalidRows = builder.ignoreInvalidRows;
 
     dateFormatter = builder.dateFormatter;
     timeFormatter = builder.timeFormatter;
@@ -154,6 +157,10 @@ public class ReadOptions {
     return ignoreZeroDecimal;
   }
 
+  public boolean ignoreInvalidRows() {
+    return ignoreInvalidRows;
+  }
+
   public DateTimeFormatter dateTimeFormatter() {
     if (dateTimeFormatter != null) {
       return dateTimeFormatter;
@@ -203,6 +210,7 @@ public class ReadOptions {
     protected boolean header = true;
     protected int maxCharsPerColumn = 4096;
     protected boolean ignoreZeroDecimal = DEFAULT_IGNORE_ZERO_DECIMAL;
+    protected boolean ignoreInvalidRows = DEFAULT_IGNORE_INVALID_ROWS;
     private boolean allowDuplicateColumnNames = false;
 
     protected Builder() {
@@ -299,6 +307,11 @@ public class ReadOptions {
     /** Ignore zero value decimals in data values. Defaults to {@code true}. */
     public Builder ignoreZeroDecimal(boolean ignoreZeroDecimal) {
       this.ignoreZeroDecimal = ignoreZeroDecimal;
+      return this;
+    }
+
+    public Builder ignoreInvalidRows(boolean ignoreInvalidRows) {
+      this.ignoreInvalidRows = ignoreInvalidRows;
       return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/io/ReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/ReadOptions.java
@@ -42,7 +42,7 @@ import tech.tablesaw.api.ColumnType;
 public class ReadOptions {
 
   public static final boolean DEFAULT_IGNORE_ZERO_DECIMAL = true;
-  public static final boolean DEFAULT_IGNORE_INVALID_ROWS = false;
+  public static final boolean DEFAULT_SKIP_ROWS_WITH_INVALID_COLUMN_COUNT = false;
 
   private static final List<ColumnType> DEFAULT_TYPES =
       Lists.newArrayList(
@@ -81,7 +81,7 @@ public class ReadOptions {
   protected final int maxCharsPerColumn;
   protected final boolean ignoreZeroDecimal;
   protected final boolean allowDuplicateColumnNames;
-  protected final boolean ignoreInvalidRows;
+  protected final boolean skipRowsWithInvalidColumnCount;
 
   protected final DateTimeFormatter dateFormatter;
   protected final DateTimeFormatter dateTimeFormatter;
@@ -102,7 +102,7 @@ public class ReadOptions {
     header = builder.header;
     maxCharsPerColumn = builder.maxCharsPerColumn;
     ignoreZeroDecimal = builder.ignoreZeroDecimal;
-    ignoreInvalidRows = builder.ignoreInvalidRows;
+    skipRowsWithInvalidColumnCount = builder.skipRowsWithInvalidColumnCount;
 
     dateFormatter = builder.dateFormatter;
     timeFormatter = builder.timeFormatter;
@@ -157,8 +157,8 @@ public class ReadOptions {
     return ignoreZeroDecimal;
   }
 
-  public boolean ignoreInvalidRows() {
-    return ignoreInvalidRows;
+  public boolean skipRowsWithInvalidColumnCount() {
+    return skipRowsWithInvalidColumnCount;
   }
 
   public DateTimeFormatter dateTimeFormatter() {
@@ -210,7 +210,7 @@ public class ReadOptions {
     protected boolean header = true;
     protected int maxCharsPerColumn = 4096;
     protected boolean ignoreZeroDecimal = DEFAULT_IGNORE_ZERO_DECIMAL;
-    protected boolean ignoreInvalidRows = DEFAULT_IGNORE_INVALID_ROWS;
+    protected boolean skipRowsWithInvalidColumnCount = DEFAULT_SKIP_ROWS_WITH_INVALID_COLUMN_COUNT;
     private boolean allowDuplicateColumnNames = false;
 
     protected Builder() {
@@ -310,8 +310,9 @@ public class ReadOptions {
       return this;
     }
 
-    public Builder ignoreInvalidRows(boolean ignoreInvalidRows) {
-      this.ignoreInvalidRows = ignoreInvalidRows;
+    /** Skip the rows with invalid column count in data values. Defaluts to {@code false}. */
+    public Builder skipRowsWithInvalidColumnCount(boolean skipRowsWithInvalidColumnCount) {
+      this.skipRowsWithInvalidColumnCount = skipRowsWithInvalidColumnCount;
       return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
@@ -364,5 +364,11 @@ public class CsvReadOptions extends ReadOptions {
       super.ignoreZeroDecimal(ignoreZeroDecimal);
       return this;
     }
+
+    @Override
+    public Builder ignoreInvalidRows(boolean ignoreInvalidRows) {
+      super.ignoreInvalidRows(ignoreInvalidRows);
+      return this;
+    }
   }
 }

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
@@ -366,8 +366,8 @@ public class CsvReadOptions extends ReadOptions {
     }
 
     @Override
-    public Builder ignoreInvalidRows(boolean ignoreInvalidRows) {
-      super.ignoreInvalidRows(ignoreInvalidRows);
+    public Builder skipRowsWithInvalidColumnCount(boolean skipRowsWithInvalidColumnCount) {
+      super.skipRowsWithInvalidColumnCount(skipRowsWithInvalidColumnCount);
       return this;
     }
   }

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
@@ -826,4 +826,23 @@ public class CsvReaderTest {
     Table out = Table.read().csv(new StringReader(string));
     assertEquals(table.get(0, 0), out.get(0, 0));
   }
+
+  @Test
+  public void testIgnoreInvalidRowsTrue() throws IOException {
+    Table table =
+        Table.read()
+            .csv(CsvReadOptions.builder("../data/short_row.csv").ignoreInvalidRows(true).build());
+    assertEquals(2, table.rowCount());
+  }
+
+  @Test
+  public void testIgnoreInvalidRowsFalse() throws IOException {
+    assertThrows(
+        AddCellToColumnException.class,
+        () -> {
+          Table.read()
+              .csv(
+                  CsvReadOptions.builder("../data/short_row.csv").ignoreInvalidRows(false).build());
+        });
+  }
 }

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
@@ -828,21 +828,27 @@ public class CsvReaderTest {
   }
 
   @Test
-  public void testIgnoreInvalidRowsTrue() throws IOException {
+  public void testSkipRowsWithInvalidColumnCount() throws IOException {
     Table table =
         Table.read()
-            .csv(CsvReadOptions.builder("../data/short_row.csv").ignoreInvalidRows(true).build());
+            .csv(
+                CsvReadOptions.builder("../data/short_row.csv")
+                    .skipRowsWithInvalidColumnCount(true)
+                    .build());
     assertEquals(2, table.rowCount());
   }
 
   @Test
-  public void testIgnoreInvalidRowsFalse() throws IOException {
+  public void skipRowsWithInvalidColumnCountWithoutHeader() throws IOException {
     assertThrows(
         AddCellToColumnException.class,
         () -> {
           Table.read()
               .csv(
-                  CsvReadOptions.builder("../data/short_row.csv").ignoreInvalidRows(false).build());
+                  CsvReadOptions.builder("../data/short_row.csv")
+                      .header(false)
+                      .skipRowsWithInvalidColumnCount(true)
+                      .build());
         });
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

add ignoreInvalidRows option in `CsvReadOptions` and `ReadOptions`  to skip invalid csv rows

## Testing

add 2 unit tests
