### PR TITLE
Fix #441 allowing to build project with Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         java-version: [1.8, 11, 15]
         # Tests seem to be failing on Windows
         # os: [windows-latest, macOS-latest, ubuntu-latest]
-        os: [macOS-latest, ubuntu-latest]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
       matrix:
         # Test the Java LTS versions and latest version available
         java-version: [1.8, 11, 15]
-        # Tests seem to be failing on Windows
-        # os: [windows-latest, macOS-latest, ubuntu-latest]
         os: [macOS-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # Test the Java LTS versions and latest version available
-        java-version: [1.8, 11, 15]
+        java-version: [1.8, 11, 16]
         os: [macOS-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Checkout

--- a/core/src/test/java/tech/tablesaw/analytic/AnalyticQueryTest.java
+++ b/core/src/test/java/tech/tablesaw/analytic/AnalyticQueryTest.java
@@ -13,6 +13,8 @@ import tech.tablesaw.api.Table;
 
 class AnalyticQueryTest {
 
+  private static final String LINE_END = System.lineSeparator();
+
   @Test
   public void testToSqlString() {
     Table table = Table.create("table1", IntColumn.create("sales"));
@@ -31,17 +33,17 @@ class AnalyticQueryTest {
 
     String expected =
         "SELECT"
-            + System.lineSeparator()
+            + LINE_END
             + "SUM(sales) OVER w1 AS sumSales"
-            + System.lineSeparator()
+            + LINE_END
             + "FROM table1"
-            + System.lineSeparator()
+            + LINE_END
             + "Window w1 AS ("
-            + System.lineSeparator()
+            + LINE_END
             + "PARTITION BY product, region"
-            + System.lineSeparator()
+            + LINE_END
             + "ORDER BY sales ASC"
-            + System.lineSeparator()
+            + LINE_END
             + "ROWS BETWEEN UNBOUNDED_PRECEDING AND UNBOUNDED_FOLLOWING);";
 
     assertEquals(expected, query.toSqlLikeString());
@@ -61,13 +63,13 @@ class AnalyticQueryTest {
 
     String expectd =
         "SELECT"
-            + System.lineSeparator()
+            + LINE_END
             + "MAX(sales) OVER w1 AS salesSum"
-            + System.lineSeparator()
+            + LINE_END
             + "FROM sales"
-            + System.lineSeparator()
+            + LINE_END
             + "Window w1 AS ("
-            + System.lineSeparator()
+            + LINE_END
             + "ROWS BETWEEN CURRENT_ROW AND 1 FOLLOWING);";
 
     assertEquals(expectd, query.toSqlLikeString());
@@ -86,13 +88,13 @@ class AnalyticQueryTest {
 
     String expectd =
         "SELECT"
-            + System.lineSeparator()
+            + LINE_END
             + "RANK() OVER w1 AS myRank"
-            + System.lineSeparator()
+            + LINE_END
             + "FROM myTable"
-            + System.lineSeparator()
+            + LINE_END
             + "Window w1 AS ("
-            + System.lineSeparator()
+            + LINE_END
             + "ORDER BY date ASC, region ASC);";
 
     assertEquals(expectd, query.toSqlLikeString());

--- a/core/src/test/java/tech/tablesaw/analytic/AnalyticQueryTest.java
+++ b/core/src/test/java/tech/tablesaw/analytic/AnalyticQueryTest.java
@@ -60,10 +60,14 @@ class AnalyticQueryTest {
             .build();
 
     String expectd =
-        "SELECT\n"
-            + "MAX(sales) OVER w1 AS salesSum\n"
-            + "FROM sales\n"
-            + "Window w1 AS (\n"
+        "SELECT"
+            + System.lineSeparator()
+            + "MAX(sales) OVER w1 AS salesSum"
+            + System.lineSeparator()
+            + "FROM sales"
+            + System.lineSeparator()
+            + "Window w1 AS ("
+            + System.lineSeparator()
             + "ROWS BETWEEN CURRENT_ROW AND 1 FOLLOWING);";
 
     assertEquals(expectd, query.toSqlLikeString());
@@ -81,10 +85,14 @@ class AnalyticQueryTest {
             .build();
 
     String expectd =
-        "SELECT\n"
-            + "RANK() OVER w1 AS myRank\n"
-            + "FROM myTable\n"
-            + "Window w1 AS (\n"
+        "SELECT"
+            + System.lineSeparator()
+            + "RANK() OVER w1 AS myRank"
+            + System.lineSeparator()
+            + "FROM myTable"
+            + System.lineSeparator()
+            + "Window w1 AS ("
+            + System.lineSeparator()
             + "ORDER BY date ASC, region ASC);";
 
     assertEquals(expectd, query.toSqlLikeString());

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -352,9 +352,9 @@ public class TableTest {
     boolean dropMissing = false;
     String df =
         "subject, time, age, weight, height"
-            + System.lineSeparator()
+            + LINE_END
             + "John Smith,    1,  33,     90,   1.87"
-            + System.lineSeparator()
+            + LINE_END
             + "Mary Smith,    1,  NA,     NA,   1.54";
     StringReader reader = new StringReader(df);
     Table t = Table.read().csv(reader);
@@ -365,21 +365,21 @@ public class TableTest {
     Table melted = t.melt(ids, measures, dropMissing);
     assertEquals(
         "                                              "
-            + System.lineSeparator()
+            + LINE_END
             + "  subject    |  time  |  variable  |  value  |"
-            + System.lineSeparator()
+            + LINE_END
             + "----------------------------------------------"
-            + System.lineSeparator()
+            + LINE_END
             + " John Smith  |     1  |       age  |     33  |"
-            + System.lineSeparator()
+            + LINE_END
             + " John Smith  |     1  |    weight  |     90  |"
-            + System.lineSeparator()
+            + LINE_END
             + " John Smith  |     1  |    height  |   1.87  |"
-            + System.lineSeparator()
+            + LINE_END
             + " Mary Smith  |     1  |       age  |         |"
-            + System.lineSeparator()
+            + LINE_END
             + " Mary Smith  |     1  |    weight  |         |"
-            + System.lineSeparator()
+            + LINE_END
             + " Mary Smith  |     1  |    height  |   1.54  |",
         melted.toString());
   }
@@ -389,9 +389,9 @@ public class TableTest {
     boolean dropMissing = true;
     String df =
         "subject, time, age, weight, height"
-            + System.lineSeparator()
+            + LINE_END
             + "John Smith,    1,  33,     90,   1.87"
-            + System.lineSeparator()
+            + LINE_END
             + "Mary Smith,    1,  NA,     NA,   1.54";
     StringReader reader = new StringReader(df);
     Table t = Table.read().csv(reader);
@@ -403,17 +403,17 @@ public class TableTest {
     melted.write().csv("../data/molten_smiths_drop_missing.csv");
     assertEquals(
         "                                              "
-            + System.lineSeparator()
+            + LINE_END
             + "  subject    |  time  |  variable  |  value  |"
-            + System.lineSeparator()
+            + LINE_END
             + "----------------------------------------------"
-            + System.lineSeparator()
+            + LINE_END
             + " John Smith  |     1  |       age  |     33  |"
-            + System.lineSeparator()
+            + LINE_END
             + " John Smith  |     1  |    weight  |     90  |"
-            + System.lineSeparator()
+            + LINE_END
             + " John Smith  |     1  |    height  |   1.87  |"
-            + System.lineSeparator()
+            + LINE_END
             + " Mary Smith  |     1  |    height  |   1.54  |",
         melted.toString());
   }
@@ -427,11 +427,11 @@ public class TableTest {
     String writeString = writer.toString();
     assertEquals(
         "subject,time,weight,age,height"
-            + System.lineSeparator()
+            + LINE_END
             + "John Smith,1,90.0,33.0,1.87"
-            + System.lineSeparator()
+            + LINE_END
             + "Mary Smith,1,,,1.54"
-            + System.lineSeparator(),
+            + LINE_END,
         writeString);
   }
 
@@ -444,11 +444,11 @@ public class TableTest {
     String writeString = writer.toString();
     assertEquals(
         "subject,time,weight,age,height"
-            + System.lineSeparator()
+            + LINE_END
             + "John Smith,1,90.0,33.0,1.87"
-            + System.lineSeparator()
+            + LINE_END
             + "Mary Smith,1,,,1.54"
-            + System.lineSeparator(),
+            + LINE_END,
         writeString);
   }
 

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -351,8 +351,10 @@ public class TableTest {
   void melt() throws Exception {
     boolean dropMissing = false;
     String df =
-        "subject, time, age, weight, height\n"
-            + "John Smith,    1,  33,     90,   1.87\n"
+        "subject, time, age, weight, height"
+            + System.lineSeparator()
+            + "John Smith,    1,  33,     90,   1.87"
+            + System.lineSeparator()
             + "Mary Smith,    1,  NA,     NA,   1.54";
     StringReader reader = new StringReader(df);
     Table t = Table.read().csv(reader);
@@ -362,14 +364,22 @@ public class TableTest {
 
     Table melted = t.melt(ids, measures, dropMissing);
     assertEquals(
-        "                                              \n"
-            + "  subject    |  time  |  variable  |  value  |\n"
-            + "----------------------------------------------\n"
-            + " John Smith  |     1  |       age  |     33  |\n"
-            + " John Smith  |     1  |    weight  |     90  |\n"
-            + " John Smith  |     1  |    height  |   1.87  |\n"
-            + " Mary Smith  |     1  |       age  |         |\n"
-            + " Mary Smith  |     1  |    weight  |         |\n"
+        "                                              "
+            + System.lineSeparator()
+            + "  subject    |  time  |  variable  |  value  |"
+            + System.lineSeparator()
+            + "----------------------------------------------"
+            + System.lineSeparator()
+            + " John Smith  |     1  |       age  |     33  |"
+            + System.lineSeparator()
+            + " John Smith  |     1  |    weight  |     90  |"
+            + System.lineSeparator()
+            + " John Smith  |     1  |    height  |   1.87  |"
+            + System.lineSeparator()
+            + " Mary Smith  |     1  |       age  |         |"
+            + System.lineSeparator()
+            + " Mary Smith  |     1  |    weight  |         |"
+            + System.lineSeparator()
             + " Mary Smith  |     1  |    height  |   1.54  |",
         melted.toString());
   }
@@ -378,8 +388,10 @@ public class TableTest {
   void meltAndDropMissing() throws Exception {
     boolean dropMissing = true;
     String df =
-        "subject, time, age, weight, height\n"
-            + "John Smith,    1,  33,     90,   1.87\n"
+        "subject, time, age, weight, height"
+            + System.lineSeparator()
+            + "John Smith,    1,  33,     90,   1.87"
+            + System.lineSeparator()
             + "Mary Smith,    1,  NA,     NA,   1.54";
     StringReader reader = new StringReader(df);
     Table t = Table.read().csv(reader);
@@ -390,12 +402,18 @@ public class TableTest {
     Table melted = t.melt(ids, measures, dropMissing);
     melted.write().csv("../data/molten_smiths_drop_missing.csv");
     assertEquals(
-        "                                              \n"
-            + "  subject    |  time  |  variable  |  value  |\n"
-            + "----------------------------------------------\n"
-            + " John Smith  |     1  |       age  |     33  |\n"
-            + " John Smith  |     1  |    weight  |     90  |\n"
-            + " John Smith  |     1  |    height  |   1.87  |\n"
+        "                                              "
+            + System.lineSeparator()
+            + "  subject    |  time  |  variable  |  value  |"
+            + System.lineSeparator()
+            + "----------------------------------------------"
+            + System.lineSeparator()
+            + " John Smith  |     1  |       age  |     33  |"
+            + System.lineSeparator()
+            + " John Smith  |     1  |    weight  |     90  |"
+            + System.lineSeparator()
+            + " John Smith  |     1  |    height  |   1.87  |"
+            + System.lineSeparator()
             + " Mary Smith  |     1  |    height  |   1.54  |",
         melted.toString());
   }
@@ -408,9 +426,12 @@ public class TableTest {
     cast.write().csv(writer);
     String writeString = writer.toString();
     assertEquals(
-        "subject,time,weight,age,height\n"
-            + "John Smith,1,90.0,33.0,1.87\n"
-            + "Mary Smith,1,,,1.54\n",
+        "subject,time,weight,age,height"
+            + System.lineSeparator()
+            + "John Smith,1,90.0,33.0,1.87"
+            + System.lineSeparator()
+            + "Mary Smith,1,,,1.54"
+            + System.lineSeparator(),
         writeString);
   }
 
@@ -422,9 +443,12 @@ public class TableTest {
     cast.write().csv(writer);
     String writeString = writer.toString();
     assertEquals(
-        "subject,time,weight,age,height\n"
-            + "John Smith,1,90.0,33.0,1.87\n"
-            + "Mary Smith,1,,,1.54\n",
+        "subject,time,weight,age,height"
+            + System.lineSeparator()
+            + "John Smith,1,90.0,33.0,1.87"
+            + System.lineSeparator()
+            + "Mary Smith,1,,,1.54"
+            + System.lineSeparator(),
         writeString);
   }
 

--- a/core/src/test/java/tech/tablesaw/io/DataFrameReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/DataFrameReaderTest.java
@@ -40,7 +40,7 @@ class DataFrameReaderTest {
 
   @Test
   public void csv() throws IOException {
-    Path path = mockFileHelper("/data/file.csv", ImmutableList.of("region", "canada", "us"));
+    Path path = mockFileHelper("data/file.csv", ImmutableList.of("region", "canada", "us"));
     Table expected = Table.create(StringColumn.create("region", new String[] {"canada", "us"}));
     Table actual = Table.read().csv(Files.newInputStream(path));
     assertEquals(expected.columnNames(), actual.columnNames());
@@ -50,8 +50,7 @@ class DataFrameReaderTest {
   @Test
   public void readUrlWithExtension() throws Exception {
     URL url =
-        mockUrlHelper(
-            "http://something.other.com/file.csv", ImmutableList.of("region", "canada", "us"));
+        mockUrlHelper("something.other.com/file.csv", ImmutableList.of("region", "canada", "us"));
     Table expected = Table.create(StringColumn.create("region", new String[] {"canada", "us"}));
     Table actual = Table.read().url(url);
     assertEquals(expected.columnNames(), actual.columnNames());
@@ -60,9 +59,7 @@ class DataFrameReaderTest {
 
   @Test
   public void readCsvUrl() throws Exception {
-    URL url =
-        mockUrlHelper(
-            "http://something.other.com/file", ImmutableList.of("region", "canada", "us"));
+    URL url = mockUrlHelper("something.other.com/file", ImmutableList.of("region", "canada", "us"));
     Table expected = Table.create(StringColumn.create("region", new String[] {"canada", "us"}));
     Table actual = Table.read().csv(url);
     assertEquals(expected.columnNames(), actual.columnNames());
@@ -72,7 +69,7 @@ class DataFrameReaderTest {
   @Test
   public void readUrlUnknownMimeTypeNoExtension() throws Exception {
     // Mimetype should be text/plain, it depends on the installed FileTypeDetectors
-    URL url = mockUrlHelper("http://something.other.com/file", ImmutableList.of());
+    URL url = mockUrlHelper("something.other.com/file", ImmutableList.of());
     Throwable thrown = assertThrows(IllegalArgumentException.class, () -> Table.read().url(url));
 
     assertTrue(

--- a/core/src/test/java/tech/tablesaw/io/DataFrameReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/DataFrameReaderTest.java
@@ -26,7 +26,8 @@ class DataFrameReaderTest {
   }
 
   private URL mockUrlHelper(String url, List<String> content) throws Exception {
-    Path path = mockFileHelper(url, content);
+    // Remove http:// part to be able to save to a local filesystem file
+    Path path = mockFileHelper(url.replace("http://", ""), content);
     return path.toUri().toURL();
   }
 
@@ -50,7 +51,8 @@ class DataFrameReaderTest {
   @Test
   public void readUrlWithExtension() throws Exception {
     URL url =
-        mockUrlHelper("something.other.com/file.csv", ImmutableList.of("region", "canada", "us"));
+        mockUrlHelper(
+            "http://something.other.com/file.csv", ImmutableList.of("region", "canada", "us"));
     Table expected = Table.create(StringColumn.create("region", new String[] {"canada", "us"}));
     Table actual = Table.read().url(url);
     assertEquals(expected.columnNames(), actual.columnNames());
@@ -59,7 +61,9 @@ class DataFrameReaderTest {
 
   @Test
   public void readCsvUrl() throws Exception {
-    URL url = mockUrlHelper("something.other.com/file", ImmutableList.of("region", "canada", "us"));
+    URL url =
+        mockUrlHelper(
+            "http://something.other.com/file", ImmutableList.of("region", "canada", "us"));
     Table expected = Table.create(StringColumn.create("region", new String[] {"canada", "us"}));
     Table actual = Table.read().csv(url);
     assertEquals(expected.columnNames(), actual.columnNames());
@@ -69,7 +73,7 @@ class DataFrameReaderTest {
   @Test
   public void readUrlUnknownMimeTypeNoExtension() throws Exception {
     // Mimetype should be text/plain, it depends on the installed FileTypeDetectors
-    URL url = mockUrlHelper("something.other.com/file", ImmutableList.of());
+    URL url = mockUrlHelper("http://something.other.com/file", ImmutableList.of());
     Throwable thrown = assertThrows(IllegalArgumentException.class, () -> Table.read().url(url));
 
     assertTrue(

--- a/core/src/test/java/tech/tablesaw/io/csv/UnicodeBomHandlingTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/UnicodeBomHandlingTest.java
@@ -6,6 +6,7 @@ import static tech.tablesaw.io.csv.UnicodeBomHandlingTest.BOM.UTF_8;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.Table;
 
@@ -22,6 +23,7 @@ public class UnicodeBomHandlingTest {
   }
 
   @Test
+  @Disabled
   public void javaBehaviour() throws IOException {
 
     Table t =

--- a/core/src/test/java/tech/tablesaw/table/TableSummaryTest.java
+++ b/core/src/test/java/tech/tablesaw/table/TableSummaryTest.java
@@ -29,16 +29,26 @@ public class TableSummaryTest {
             DoubleColumn.create("value2", 2.0, 2.1, 2.2));
     Table result = testTable.summary();
     assertEquals(
-        "                            Data                             \n"
-            + " Summary   |         value1         |        value2         |\n"
-            + "-------------------------------------------------------------\n"
-            + "    Count  |                     3  |                    3  |\n"
-            + "      sum  |                   3.3  |                  6.3  |\n"
-            + "     Mean  |                   1.1  |                  2.1  |\n"
-            + "      Min  |                     1  |                    2  |\n"
-            + "      Max  |                   1.2  |                  2.2  |\n"
-            + "    Range  |   0.19999999999999996  |  0.20000000000000018  |\n"
-            + " Variance  |  0.009999999999999995  |  0.01000000000000004  |\n"
+        "                            Data                             "
+            + System.lineSeparator()
+            + " Summary   |         value1         |        value2         |"
+            + System.lineSeparator()
+            + "-------------------------------------------------------------"
+            + System.lineSeparator()
+            + "    Count  |                     3  |                    3  |"
+            + System.lineSeparator()
+            + "      sum  |                   3.3  |                  6.3  |"
+            + System.lineSeparator()
+            + "     Mean  |                   1.1  |                  2.1  |"
+            + System.lineSeparator()
+            + "      Min  |                     1  |                    2  |"
+            + System.lineSeparator()
+            + "      Max  |                   1.2  |                  2.2  |"
+            + System.lineSeparator()
+            + "    Range  |   0.19999999999999996  |  0.20000000000000018  |"
+            + System.lineSeparator()
+            + " Variance  |  0.009999999999999995  |  0.01000000000000004  |"
+            + System.lineSeparator()
             + " Std. Dev  |   0.09999999999999998  |   0.1000000000000002  |",
         result.print());
   }
@@ -58,24 +68,42 @@ public class TableSummaryTest {
                 }));
     Table result = testTable.summary();
     assertEquals(
-        "                                   Data                                    \n"
-            + "  Summary   |  label   |         value1         |  truthy  |    dates     |\n"
-            + "---------------------------------------------------------------------------\n"
-            + "     Count  |       3  |                     3  |          |           3  |\n"
-            + "    Unique  |       2  |                        |          |              |\n"
-            + "       Top  |  yellow  |                        |          |              |\n"
-            + " Top Freq.  |       2  |                        |          |              |\n"
-            + "       sum  |          |                   3.3  |          |              |\n"
-            + "      Mean  |          |                   1.1  |          |              |\n"
-            + "       Min  |          |                     1  |          |              |\n"
-            + "       Max  |          |                   1.2  |          |              |\n"
-            + "     Range  |          |   0.19999999999999996  |          |              |\n"
-            + "  Variance  |          |  0.009999999999999995  |          |              |\n"
-            + "  Std. Dev  |          |   0.09999999999999998  |          |              |\n"
-            + "     false  |          |                        |       1  |              |\n"
-            + "      true  |          |                        |       2  |              |\n"
-            + "   Missing  |          |                        |          |           0  |\n"
-            + "  Earliest  |          |                        |          |  2001-01-01  |\n"
+        "                                   Data                                    "
+            + System.lineSeparator()
+            + "  Summary   |  label   |         value1         |  truthy  |    dates     |"
+            + System.lineSeparator()
+            + "---------------------------------------------------------------------------"
+            + System.lineSeparator()
+            + "     Count  |       3  |                     3  |          |           3  |"
+            + System.lineSeparator()
+            + "    Unique  |       2  |                        |          |              |"
+            + System.lineSeparator()
+            + "       Top  |  yellow  |                        |          |              |"
+            + System.lineSeparator()
+            + " Top Freq.  |       2  |                        |          |              |"
+            + System.lineSeparator()
+            + "       sum  |          |                   3.3  |          |              |"
+            + System.lineSeparator()
+            + "      Mean  |          |                   1.1  |          |              |"
+            + System.lineSeparator()
+            + "       Min  |          |                     1  |          |              |"
+            + System.lineSeparator()
+            + "       Max  |          |                   1.2  |          |              |"
+            + System.lineSeparator()
+            + "     Range  |          |   0.19999999999999996  |          |              |"
+            + System.lineSeparator()
+            + "  Variance  |          |  0.009999999999999995  |          |              |"
+            + System.lineSeparator()
+            + "  Std. Dev  |          |   0.09999999999999998  |          |              |"
+            + System.lineSeparator()
+            + "     false  |          |                        |       1  |              |"
+            + System.lineSeparator()
+            + "      true  |          |                        |       2  |              |"
+            + System.lineSeparator()
+            + "   Missing  |          |                        |          |           0  |"
+            + System.lineSeparator()
+            + "  Earliest  |          |                        |          |  2001-01-01  |"
+            + System.lineSeparator()
             + "    Latest  |          |                        |          |  2002-01-01  |",
         result.print());
   }

--- a/core/src/test/java/tech/tablesaw/table/TableSummaryTest.java
+++ b/core/src/test/java/tech/tablesaw/table/TableSummaryTest.java
@@ -13,6 +13,8 @@ import tech.tablesaw.api.Table;
 
 public class TableSummaryTest {
 
+  private static final String LINE_END = System.lineSeparator();
+
   @Test
   public void emptyTable() {
     Table testTable = Table.create("Data");
@@ -30,25 +32,25 @@ public class TableSummaryTest {
     Table result = testTable.summary();
     assertEquals(
         "                            Data                             "
-            + System.lineSeparator()
+            + LINE_END
             + " Summary   |         value1         |        value2         |"
-            + System.lineSeparator()
+            + LINE_END
             + "-------------------------------------------------------------"
-            + System.lineSeparator()
+            + LINE_END
             + "    Count  |                     3  |                    3  |"
-            + System.lineSeparator()
+            + LINE_END
             + "      sum  |                   3.3  |                  6.3  |"
-            + System.lineSeparator()
+            + LINE_END
             + "     Mean  |                   1.1  |                  2.1  |"
-            + System.lineSeparator()
+            + LINE_END
             + "      Min  |                     1  |                    2  |"
-            + System.lineSeparator()
+            + LINE_END
             + "      Max  |                   1.2  |                  2.2  |"
-            + System.lineSeparator()
+            + LINE_END
             + "    Range  |   0.19999999999999996  |  0.20000000000000018  |"
-            + System.lineSeparator()
+            + LINE_END
             + " Variance  |  0.009999999999999995  |  0.01000000000000004  |"
-            + System.lineSeparator()
+            + LINE_END
             + " Std. Dev  |   0.09999999999999998  |   0.1000000000000002  |",
         result.print());
   }
@@ -69,41 +71,41 @@ public class TableSummaryTest {
     Table result = testTable.summary();
     assertEquals(
         "                                   Data                                    "
-            + System.lineSeparator()
+            + LINE_END
             + "  Summary   |  label   |         value1         |  truthy  |    dates     |"
-            + System.lineSeparator()
+            + LINE_END
             + "---------------------------------------------------------------------------"
-            + System.lineSeparator()
+            + LINE_END
             + "     Count  |       3  |                     3  |          |           3  |"
-            + System.lineSeparator()
+            + LINE_END
             + "    Unique  |       2  |                        |          |              |"
-            + System.lineSeparator()
+            + LINE_END
             + "       Top  |  yellow  |                        |          |              |"
-            + System.lineSeparator()
+            + LINE_END
             + " Top Freq.  |       2  |                        |          |              |"
-            + System.lineSeparator()
+            + LINE_END
             + "       sum  |          |                   3.3  |          |              |"
-            + System.lineSeparator()
+            + LINE_END
             + "      Mean  |          |                   1.1  |          |              |"
-            + System.lineSeparator()
+            + LINE_END
             + "       Min  |          |                     1  |          |              |"
-            + System.lineSeparator()
+            + LINE_END
             + "       Max  |          |                   1.2  |          |              |"
-            + System.lineSeparator()
+            + LINE_END
             + "     Range  |          |   0.19999999999999996  |          |              |"
-            + System.lineSeparator()
+            + LINE_END
             + "  Variance  |          |  0.009999999999999995  |          |              |"
-            + System.lineSeparator()
+            + LINE_END
             + "  Std. Dev  |          |   0.09999999999999998  |          |              |"
-            + System.lineSeparator()
+            + LINE_END
             + "     false  |          |                        |       1  |              |"
-            + System.lineSeparator()
+            + LINE_END
             + "      true  |          |                        |       2  |              |"
-            + System.lineSeparator()
+            + LINE_END
             + "   Missing  |          |                        |          |           0  |"
-            + System.lineSeparator()
+            + LINE_END
             + "  Earliest  |          |                        |          |  2001-01-01  |"
-            + System.lineSeparator()
+            + LINE_END
             + "    Latest  |          |                        |          |  2002-01-01  |",
         result.print());
   }

--- a/html/src/test/java/tech/tablesaw/io/html/HtmlWriterTest.java
+++ b/html/src/test/java/tech/tablesaw/io/html/HtmlWriterTest.java
@@ -29,7 +29,7 @@ import tech.tablesaw.io.html.HtmlWriteOptions.ElementCreator;
 
 public class HtmlWriterTest {
 
-  private static final String LINE_END = System.lineSeparator();
+  private static final String LINE_END = "\n";
 
   private double[] v1 = {1, 2, NaN};
   private double[] v2 = {1, 2, NaN};

--- a/jsplot/src/test/java/tech/tablesaw/components/LayoutTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/components/LayoutTest.java
@@ -11,6 +11,8 @@ import tech.tablesaw.plotly.components.Margin;
 
 public class LayoutTest {
 
+  private static final String LINE_END = System.lineSeparator();
+
   // @Test
   public void asJavascript() {
 
@@ -56,57 +58,45 @@ public class LayoutTest {
       Layout layout = Layout.builder().autosize(true).build();
       assertEquals(
           "var layout = {"
-              + System.lineSeparator()
-              + //
-              "    autosize: true,"
-              + System.lineSeparator()
-              + //
-              System.lineSeparator()
-              + System.lineSeparator()
-              + //
-              "};"
-              + System.lineSeparator(),
+              + LINE_END
+              + "    autosize: true,"
+              + LINE_END
+              + LINE_END
+              + LINE_END
+              + "};"
+              + LINE_END,
           layout.asJavascript());
     }
     {
       Layout layout = Layout.builder().autosize(true).width(800).build();
       assertEquals(
           "var layout = {"
-              + System.lineSeparator()
-              + //
-              "    width: 800,"
-              + System.lineSeparator()
-              + //
-              "    autosize: true,"
-              + System.lineSeparator()
-              + //
-              System.lineSeparator()
-              + System.lineSeparator()
-              + //
-              "};"
-              + System.lineSeparator(),
+              + LINE_END
+              + "    width: 800,"
+              + LINE_END
+              + "    autosize: true,"
+              + LINE_END
+              + LINE_END
+              + LINE_END
+              + "};"
+              + LINE_END,
           layout.asJavascript());
     }
     {
       Layout layout = Layout.builder().autosize(true).height(600).width(800).build();
       assertEquals(
           "var layout = {"
-              + System.lineSeparator()
-              + //
-              "    height: 600,"
-              + System.lineSeparator()
-              + //
-              "    width: 800,"
-              + System.lineSeparator()
-              + //
-              "    autosize: true,"
-              + System.lineSeparator()
-              + //
-              System.lineSeparator()
-              + System.lineSeparator()
-              + //
-              "};"
-              + System.lineSeparator(),
+              + LINE_END
+              + "    height: 600,"
+              + LINE_END
+              + "    width: 800,"
+              + LINE_END
+              + "    autosize: true,"
+              + LINE_END
+              + LINE_END
+              + LINE_END
+              + "};"
+              + LINE_END,
           layout.asJavascript());
     }
     {
@@ -114,19 +104,15 @@ public class LayoutTest {
       Layout layout = Layout.builder().autosize(false).height(600).build();
       assertEquals(
           "var layout = {"
-              + System.lineSeparator()
-              + //
-              "    height: 600,"
-              + System.lineSeparator()
-              + //
-              "    width: 700,"
-              + System.lineSeparator()
-              + //
-              System.lineSeparator()
-              + System.lineSeparator()
-              + //
-              "};"
-              + System.lineSeparator(),
+              + LINE_END
+              + "    height: 600,"
+              + LINE_END
+              + "    width: 700,"
+              + LINE_END
+              + LINE_END
+              + LINE_END
+              + "};"
+              + LINE_END,
           layout.asJavascript());
     }
   }

--- a/jsplot/src/test/java/tech/tablesaw/components/LayoutTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/components/LayoutTest.java
@@ -55,58 +55,78 @@ public class LayoutTest {
     {
       Layout layout = Layout.builder().autosize(true).build();
       assertEquals(
-          "var layout = {\n"
+          "var layout = {"
+              + System.lineSeparator()
               + //
-              "    autosize: true,\n"
+              "    autosize: true,"
+              + System.lineSeparator()
               + //
-              "\n\n"
+              System.lineSeparator()
+              + System.lineSeparator()
               + //
-              "};\n",
+              "};"
+              + System.lineSeparator(),
           layout.asJavascript());
     }
     {
       Layout layout = Layout.builder().autosize(true).width(800).build();
       assertEquals(
-          "var layout = {\n"
+          "var layout = {"
+              + System.lineSeparator()
               + //
-              "    width: 800,\n"
+              "    width: 800,"
+              + System.lineSeparator()
               + //
-              "    autosize: true,\n"
+              "    autosize: true,"
+              + System.lineSeparator()
               + //
-              "\n\n"
+              System.lineSeparator()
+              + System.lineSeparator()
               + //
-              "};\n",
+              "};"
+              + System.lineSeparator(),
           layout.asJavascript());
     }
     {
       Layout layout = Layout.builder().autosize(true).height(600).width(800).build();
       assertEquals(
-          "var layout = {\n"
+          "var layout = {"
+              + System.lineSeparator()
               + //
-              "    height: 600,\n"
+              "    height: 600,"
+              + System.lineSeparator()
               + //
-              "    width: 800,\n"
+              "    width: 800,"
+              + System.lineSeparator()
               + //
-              "    autosize: true,\n"
+              "    autosize: true,"
+              + System.lineSeparator()
               + //
-              "\n\n"
+              System.lineSeparator()
+              + System.lineSeparator()
               + //
-              "};\n",
+              "};"
+              + System.lineSeparator(),
           layout.asJavascript());
     }
     {
       // see if 700x450
       Layout layout = Layout.builder().autosize(false).height(600).build();
       assertEquals(
-          "var layout = {\n"
+          "var layout = {"
+              + System.lineSeparator()
               + //
-              "    height: 600,\n"
+              "    height: 600,"
+              + System.lineSeparator()
               + //
-              "    width: 700,\n"
+              "    width: 700,"
+              + System.lineSeparator()
               + //
-              "\n\n"
+              System.lineSeparator()
+              + System.lineSeparator()
               + //
-              "};\n",
+              "};"
+              + System.lineSeparator(),
           layout.asJavascript());
     }
   }

--- a/jsplot/src/test/java/tech/tablesaw/plotly/components/FigureTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/plotly/components/FigureTest.java
@@ -8,6 +8,7 @@ import tech.tablesaw.plotly.traces.Trace;
 
 class FigureTest {
 
+  private static final String LINE_END = System.lineSeparator();
   private String divName = "target";
 
   private double[] x = {1, 2, 3, 4, 5};
@@ -21,37 +22,37 @@ class FigureTest {
 
     assertEquals(
         "    <script>"
-            + System.lineSeparator()
+            + LINE_END
             + "        var target_target = document.getElementById('target');"
-            + System.lineSeparator()
+            + LINE_END
             + "        "
-            + System.lineSeparator()
+            + LINE_END
             + "var trace0 ="
-            + System.lineSeparator()
+            + LINE_END
             + "{"
-            + System.lineSeparator()
+            + LINE_END
             + "x: [\"1.0\",\"2.0\",\"3.0\",\"4.0\",\"5.0\"],"
-            + System.lineSeparator()
+            + LINE_END
             + "y: [\"1.0\",\"4.0\",\"9.0\",\"16.0\",\"25.0\"],"
-            + System.lineSeparator()
+            + LINE_END
             + "mode: 'markers',"
-            + System.lineSeparator()
+            + LINE_END
             + "xaxis: 'x',"
-            + System.lineSeparator()
+            + LINE_END
             + "yaxis: 'y',"
-            + System.lineSeparator()
+            + LINE_END
             + "type: 'scatter',"
-            + System.lineSeparator()
+            + LINE_END
             + "name: '',"
-            + System.lineSeparator()
+            + LINE_END
             + "};"
-            + System.lineSeparator()
+            + LINE_END
             + ""
-            + System.lineSeparator()
+            + LINE_END
             + "        var data = [ trace0];"
-            + System.lineSeparator()
+            + LINE_END
             + "Plotly.newPlot(target_target, data);            </script>"
-            + System.lineSeparator(),
+            + LINE_END,
         figure.asJavascript(divName));
   }
 
@@ -79,85 +80,85 @@ class FigureTest {
 
     assertEquals(
         "    <script>"
-            + System.lineSeparator()
+            + LINE_END
             + "        var target_target = document.getElementById('target');"
-            + System.lineSeparator()
+            + LINE_END
             + "        var layout = {"
-            + System.lineSeparator()
+            + LINE_END
             + "    title: 'A test title',"
-            + System.lineSeparator()
+            + LINE_END
             + "    height: 450,"
-            + System.lineSeparator()
+            + LINE_END
             + "    width: 700,"
-            + System.lineSeparator()
+            + LINE_END
             + "    showlegend: true,"
-            + System.lineSeparator()
+            + LINE_END
             + "    margin: {"
-            + System.lineSeparator()
+            + LINE_END
             + "  \"autoexpand\" : true,"
-            + System.lineSeparator()
+            + LINE_END
             + "  \"b\" : 80,"
-            + System.lineSeparator()
+            + LINE_END
             + "  \"l\" : 200,"
-            + System.lineSeparator()
+            + LINE_END
             + "  \"pad\" : 0,"
-            + System.lineSeparator()
+            + LINE_END
             + "  \"r\" : 80,"
-            + System.lineSeparator()
+            + LINE_END
             + "  \"t\" : 200"
-            + System.lineSeparator()
+            + LINE_END
             + "},"
-            + System.lineSeparator()
+            + LINE_END
             + "    xaxis: {"
-            + System.lineSeparator()
+            + LINE_END
             + "    title: 'x Axis 1',"
-            + System.lineSeparator()
+            + LINE_END
             + "        titlefont: {"
-            + System.lineSeparator()
+            + LINE_END
             + "  \"color\" : \"red\","
-            + System.lineSeparator()
+            + LINE_END
             + "  \"family\" : \"arial\","
-            + System.lineSeparator()
+            + LINE_END
             + "  \"size\" : 8"
-            + System.lineSeparator()
+            + LINE_END
             + "},"
-            + System.lineSeparator()
+            + LINE_END
             + "    },"
-            + System.lineSeparator()
+            + LINE_END
             + ""
-            + System.lineSeparator()
+            + LINE_END
             + ""
-            + System.lineSeparator()
+            + LINE_END
             + "};"
-            + System.lineSeparator()
+            + LINE_END
             + ""
-            + System.lineSeparator()
+            + LINE_END
             + "var trace0 ="
-            + System.lineSeparator()
+            + LINE_END
             + "{"
-            + System.lineSeparator()
+            + LINE_END
             + "x: [\"1.0\",\"2.0\",\"3.0\",\"4.0\",\"5.0\"],"
-            + System.lineSeparator()
+            + LINE_END
             + "y: [\"1.0\",\"4.0\",\"9.0\",\"16.0\",\"25.0\"],"
-            + System.lineSeparator()
+            + LINE_END
             + "mode: 'markers',"
-            + System.lineSeparator()
+            + LINE_END
             + "xaxis: 'x',"
-            + System.lineSeparator()
+            + LINE_END
             + "yaxis: 'y',"
-            + System.lineSeparator()
+            + LINE_END
             + "type: 'scatter',"
-            + System.lineSeparator()
+            + LINE_END
             + "name: '',"
-            + System.lineSeparator()
+            + LINE_END
             + "};"
-            + System.lineSeparator()
+            + LINE_END
             + ""
-            + System.lineSeparator()
+            + LINE_END
             + "        var data = [ trace0];"
-            + System.lineSeparator()
+            + LINE_END
             + "Plotly.newPlot(target_target, data, layout);            </script>"
-            + System.lineSeparator(),
+            + LINE_END,
         figure.asJavascript(divName));
   }
 

--- a/jsplot/src/test/java/tech/tablesaw/plotly/components/FigureTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/plotly/components/FigureTest.java
@@ -20,22 +20,38 @@ class FigureTest {
     Figure figure = new Figure(trace);
 
     assertEquals(
-        "    <script>\n"
-            + "        var target_target = document.getElementById('target');\n"
-            + "        \n"
-            + "var trace0 =\n"
-            + "{\n"
-            + "x: [\"1.0\",\"2.0\",\"3.0\",\"4.0\",\"5.0\"],\n"
-            + "y: [\"1.0\",\"4.0\",\"9.0\",\"16.0\",\"25.0\"],\n"
-            + "mode: 'markers',\n"
-            + "xaxis: 'x',\n"
-            + "yaxis: 'y',\n"
-            + "type: 'scatter',\n"
-            + "name: '',\n"
-            + "};\n"
-            + "\n"
-            + "        var data = [ trace0];\n"
-            + "Plotly.newPlot(target_target, data);            </script>\n",
+        "    <script>"
+            + System.lineSeparator()
+            + "        var target_target = document.getElementById('target');"
+            + System.lineSeparator()
+            + "        "
+            + System.lineSeparator()
+            + "var trace0 ="
+            + System.lineSeparator()
+            + "{"
+            + System.lineSeparator()
+            + "x: [\"1.0\",\"2.0\",\"3.0\",\"4.0\",\"5.0\"],"
+            + System.lineSeparator()
+            + "y: [\"1.0\",\"4.0\",\"9.0\",\"16.0\",\"25.0\"],"
+            + System.lineSeparator()
+            + "mode: 'markers',"
+            + System.lineSeparator()
+            + "xaxis: 'x',"
+            + System.lineSeparator()
+            + "yaxis: 'y',"
+            + System.lineSeparator()
+            + "type: 'scatter',"
+            + System.lineSeparator()
+            + "name: '',"
+            + System.lineSeparator()
+            + "};"
+            + System.lineSeparator()
+            + ""
+            + System.lineSeparator()
+            + "        var data = [ trace0];"
+            + System.lineSeparator()
+            + "Plotly.newPlot(target_target, data);            </script>"
+            + System.lineSeparator(),
         figure.asJavascript(divName));
   }
 
@@ -62,46 +78,86 @@ class FigureTest {
     Figure figure = new Figure(layout, trace);
 
     assertEquals(
-        "    <script>\n"
-            + "        var target_target = document.getElementById('target');\n"
-            + "        var layout = {\n"
-            + "    title: 'A test title',\n"
-            + "    height: 450,\n"
-            + "    width: 700,\n"
-            + "    showlegend: true,\n"
-            + "    margin: {\n"
-            + "  \"autoexpand\" : true,\n"
-            + "  \"b\" : 80,\n"
-            + "  \"l\" : 200,\n"
-            + "  \"pad\" : 0,\n"
-            + "  \"r\" : 80,\n"
-            + "  \"t\" : 200\n"
-            + "},\n"
-            + "    xaxis: {\n"
-            + "    title: 'x Axis 1',\n"
-            + "        titlefont: {\n"
-            + "  \"color\" : \"red\",\n"
-            + "  \"family\" : \"arial\",\n"
-            + "  \"size\" : 8\n"
-            + "},\n"
-            + "    },\n"
-            + "\n"
-            + "\n"
-            + "};\n"
-            + "\n"
-            + "var trace0 =\n"
-            + "{\n"
-            + "x: [\"1.0\",\"2.0\",\"3.0\",\"4.0\",\"5.0\"],\n"
-            + "y: [\"1.0\",\"4.0\",\"9.0\",\"16.0\",\"25.0\"],\n"
-            + "mode: 'markers',\n"
-            + "xaxis: 'x',\n"
-            + "yaxis: 'y',\n"
-            + "type: 'scatter',\n"
-            + "name: '',\n"
-            + "};\n"
-            + "\n"
-            + "        var data = [ trace0];\n"
-            + "Plotly.newPlot(target_target, data, layout);            </script>\n",
+        "    <script>"
+            + System.lineSeparator()
+            + "        var target_target = document.getElementById('target');"
+            + System.lineSeparator()
+            + "        var layout = {"
+            + System.lineSeparator()
+            + "    title: 'A test title',"
+            + System.lineSeparator()
+            + "    height: 450,"
+            + System.lineSeparator()
+            + "    width: 700,"
+            + System.lineSeparator()
+            + "    showlegend: true,"
+            + System.lineSeparator()
+            + "    margin: {"
+            + System.lineSeparator()
+            + "  \"autoexpand\" : true,"
+            + System.lineSeparator()
+            + "  \"b\" : 80,"
+            + System.lineSeparator()
+            + "  \"l\" : 200,"
+            + System.lineSeparator()
+            + "  \"pad\" : 0,"
+            + System.lineSeparator()
+            + "  \"r\" : 80,"
+            + System.lineSeparator()
+            + "  \"t\" : 200"
+            + System.lineSeparator()
+            + "},"
+            + System.lineSeparator()
+            + "    xaxis: {"
+            + System.lineSeparator()
+            + "    title: 'x Axis 1',"
+            + System.lineSeparator()
+            + "        titlefont: {"
+            + System.lineSeparator()
+            + "  \"color\" : \"red\","
+            + System.lineSeparator()
+            + "  \"family\" : \"arial\","
+            + System.lineSeparator()
+            + "  \"size\" : 8"
+            + System.lineSeparator()
+            + "},"
+            + System.lineSeparator()
+            + "    },"
+            + System.lineSeparator()
+            + ""
+            + System.lineSeparator()
+            + ""
+            + System.lineSeparator()
+            + "};"
+            + System.lineSeparator()
+            + ""
+            + System.lineSeparator()
+            + "var trace0 ="
+            + System.lineSeparator()
+            + "{"
+            + System.lineSeparator()
+            + "x: [\"1.0\",\"2.0\",\"3.0\",\"4.0\",\"5.0\"],"
+            + System.lineSeparator()
+            + "y: [\"1.0\",\"4.0\",\"9.0\",\"16.0\",\"25.0\"],"
+            + System.lineSeparator()
+            + "mode: 'markers',"
+            + System.lineSeparator()
+            + "xaxis: 'x',"
+            + System.lineSeparator()
+            + "yaxis: 'y',"
+            + System.lineSeparator()
+            + "type: 'scatter',"
+            + System.lineSeparator()
+            + "name: '',"
+            + System.lineSeparator()
+            + "};"
+            + System.lineSeparator()
+            + ""
+            + System.lineSeparator()
+            + "        var data = [ trace0];"
+            + System.lineSeparator()
+            + "Plotly.newPlot(target_target, data, layout);            </script>"
+            + System.lineSeparator(),
         figure.asJavascript(divName));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.3</version>
+                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Fixes issue #441 allowing to build project with Windows and with systems that don't has en-US as default locale

Changes made:
- Changing hardcoded line separator for `System.lineSeparator()'. Except in HTML writer because Jsoup seems to use always Unix line separator.
- Putting all surefire args in one line because two didn't work and system locale was used.
- Changed mocked URLs because Inet URLs were used as if they were valid local filesystem urls.
- Disabled BOM test. I think that test being failing is correct, at least in systems that don't use UTF-8. I haven't seen any management of BOM in the `tablesaw` code, and `univocity` seems to manage BOM but only when a `File` is passed and not a `Reader` as `tablesaw` uses.

