### PR TITLE
methods that parse stringColumns into the various numeric cols

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/strings/StringMapFunctions.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/StringMapFunctions.java
@@ -21,6 +21,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import tech.tablesaw.api.*;
 import tech.tablesaw.columns.Column;
@@ -227,13 +230,13 @@ public interface StringMapFunctions extends Column<String> {
     return newColumn;
   }
 
-  default DoubleColumn parseDouble(Function<String, Double> parseFunction) {
+  default DoubleColumn parseDouble(ToDoubleFunction<String> parseFunction) {
     DoubleColumn newColumn = DoubleColumn.create(name() + "[parsed]");
     for (String s : this) {
       if (StringColumn.valueIsMissing(s)) {
         newColumn.appendMissing();
       } else {
-        newColumn.append(parseFunction.apply(s));
+        newColumn.append(parseFunction.applyAsDouble(s));
       }
     }
     return newColumn;
@@ -251,25 +254,25 @@ public interface StringMapFunctions extends Column<String> {
     return newColumn;
   }
 
-  default IntColumn parseInt(Function<String, Integer> parseFunction) {
+  default IntColumn parseInt(ToIntFunction<String> parseFunction) {
     IntColumn newColumn = IntColumn.create(name() + "[parsed]");
     for (String s : this) {
       if (StringColumn.valueIsMissing(s)) {
         newColumn.appendMissing();
       } else {
-        newColumn.append(parseFunction.apply(s));
+        newColumn.append(parseFunction.applyAsInt(s));
       }
     }
     return newColumn;
   }
 
-  default LongColumn parseLong(Function<String, Long> parseFunction) {
+  default LongColumn parseLong(ToLongFunction<String> parseFunction) {
     LongColumn newColumn = LongColumn.create(name() + "[parsed]");
     for (String s : this) {
       if (StringColumn.valueIsMissing(s)) {
         newColumn.appendMissing();
       } else {
-        newColumn.append(parseFunction.apply(s));
+        newColumn.append(parseFunction.applyAsLong(s));
       }
     }
     return newColumn;

--- a/core/src/main/java/tech/tablesaw/columns/strings/StringMapFunctions.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/StringMapFunctions.java
@@ -20,11 +20,9 @@ import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
-import tech.tablesaw.api.DoubleColumn;
-import tech.tablesaw.api.FloatColumn;
-import tech.tablesaw.api.IntColumn;
-import tech.tablesaw.api.StringColumn;
+import tech.tablesaw.api.*;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.util.LevenshteinDistance;
 import tech.tablesaw.util.StringUtils;
@@ -224,6 +222,66 @@ public interface StringMapFunctions extends Column<String> {
         newColumn.appendMissing();
       } else {
         newColumn.append(Double.parseDouble(s));
+      }
+    }
+    return newColumn;
+  }
+
+  default DoubleColumn parseDouble(Function<String, Double> parseFunction) {
+    DoubleColumn newColumn = DoubleColumn.create(name() + "[parsed]");
+    for (String s : this) {
+      if (StringColumn.valueIsMissing(s)) {
+        newColumn.appendMissing();
+      } else {
+        newColumn.append(parseFunction.apply(s));
+      }
+    }
+    return newColumn;
+  }
+
+  default FloatColumn parseFloat(Function<String, Float> parseFunction) {
+    FloatColumn newColumn = FloatColumn.create(name() + "[parsed]");
+    for (String s : this) {
+      if (StringColumn.valueIsMissing(s)) {
+        newColumn.appendMissing();
+      } else {
+        newColumn.append(parseFunction.apply(s));
+      }
+    }
+    return newColumn;
+  }
+
+  default IntColumn parseInt(Function<String, Integer> parseFunction) {
+    IntColumn newColumn = IntColumn.create(name() + "[parsed]");
+    for (String s : this) {
+      if (StringColumn.valueIsMissing(s)) {
+        newColumn.appendMissing();
+      } else {
+        newColumn.append(parseFunction.apply(s));
+      }
+    }
+    return newColumn;
+  }
+
+  default LongColumn parseLong(Function<String, Long> parseFunction) {
+    LongColumn newColumn = LongColumn.create(name() + "[parsed]");
+    for (String s : this) {
+      if (StringColumn.valueIsMissing(s)) {
+        newColumn.appendMissing();
+      } else {
+        newColumn.append(parseFunction.apply(s));
+      }
+    }
+    return newColumn;
+  }
+
+  default ShortColumn parseShort(Function<String, Short> parseFunction) {
+    ShortColumn newColumn = ShortColumn.create(name() + "[parsed]");
+    for (String s : this) {
+      if (StringColumn.valueIsMissing(s)) {
+        newColumn.appendMissing();
+      } else {
+        newColumn.append(parseFunction.apply(s));
       }
     }
     return newColumn;

--- a/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
@@ -770,16 +770,15 @@ class StringColumnTest {
   void testParseCurrencyToDouble() {
     String[] values = {"428.231,42 €", "23.231,98 €"};
     StringColumn currency = StringColumn.create("currency", values);
-    final NumberFormat format = DecimalFormat.getCurrencyInstance(Locale.FRANCE);
+    final NumberFormat format = DecimalFormat.getNumberInstance();
     DoubleColumn doubles =
         currency.parseDouble(
             s -> {
               if (Strings.isNullOrEmpty(s)) {
                 return DoubleColumnType.missingValueIndicator();
               }
-              try { // French currency instance doesn't deal with . as a grouping character, go
-                    // figure
-                return (Double) format.parse(s.replace(".", ""));
+              try {
+                return (Double) format.parse(s.replaceAll("[^\\d,]", "").replace(",", "."));
               } catch (ParseException e) {
                 throw new RuntimeException(e);
               }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Added map functions that parse StringColumn and TextColumn values, returning one of the 5 numeric column types (LONG, SHORT, INT, DOUBLE, FLOAT).  These functions can be used to convert anything of a numeric nature (like currencies, percents, etc) or more generally, to extract numbers from strings, into an appropriate numeric column type using a user-provided parse function. 

## Testing

Tests were added for each of the new methods.
