### PR TITLE
fix bug in appendCell that caused custom parser to be ignored

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/TextColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TextColumn.java
@@ -292,7 +292,8 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
 
   @Override
   public TextColumn appendCell(String object, AbstractColumnParser<?> parser) {
-    return appendObj(parser.parse(object));
+    values.add(String.valueOf(parser.parse(object)));
+    return this;
   }
 
   @Override

--- a/core/src/main/java/tech/tablesaw/columns/AbstractColumnParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/AbstractColumnParser.java
@@ -83,4 +83,8 @@ public abstract class AbstractColumnParser<T> {
     }
     return new String(chars, 0, pos);
   }
+
+  public void setMissingValueStrings(List<String> missingValueStrings) {
+    this.missingValueStrings = missingValueStrings;
+  }
 }

--- a/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tech.tablesaw.columns.strings.StringPredicates.isEqualToIgnoringCase;
 
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.TestDataUtil;
 import tech.tablesaw.columns.strings.StringColumnFormatter;
+import tech.tablesaw.columns.strings.StringParser;
 import tech.tablesaw.selection.Selection;
 
 class StringColumnTest {
@@ -61,6 +64,21 @@ class StringColumnTest {
   void testAppendObj2() {
     final StringColumn sc = StringColumn.create("sc", Arrays.asList("a", "b", "c", "a"));
     assertArrayEquals(sc.asList().toArray(), sc.asObjectArray());
+  }
+
+  @Test
+  void appendAsterisk() {
+    final StringColumn sc = StringColumn.create("sc");
+    sc.append("*");
+    assertEquals(0, sc.countMissing());
+    StringParser parser = new StringParser(ColumnType.TEXT);
+    parser.setMissingValueStrings(new ArrayList<>());
+    sc.appendCell("*", parser);
+    assertEquals(0, sc.countMissing());
+    StringParser parser2 = new StringParser(ColumnType.TEXT);
+    parser2.setMissingValueStrings(Lists.newArrayList("45"));
+    sc.appendCell("45", parser2);
+    assertEquals(1, sc.countMissing());
   }
 
   @Test

--- a/core/src/test/java/tech/tablesaw/api/TextColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TextColumnTest.java
@@ -21,6 +21,7 @@ import static tech.tablesaw.columns.strings.StringPredicates.isEqualToIgnoringCa
 
 import com.google.common.base.Joiner;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.TestDataUtil;
 import tech.tablesaw.columns.strings.StringColumnFormatter;
+import tech.tablesaw.columns.strings.StringParser;
 import tech.tablesaw.io.csv.CsvReadOptions;
 import tech.tablesaw.selection.Selection;
 
@@ -107,6 +109,15 @@ public class TextColumnTest {
 
     Table joined = t1.joinOn("TIME").fullOuter(t2);
     assertEquals(3, joined.columnCount());
+  }
+
+  @Test
+  void appendAsterisk() {
+    final TextColumn sc = TextColumn.create("sc");
+    StringParser parser = new StringParser(ColumnType.TEXT);
+    parser.setMissingValueStrings(new ArrayList<>());
+    sc.appendCell("*", parser);
+    assertEquals(0, sc.countMissing());
   }
 
   @Test


### PR DESCRIPTION
In TextColumn, calling appendCell(string, parser) failed because the results of the call to parser.parse(string) was passed to appendObj(), which called parse again, this time using the default parser. This is fixed.

This commit also makes it possible to directly set the missingValueStrings list in a custom parser.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

see above

## Testing

Tests were added for TextColumn and StringColumn, which already worked ok.
