### PR TITLE
Support multiple custom missing value options in Readers

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/booleans/BooleanParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/booleans/BooleanParser.java
@@ -35,8 +35,8 @@ public class BooleanParser extends AbstractColumnParser<Boolean> {
 
   public BooleanParser(BooleanColumnType booleanColumnType, ReadOptions readOptions) {
     super(booleanColumnType);
-    if (readOptions.missingValueIndicator() != null) {
-      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicator());
+    if (readOptions.missingValueIndicators().length > 0) {
+      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicators());
     }
   }
 

--- a/core/src/main/java/tech/tablesaw/columns/dates/DateParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/dates/DateParser.java
@@ -69,8 +69,8 @@ public class DateParser extends AbstractColumnParser<LocalDate> {
     if (readOptions.locale() != null) {
       locale = readOptions.locale();
     }
-    if (readOptions.missingValueIndicator() != null) {
-      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicator());
+    if (readOptions.missingValueIndicators().length > 0) {
+      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicators());
     }
   }
 

--- a/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/datetimes/DateTimeParser.java
@@ -66,8 +66,8 @@ public class DateTimeParser extends AbstractColumnParser<LocalDateTime> {
     if (readOptions.locale() != null) {
       locale = readOptions.locale();
     }
-    if (readOptions.missingValueIndicator() != null) {
-      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicator());
+    if (readOptions.missingValueIndicators().length > 0) {
+      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicators());
     }
   }
 

--- a/core/src/main/java/tech/tablesaw/columns/numbers/DoubleParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/DoubleParser.java
@@ -13,8 +13,8 @@ public class DoubleParser extends AbstractColumnParser<Double> {
 
   public DoubleParser(DoubleColumnType doubleColumnType, ReadOptions readOptions) {
     super(doubleColumnType);
-    if (readOptions.missingValueIndicator() != null) {
-      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicator());
+    if (readOptions.missingValueIndicators().length > 0) {
+      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicators());
     }
   }
 

--- a/core/src/main/java/tech/tablesaw/columns/numbers/FloatParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/FloatParser.java
@@ -13,8 +13,8 @@ public class FloatParser extends AbstractColumnParser<Float> {
 
   public FloatParser(FloatColumnType columnType, ReadOptions readOptions) {
     super(columnType);
-    if (readOptions.missingValueIndicator() != null) {
-      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicator());
+    if (readOptions.missingValueIndicators().length > 0) {
+      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicators());
     }
   }
 

--- a/core/src/main/java/tech/tablesaw/columns/numbers/IntParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/IntParser.java
@@ -17,8 +17,8 @@ public class IntParser extends AbstractColumnParser<Integer> {
 
   public IntParser(IntColumnType columnType, ReadOptions readOptions) {
     super(columnType);
-    if (readOptions.missingValueIndicator() != null) {
-      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicator());
+    if (readOptions.missingValueIndicators().length > 0) {
+      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicators());
     }
     ignoreZeroDecimal = readOptions.ignoreZeroDecimal();
   }

--- a/core/src/main/java/tech/tablesaw/columns/numbers/LongParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/LongParser.java
@@ -17,8 +17,8 @@ public class LongParser extends AbstractColumnParser<Long> {
 
   public LongParser(LongColumnType columnType, ReadOptions readOptions) {
     super(columnType);
-    if (readOptions.missingValueIndicator() != null) {
-      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicator());
+    if (readOptions.missingValueIndicators().length > 0) {
+      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicators());
     }
     ignoreZeroDecimal = readOptions.ignoreZeroDecimal();
   }

--- a/core/src/main/java/tech/tablesaw/columns/numbers/ShortParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/numbers/ShortParser.java
@@ -16,8 +16,8 @@ public class ShortParser extends AbstractColumnParser<Short> {
 
   public ShortParser(ShortColumnType columnType, ReadOptions readOptions) {
     super(columnType);
-    if (readOptions.missingValueIndicator() != null) {
-      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicator());
+    if (readOptions.missingValueIndicators().length > 0) {
+      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicators());
     }
     ignoreZeroDecimal = readOptions.ignoreZeroDecimal();
   }

--- a/core/src/main/java/tech/tablesaw/columns/strings/StringParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/StringParser.java
@@ -13,8 +13,8 @@ public class StringParser extends AbstractColumnParser<String> {
 
   public StringParser(ColumnType columnType, ReadOptions readOptions) {
     super(columnType);
-    if (readOptions.missingValueIndicator() != null) {
-      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicator());
+    if (readOptions.missingValueIndicators().length > 0) {
+      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicators());
     }
   }
 

--- a/core/src/main/java/tech/tablesaw/columns/times/TimeParser.java
+++ b/core/src/main/java/tech/tablesaw/columns/times/TimeParser.java
@@ -72,8 +72,8 @@ public class TimeParser extends AbstractColumnParser<LocalTime> {
     if (readOptions.locale() != null) {
       locale = readOptions.locale();
     }
-    if (readOptions.missingValueIndicator() != null) {
-      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicator());
+    if (readOptions.missingValueIndicators().length > 0) {
+      missingValueStrings = Lists.newArrayList(readOptions.missingValueIndicators());
     }
   }
 

