### PR TITLE
Corrected surefire plugin argLine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,12 +238,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Duser.language=en-US -Duser.region=US</argLine>
                     <printSummary>false</printSummary>
                     <!-- Jacoco prepare-agent builds some command-line params without -->
                     <!-- which jacoco will not instrument. Hence it is important to add -->
                     <!-- those command-line params here (${argLine} holds those params) -->
-                    <argLine>${argLine} -Xms256m -Xmx2048m</argLine>
+                    <argLine>${argLine} -Xms256m -Xmx2048m -Duser.language=en-US -Duser.region=US</argLine>
                     <forkCount>1</forkCount>
                     <runOrder>random</runOrder>
                 </configuration>


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Corrected maven-surefire-plugin configuration: merged the 2 argLine tags.
Allows tests to run on systems with a different default locale.

## Testing

No new tests. Previous tests now pass on systems with a different default locale.
