### PR TITLE
Fixes #897 - override default TextColumn string parsing.

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/TextColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TextColumn.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import tech.tablesaw.columns.AbstractColumnParser;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.columns.strings.AbstractStringColumn;
+import tech.tablesaw.columns.strings.StringParser;
 import tech.tablesaw.columns.strings.TextColumnType;
 import tech.tablesaw.selection.BitmapBackedSelection;
 import tech.tablesaw.selection.Selection;
@@ -55,6 +56,8 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
 
   private final Comparator<String> descendingStringComparator = Comparator.reverseOrder();
 
+  private StringParser stringParser = TextColumnType.DEFAULT_PARSER;
+
   private TextColumn(String name, Collection<String> strings) {
     super(TextColumnType.instance(), name);
     values = new ArrayList<>(strings.size());
@@ -74,6 +77,14 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
     for (String string : strings) {
       append(string);
     }
+  }
+
+  public StringParser getStringParser() {
+    return stringParser;
+  }
+
+  public void setStringParser(StringParser stringParser) {
+    this.stringParser = stringParser;
   }
 
   public static boolean valueIsMissing(String string) {
@@ -286,7 +297,11 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
 
   @Override
   public TextColumn appendCell(String object) {
-    values.add(TextColumnType.DEFAULT_PARSER.parse(object));
+    if (stringParser == null) {
+      values.add(object);
+    } else {
+      values.add(stringParser.parse(object));
+    }
     return this;
   }
 

--- a/core/src/test/java/tech/tablesaw/api/TextColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TextColumnTest.java
@@ -51,7 +51,21 @@ public class TextColumnTest {
     column.appendObj("Value 1");
     column.appendObj(null);
     column.appendObj("Value 2");
-    assertEquals(3, column.size());
+    column.appendObj("*");
+    assertEquals(4, column.size());
+    assertTrue(column.isMissing(3));
+  }
+
+  @Test
+  public void testAppendObjNullParser() {
+    TextColumn column = TextColumn.create("testing");
+    column.setStringParser(null);
+    column.appendObj("Value 1");
+    column.appendObj(null);
+    column.appendObj("Value 2");
+    column.appendObj("*");
+    assertEquals(4, column.size());
+    assertEquals("*", column.getString(3));
   }
 
   @Test

--- a/core/src/test/java/tech/tablesaw/api/TextColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TextColumnTest.java
@@ -16,6 +16,7 @@ package tech.tablesaw.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tech.tablesaw.columns.strings.StringPredicates.isEqualToIgnoringCase;
 
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.TestDataUtil;
 import tech.tablesaw.columns.strings.StringColumnFormatter;
+import tech.tablesaw.columns.strings.StringColumnType;
 import tech.tablesaw.columns.strings.StringParser;
 import tech.tablesaw.io.csv.CsvReadOptions;
 import tech.tablesaw.selection.Selection;
@@ -66,6 +68,33 @@ public class TextColumnTest {
     column.appendObj("*");
     assertEquals(4, column.size());
     assertEquals("*", column.getString(3));
+  }
+
+  @Test
+  public void testAppendObjCustomParser() {
+    class LowerCasingStringParser extends StringParser {
+      public LowerCasingStringParser(ColumnType columnType) {
+        super(columnType);
+      }
+
+      @Override
+      public String parse(String s) {
+        if (isMissing(s)) {
+          return StringColumnType.missingValueIndicator();
+        }
+        return s.toLowerCase();
+      }
+    };
+
+    final TextColumn column = TextColumn.create("testing");
+    final StringParser parser = new LowerCasingStringParser(ColumnType.TEXT);
+    column.setStringParser(parser);
+    column.appendObj("Value 1");
+    column.appendObj(null);
+    column.appendObj("Value 2");
+    assertSame(parser, column.getStringParser());
+    assertEquals(3, column.size());
+    assertEquals("value 1", column.getString(0));
   }
 
   @Test


### PR DESCRIPTION
Fixes #897

Replace hard-coded parser in TextColumn appendCell() with a private parser field that is initialized to DEFAULT_PARSER to preserve existing default behavior.  A client may use the new getStringParser() and setStringParser() methods to access and change the parser used for the column.  Setting the parser to null specifies that no parsing shall be performed when adding data to the column.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

see above

## Testing

Modified existing test to validate that previous behavior does not regress.  Added tests for null parser and custom parser.
