### PR TITLE
Improve innerJoin performance

### DIFF
--- a/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
+++ b/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
@@ -169,6 +169,7 @@ public class DataFrameJoiner {
    *     column have the same name if {@code true} the join will succeed and duplicate columns are
    *     renamed
    * @param table2JoinColumnNames The names of the columns in table2 to join on.
+   * @return the joined table
    */
   private Table joinInternal(
       Table table1,
@@ -391,6 +392,7 @@ public class DataFrameJoiner {
    * @param ri row number of row in table 1.
    * @param selectionSize max size in table 1.
    * @param joinColumnIndexes the column index of table1
+   * @return selection created
    */
   private Selection createMultiColSelection(
       Table table1,

--- a/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
+++ b/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
@@ -199,7 +199,6 @@ public class DataFrameJoiner {
 
     Selection table1DoneRows = Selection.with();
     Selection table2DoneRows = Selection.with();
-    // 2021/04/24 @Daniel Modified: If size of table1 is larger than table2,
     // use table 2 for row iteration, which can significantly increase performance
     if (table1.rowCount() > table2.rowCount() && joinType == JoinType.INNER) {
       for (Row row : table2) {
@@ -388,14 +387,15 @@ public class DataFrameJoiner {
   /**
    * Create a big multicolumn selection for all join columns in the given table. Joins two tables.
    *
-   * @param table1 the table which used to generate Selection.
-   * @param ri row number of row in table 1.
-   * @param selectionSize max size in table 1.
-   * @param joinColumnIndexes the column index of table1
+   * @param table the table that used to generate Selection.
+   * @param ri row number of row in table.
+   * @param indexes a reverse index for every join column in the table.
+   * @param selectionSize max size in table .
+   * @param joinColumnIndexes the column index of join key in tables
    * @return selection created
    */
   private Selection createMultiColSelection(
-      Table table1,
+      Table table,
       int ri,
       List<Index> indexes,
       int selectionSize,
@@ -403,7 +403,7 @@ public class DataFrameJoiner {
     Selection multiColSelection = Selection.withRange(0, selectionSize);
     int i = 0;
     for (Integer joinColumnIndex : joinColumnIndexes) {
-      Column<?> col = table1.column(joinColumnIndex);
+      Column<?> col = table.column(joinColumnIndex);
       Selection oneColSelection = selectionForColumn(col, ri, indexes.get(i));
       // and the selections.
       multiColSelection = multiColSelection.and(oneColSelection);

--- a/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
+++ b/core/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
@@ -384,8 +384,14 @@ public class DataFrameJoiner {
               + valueColumn.type());
     }
   }
-
-  /** Create a big multicolumn selection for all join columns in the given table. */
+  /**
+   * Create a big multicolumn selection for all join columns in the given table. Joins two tables.
+   *
+   * @param table1 the table which used to generate Selection.
+   * @param ri row number of row in table 1.
+   * @param selectionSize max size in table 1.
+   * @param joinColumnIndexes the column index of table1
+   */
   private Selection createMultiColSelection(
       Table table1,
       int ri,

--- a/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerPerformanceTest.java
+++ b/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerPerformanceTest.java
@@ -63,6 +63,26 @@ public class DataFrameJoinerPerformanceTest {
   }
 
   @Test
+  public void innerJoinCustomersFirstTimeMeasure() {
+    int numberOrders = 1_000_0;
+    int numberCustomers = 1_000_000_0;
+    Table customers = createCustomersTable(numberCustomers);
+    addFillerColumn(customers, 2, "customer");
+    Table orders = createOrdersTable(numberOrders, numberCustomers);
+    addFillerColumn(orders, 2, "order");
+    long begin = System.currentTimeMillis();
+    orders.joinOn("customerId").inner(customers);
+    long end = System.currentTimeMillis();
+    System.out.println("small table on the left cost time:");
+    System.out.println(end - begin);
+    begin = System.currentTimeMillis();
+    customers.joinOn("customerId").inner(orders);
+    end = System.currentTimeMillis();
+    System.out.println("small table on the right cost time:");
+    System.out.println(end - begin);
+  }
+
+  @Test
   public void leftOuterOrdersFirst() {
     int numberOrders = 10_000;
     Table customers = createCustomersTable(1_000);

--- a/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerPerformanceTest.java
+++ b/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerPerformanceTest.java
@@ -63,26 +63,6 @@ public class DataFrameJoinerPerformanceTest {
   }
 
   @Test
-  public void innerJoinCustomersFirstTimeMeasure() {
-    int numberOrders = 1_000_0;
-    int numberCustomers = 1_000_000_0;
-    Table customers = createCustomersTable(numberCustomers);
-    addFillerColumn(customers, 2, "customer");
-    Table orders = createOrdersTable(numberOrders, numberCustomers);
-    addFillerColumn(orders, 2, "order");
-    long begin = System.currentTimeMillis();
-    orders.joinOn("customerId").inner(customers);
-    long end = System.currentTimeMillis();
-    System.out.println("small table on the left cost time:");
-    System.out.println(end - begin);
-    begin = System.currentTimeMillis();
-    customers.joinOn("customerId").inner(orders);
-    end = System.currentTimeMillis();
-    System.out.println("small table on the right cost time:");
-    System.out.println(end - begin);
-  }
-
-  @Test
   public void leftOuterOrdersFirst() {
     int numberOrders = 10_000;
     Table customers = createCustomersTable(1_000);

--- a/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerTest.java
+++ b/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerTest.java
@@ -227,6 +227,35 @@ public class DataFrameJoinerTest {
             "Student");
   }
 
+  private static Table createSTUDENTLarger() {
+    return Table.read()
+        .csv(
+            Joiner.on(System.lineSeparator())
+                .join(
+                    "ID,FirstName,LastName,City,State,Age,USID,GradYear",
+                    "1,Bob,Barney,Burke,VA,20,11122,2019",
+                    "2,Chris,Cabello,Canyonville,OR,20,22224,2019",
+                    "3,Dan,Dirble,Denver,CO,21,33335,2020",
+                    "4,Edward,Earhardt,Easterly,WA,21,44339,2021",
+                    "5,Frank,Farnsworth,Fredriksburg,VA,22,55338,2019",
+                    "6,George,Gabral,Garrisburg,MD,22,66337,2020",
+                    "7,Michael,Marbury,Milton,NH,23,77330,2020",
+                    "8,Robert,Riley,Roseburg,OR,23,88836,2020",
+                    "9,Bob,Earhardt,Milton,NH,24,93333,2019",
+                    "10,Dan,Gabral,Easterly,WA,24,13333,2020",
+                    "11,Bob,Barney,Burke,VA,20,11122,2019",
+                    "12,Chris,Cabello,Canyonville,OR,20,22224,2019",
+                    "13,Dan,Dirble,Denver,CO,21,33335,2020",
+                    "14,Edward,Earhardt,Easterly,WA,21,44339,2021",
+                    "15,Frank,Farnsworth,Fredriksburg,VA,22,55338,2019",
+                    "16,George,Gabral,Garrisburg,MD,22,66337,2020",
+                    "17,Michael,Marbury,Milton,NH,23,77330,2020",
+                    "18,Robert,Riley,Roseburg,OR,23,88836,2020",
+                    "19,Bob,Earhardt,Milton,NH,24,93333,2019",
+                    "20,Dan,Gabral,Easterly,WA,24,13333,2020"),
+            "Student");
+  }
+
   private static Table createINSTRUCTOR() {
     return Table.read()
         .csv(
@@ -722,6 +751,7 @@ public class DataFrameJoinerTest {
     assert (joined
         .columnNames()
         .containsAll(Arrays.asList("T2.ID", "T2.City", "T2.State", "T2.USID", "T2.GradYear")));
+    System.out.println(joined.printAll());
     assertEquals(16, joined.columnCount());
     assertEquals(14, joined.rowCount());
   }
@@ -791,6 +821,50 @@ public class DataFrameJoinerTest {
     assertEquals(30, joined.columnCount());
     assertEquals(14, joined.rowCount());
   }
+  // Tests for left table is larger than right table, single cols
+  @Test
+  public void innerJoinStudentInstructorClassDeptHeadOnAgeLargerLeftTable() {
+    Table table1 = createSTUDENTLarger();
+    Table table2 = createINSTRUCTOR();
+    Table table3 = createCLASS();
+    Table table4 = createDEPTHEAD();
+    Table joined = table1.joinOn("Age").inner(true, table2, table3, table4);
+    List<String> expectedCol =
+        Arrays.asList(
+            "ID",
+            "FirstName",
+            "LastName",
+            "City",
+            "State",
+            "Age",
+            "USID",
+            "GradYear",
+            "T2.ID",
+            "First",
+            "Last",
+            "Title",
+            "T2.City",
+            "T2.State",
+            "T2.USID",
+            "T2.GradYear",
+            "T3.ID",
+            "ClassType",
+            "Name",
+            "Level",
+            "Description",
+            "StartDate",
+            "EndDate",
+            "Completed",
+            "T4.ID",
+            "T4.First",
+            "T4.Last",
+            "Dept",
+            "T4.City",
+            "T4.State");
+    assert (String.join("", joined.columnNames()).equals(String.join("", expectedCol)));
+    assertEquals(30, joined.columnCount());
+    assertEquals(28, joined.rowCount());
+  }
 
   @Test
   public void innerJoinStudentInstructorDeptHeadOnStateAge() {
@@ -812,6 +886,42 @@ public class DataFrameJoinerTest {
                 "T3.City")));
     assertEquals(20, joined.columnCount());
     assertEquals(1, joined.rowCount());
+  }
+  // Tests for left table is larger than right table, multiple cols
+  @Test
+  public void innerJoinStudentInstructorDeptHeadOnStateAgeWithLargerLeftTable() {
+    Table table1 = createSTUDENTLarger();
+    Table table2 = createINSTRUCTOR();
+    Table table3 = createDEPTHEAD();
+    // table1 join table 2 will have 6 rows, so drop last 5 rows of table3 for test
+    table3 = table3.dropRows(5, 6, 7, 8, 9);
+    Table joined = table1.joinOn("State", "Age").inner(true, table2, table3);
+    List<String> expectedCol =
+        Arrays.asList(
+            "ID",
+            "FirstName",
+            "LastName",
+            "City",
+            "State",
+            "Age",
+            "USID",
+            "GradYear",
+            "T2.ID",
+            "First",
+            "Last",
+            "Title",
+            "T2.City",
+            "T2.USID",
+            "T2.GradYear",
+            "T3.ID",
+            "T3.First",
+            "T3.Last",
+            "Dept",
+            "T3.City");
+    // test for col order
+    assert (String.join("", joined.columnNames()).equals(String.join("", expectedCol)));
+    assertEquals(20, joined.columnCount());
+    assertEquals(2, joined.rowCount());
   }
 
   @Test


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Fix #902 
1. `tech.tablesaw.joining.DataFrameJoiner#joinInternal` method
I add the logic to determine which table will be used to do row iteration when table1 and table2 have different sizes. If table1 has a larger size than table B, table2 will be used to do row iteration. It significantly improves performance when table1 is much larger than table2.
2.`tech.tablesaw.joining.DataFrameJoiner#createMultiColSelection` method
This method is to choose the columns of a table used as the join key.  Originally, only the left table is chosen, **while I add the method parameters `List<Integer> joinColumnIndexes`, so both tables can be chosen to generate the col key index to do join.** 
## Testing
Did you add a unit test?
I added a test case called `tech.tablesaw.joining.DataFrameJoinerPerformanceTest#innerJoinCustomersFirstTimeMeasure`, and you can use this case to compare the performance between big table join the small table and small table join big table. 