--- a/core/src/main/java/tech/tablesaw/io/ReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/ReadOptions.java
@@ -75,7 +75,7 @@ public class ReadOptions {
   protected final String dateTimeFormat;
   protected final String timeFormat;
   protected final Locale locale;
-  protected final String missingValueIndicator;
+  protected final String[] missingValueIndicators;
   protected final boolean minimizeColumnSizes;
   protected final int maxCharsPerColumn;
   protected final boolean ignoreZeroDecimal;
@@ -95,7 +95,7 @@ public class ReadOptions {
     dateFormat = builder.dateFormat;
     timeFormat = builder.timeFormat;
     dateTimeFormat = builder.dateTimeFormat;
-    missingValueIndicator = builder.missingValueIndicator;
+    missingValueIndicators = builder.missingValueIndicators;
     minimizeColumnSizes = builder.minimizeColumnSizes;
     header = builder.header;
     maxCharsPerColumn = builder.maxCharsPerColumn;
@@ -138,8 +138,8 @@ public class ReadOptions {
     return minimizeColumnSizes;
   }
 
-  public String missingValueIndicator() {
-    return missingValueIndicator;
+  public String[] missingValueIndicators() {
+    return missingValueIndicators;
   }
 
   public Locale locale() {
@@ -198,7 +198,7 @@ public class ReadOptions {
     protected String dateTimeFormat;
     protected DateTimeFormatter dateTimeFormatter;
     protected Locale locale;
-    protected String missingValueIndicator;
+    protected String[] missingValueIndicators = new String[0];
     protected boolean minimizeColumnSizes = false;
     protected boolean header = true;
     protected int maxCharsPerColumn = 4096;
@@ -286,8 +286,8 @@ public class ReadOptions {
       return this;
     }
 
-    public Builder missingValueIndicator(String missingValueIndicator) {
-      this.missingValueIndicator = missingValueIndicator;
+    public Builder missingValueIndicator(String... missingValueIndicators) {
+      this.missingValueIndicators = missingValueIndicators;
       return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
@@ -348,8 +348,8 @@ public class CsvReadOptions extends ReadOptions {
     }
 
     @Override
-    public Builder missingValueIndicator(String missingValueIndicator) {
-      super.missingValueIndicator(missingValueIndicator);
+    public Builder missingValueIndicator(String... missingValueIndicators) {
+      super.missingValueIndicator(missingValueIndicators);
       return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthReadOptions.java
@@ -284,7 +284,7 @@ public class FixedWidthReadOptions extends ReadOptions {
     }
 
     @Override
-    public Builder missingValueIndicator(String missingValueIndicator) {
+    public Builder missingValueIndicator(String... missingValueIndicator) {
       super.missingValueIndicator(missingValueIndicator);
       return this;
     }

--- a/excel/src/main/java/tech/tablesaw/io/xlsx/XlsxReadOptions.java
+++ b/excel/src/main/java/tech/tablesaw/io/xlsx/XlsxReadOptions.java
@@ -143,8 +143,8 @@ public class XlsxReadOptions extends ReadOptions {
     }
 
     @Override
-    public Builder missingValueIndicator(String missingValueIndicator) {
-      super.missingValueIndicator(missingValueIndicator);
+    public Builder missingValueIndicator(String... missingValueIndicators) {
+      super.missingValueIndicator(missingValueIndicators);
       return this;
     }
 

--- a/html/src/main/java/tech/tablesaw/io/html/HtmlReadOptions.java
+++ b/html/src/main/java/tech/tablesaw/io/html/HtmlReadOptions.java
@@ -170,8 +170,8 @@ public class HtmlReadOptions extends ReadOptions {
     }
 
     @Override
-    public Builder missingValueIndicator(String missingValueIndicator) {
-      super.missingValueIndicator(missingValueIndicator);
+    public Builder missingValueIndicator(String... missingValueIndicators) {
+      super.missingValueIndicator(missingValueIndicators);
       return this;
     }
 

--- a/json/src/main/java/tech/tablesaw/io/json/JsonReadOptions.java
+++ b/json/src/main/java/tech/tablesaw/io/json/JsonReadOptions.java
@@ -169,8 +169,8 @@ public class JsonReadOptions extends ReadOptions {
     }
 
     @Override
-    public Builder missingValueIndicator(String missingValueIndicator) {
-      super.missingValueIndicator(missingValueIndicator);
+    public Builder missingValueIndicator(String... missingValueIndicators) {
+      super.missingValueIndicator(missingValueIndicators);
       return this;
     }
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Made the ReadOption for missingValues accept varargs so that multiple custom values could be handled. Users can now write

```
   ...missingValueIndicator("-", "?").build();
```
rather than being limited to a single value.

## Testing

Did you add a unit test?
Yes
