### PR TITLE
Fixes #927 - Allow default parsing to be overridden per column.

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
@@ -70,7 +70,7 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
   private BooleanFormatter formatter = new BooleanFormatter("true", "false", "");
 
   private BooleanColumn(String name, ByteArrayList values) {
-    super(BooleanColumnType.instance(), name);
+    super(BooleanColumnType.instance(), name, BooleanColumnType.DEFAULT_PARSER);
     data = values;
   }
 
@@ -304,7 +304,7 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
 
   @Override
   public BooleanColumn appendCell(String object) {
-    return append(BooleanColumnType.DEFAULT_PARSER.parseByte(object));
+    return append(parser().parseByte(object));
   }
 
   @Override
@@ -392,6 +392,7 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
     return countTrue() == 0;
   }
 
+  @Override
   public Selection isFalse() {
     Selection results = new BitmapBackedSelection();
     int i = 0;
@@ -404,6 +405,7 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
     return results;
   }
 
+  @Override
   public Selection isTrue() {
     Selection results = new BitmapBackedSelection();
     int i = 0;
@@ -416,6 +418,7 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
     return results;
   }
 
+  @Override
   public Selection isEqualTo(BooleanColumn other) {
     Selection results = new BitmapBackedSelection();
     int i = 0;
@@ -539,6 +542,7 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
     return this;
   }
 
+  @Override
   public Selection asSelection() {
     Selection selection = new BitmapBackedSelection();
     for (int i = 0; i < size(); i++) {

--- a/core/src/main/java/tech/tablesaw/api/DateColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateColumn.java
@@ -103,7 +103,7 @@ public class DateColumn extends AbstractColumn<DateColumn, LocalDate>
   }
 
   private DateColumn(String name, IntArrayList data) {
-    super(DateColumnType.instance(), name);
+    super(DateColumnType.instance(), name, DateColumnType.DEFAULT_PARSER);
     this.data = data;
   }
 
@@ -381,7 +381,7 @@ public class DateColumn extends AbstractColumn<DateColumn, LocalDate>
 
   @Override
   public DateColumn appendCell(String string) {
-    return appendInternal(PackedLocalDate.pack(DateColumnType.DEFAULT_PARSER.parse(string)));
+    return appendInternal(PackedLocalDate.pack(parser().parse(string)));
   }
 
   @Override
@@ -477,6 +477,7 @@ public class DateColumn extends AbstractColumn<DateColumn, LocalDate>
     return bottom;
   }
 
+  @Override
   public IntIterator intIterator() {
     return data.iterator();
   }

--- a/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
@@ -69,7 +69,7 @@ public class DateTimeColumn extends AbstractColumn<DateTimeColumn, LocalDateTime
   private DateTimeColumnFormatter printFormatter = new DateTimeColumnFormatter();
 
   private DateTimeColumn(String name, LongArrayList data) {
-    super(DateTimeColumnType.instance(), name);
+    super(DateTimeColumnType.instance(), name, DateTimeColumnType.DEFAULT_PARSER);
     this.data = data;
   }
 
@@ -176,6 +176,7 @@ public class DateTimeColumn extends AbstractColumn<DateTimeColumn, LocalDateTime
     return set(i, DateTimeColumnType.missingValueIndicator());
   }
 
+  @Override
   public DateTimeColumn where(Selection selection) {
     return subset(selection.toArray());
   }
@@ -217,8 +218,7 @@ public class DateTimeColumn extends AbstractColumn<DateTimeColumn, LocalDateTime
 
   @Override
   public DateTimeColumn appendCell(String stringValue) {
-    return appendInternal(
-        PackedLocalDateTime.pack(DateTimeColumnType.DEFAULT_PARSER.parse(stringValue)));
+    return appendInternal(PackedLocalDateTime.pack(parser().parse(stringValue)));
   }
 
   @Override
@@ -226,6 +226,7 @@ public class DateTimeColumn extends AbstractColumn<DateTimeColumn, LocalDateTime
     return appendObj(parser.parse(stringValue));
   }
 
+  @Override
   public DateTimeColumn append(LocalDateTime dateTime) {
     if (dateTime != null) {
       final long dt = PackedLocalDateTime.pack(dateTime);
@@ -252,10 +253,12 @@ public class DateTimeColumn extends AbstractColumn<DateTimeColumn, LocalDateTime
         "Cannot append " + obj.getClass().getName() + " to DateTimeColumn");
   }
 
+  @Override
   public int size() {
     return data.size();
   }
 
+  @Override
   public DateTimeColumn appendInternal(long dateTime) {
     data.add(dateTime);
     return this;
@@ -356,6 +359,7 @@ public class DateTimeColumn extends AbstractColumn<DateTimeColumn, LocalDateTime
     return data.isEmpty();
   }
 
+  @Override
   public long getLongInternal(int index) {
     return data.getLong(index);
   }
@@ -364,6 +368,7 @@ public class DateTimeColumn extends AbstractColumn<DateTimeColumn, LocalDateTime
     return getLongInternal(index);
   }
 
+  @Override
   public LocalDateTime get(int index) {
     return PackedLocalDateTime.asLocalDateTime(getPackedDateTime(index));
   }
@@ -601,6 +606,7 @@ public class DateTimeColumn extends AbstractColumn<DateTimeColumn, LocalDateTime
     return times;
   }
 
+  @Override
   public int byteSize() {
     return type().byteSize();
   }

--- a/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
@@ -26,7 +26,7 @@ public class DoubleColumn extends NumberColumn<DoubleColumn, Double>
   private final DoubleArrayList data;
 
   protected DoubleColumn(String name, DoubleArrayList data) {
-    super(DoubleColumnType.instance(), name);
+    super(DoubleColumnType.instance(), name, DoubleColumnType.DEFAULT_PARSER);
     setPrintFormatter(NumberColumnFormatter.floatingPointDefault());
     this.data = data;
   }
@@ -54,13 +54,14 @@ public class DoubleColumn extends NumberColumn<DoubleColumn, Double>
     data.clear();
   }
 
+  @Override
   public DoubleColumn setMissing(int index) {
     set(index, DoubleColumnType.missingValueIndicator());
     return this;
   }
 
   protected DoubleColumn(String name) {
-    super(DoubleColumnType.instance(), name);
+    super(DoubleColumnType.instance(), name, DoubleColumnType.DEFAULT_PARSER);
     setPrintFormatter(NumberColumnFormatter.floatingPointDefault());
     this.data = new DoubleArrayList(DEFAULT_ARRAY_SIZE);
   }
@@ -282,7 +283,7 @@ public class DoubleColumn extends NumberColumn<DoubleColumn, Double>
 
   @Override
   public Iterator<Double> iterator() {
-    return (Iterator<Double>) data.iterator();
+    return data.iterator();
   }
 
   @Override
@@ -435,7 +436,7 @@ public class DoubleColumn extends NumberColumn<DoubleColumn, Double>
   @Override
   public DoubleColumn appendCell(final String value) {
     try {
-      return append(DoubleColumnType.DEFAULT_PARSER.parseDouble(value));
+      return append(parser().parseDouble(value));
     } catch (final NumberFormatException e) {
       throw new NumberFormatException(
           "Error adding value to column " + name() + ": " + e.getMessage());

--- a/core/src/main/java/tech/tablesaw/api/FloatColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/FloatColumn.java
@@ -17,7 +17,7 @@ public class FloatColumn extends NumberColumn<FloatColumn, Float> {
   private final FloatArrayList data;
 
   private FloatColumn(String name, FloatArrayList data) {
-    super(FloatColumnType.instance(), name);
+    super(FloatColumnType.instance(), name, FloatColumnType.DEFAULT_PARSER);
     setPrintFormatter(NumberColumnFormatter.floatingPointDefault());
     this.data = data;
   }
@@ -189,6 +189,7 @@ public class FloatColumn extends NumberColumn<FloatColumn, Float> {
     return this;
   }
 
+  @Override
   public FloatColumn append(Float val) {
     if (val == null) {
       appendMissing();
@@ -342,7 +343,7 @@ public class FloatColumn extends NumberColumn<FloatColumn, Float> {
   @Override
   public FloatColumn appendCell(final String value) {
     try {
-      return append(FloatColumnType.DEFAULT_PARSER.parseFloat(value));
+      return append(parser().parseFloat(value));
     } catch (final NumberFormatException e) {
       throw new NumberFormatException(
           "Error adding value to column " + name() + ": " + e.getMessage());

--- a/core/src/main/java/tech/tablesaw/api/InstantColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/InstantColumn.java
@@ -71,7 +71,7 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
   private InstantColumnFormatter printFormatter = new InstantColumnFormatter();
 
   private InstantColumn(String name, LongArrayList data) {
-    super(InstantColumnType.instance(), name);
+    super(InstantColumnType.instance(), name, InstantColumnType.DEFAULT_PARSER);
     this.data = data;
   }
 
@@ -178,6 +178,7 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
     return set(i, InstantColumnType.missingValueIndicator());
   }
 
+  @Override
   public InstantColumn where(Selection selection) {
     return subset(selection.toArray());
   }
@@ -208,7 +209,7 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
 
   @Override
   public InstantColumn appendCell(String stringValue) {
-    return appendInternal(PackedInstant.pack(InstantColumnType.DEFAULT_PARSER.parse(stringValue)));
+    return appendInternal(PackedInstant.pack(parser().parse(stringValue)));
   }
 
   @Override
@@ -216,6 +217,7 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
     return appendObj(parser.parse(stringValue));
   }
 
+  @Override
   public InstantColumn append(Instant dateTime) {
     if (dateTime != null) {
       final long dt = PackedInstant.pack(dateTime);
@@ -242,10 +244,12 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
         "Cannot append " + obj.getClass().getName() + " to DateTimeColumn");
   }
 
+  @Override
   public int size() {
     return data.size();
   }
 
+  @Override
   public InstantColumn appendInternal(long dateTime) {
     data.add(dateTime);
     return this;
@@ -346,6 +350,7 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
     return data.isEmpty();
   }
 
+  @Override
   public long getLongInternal(int index) {
     return data.getLong(index);
   }
@@ -354,6 +359,7 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
     return getLongInternal(index);
   }
 
+  @Override
   public Instant get(int index) {
     return PackedInstant.asInstant(getPackedDateTime(index));
   }
@@ -588,6 +594,7 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
     return times;
   }
 
+  @Override
   public int byteSize() {
     return type().byteSize();
   }

--- a/core/src/main/java/tech/tablesaw/api/IntColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/IntColumn.java
@@ -19,7 +19,7 @@ public class IntColumn extends NumberColumn<IntColumn, Integer>
   private final IntArrayList data;
 
   protected IntColumn(final String name, IntArrayList data) {
-    super(IntColumnType.instance(), name);
+    super(IntColumnType.instance(), name, IntColumnType.DEFAULT_PARSER);
     setPrintFormatter(NumberColumnFormatter.ints());
     this.data = data;
   }
@@ -179,6 +179,7 @@ public class IntColumn extends NumberColumn<IntColumn, Integer>
     return this;
   }
 
+  @Override
   public IntColumn append(Integer val) {
     if (val == null) {
       appendMissing();
@@ -353,7 +354,7 @@ public class IntColumn extends NumberColumn<IntColumn, Integer>
   @Override
   public IntColumn appendCell(final String value) {
     try {
-      return append(IntColumnType.DEFAULT_PARSER.parseInt(value));
+      return append(parser().parseInt(value));
     } catch (final NumberFormatException e) {
       throw new NumberFormatException(
           "Error adding value to column " + name() + ": " + e.getMessage());
@@ -503,6 +504,7 @@ public class IntColumn extends NumberColumn<IntColumn, Integer>
     return result;
   }
 
+  @Override
   public IntColumn setMissing(int r) {
     set(r, IntColumnType.missingValueIndicator());
     return this;

--- a/core/src/main/java/tech/tablesaw/api/LongColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/LongColumn.java
@@ -20,7 +20,7 @@ public class LongColumn extends NumberColumn<LongColumn, Long> implements Catego
   private final LongArrayList data;
 
   private LongColumn(String name, LongArrayList data) {
-    super(LongColumnType.instance(), name);
+    super(LongColumnType.instance(), name, LongColumnType.DEFAULT_PARSER);
     setPrintFormatter(NumberColumnFormatter.ints());
     this.data = data;
   }
@@ -199,6 +199,7 @@ public class LongColumn extends NumberColumn<LongColumn, Long> implements Catego
     return this;
   }
 
+  @Override
   public LongColumn append(Long val) {
     if (val == null) {
       appendMissing();
@@ -398,7 +399,7 @@ public class LongColumn extends NumberColumn<LongColumn, Long> implements Catego
   @Override
   public LongColumn appendCell(final String value) {
     try {
-      return append(LongColumnType.DEFAULT_PARSER.parseLong(value));
+      return append(parser().parseLong(value));
     } catch (final NumberFormatException e) {
       throw new NumberFormatException(
           "Error adding value to column " + name() + ": " + e.getMessage());

--- a/core/src/main/java/tech/tablesaw/api/NumberColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/NumberColumn.java
@@ -5,6 +5,7 @@ import java.text.NumberFormat;
 import java.util.Locale;
 import java.util.function.DoublePredicate;
 import tech.tablesaw.columns.AbstractColumn;
+import tech.tablesaw.columns.AbstractColumnParser;
 import tech.tablesaw.columns.numbers.DoubleColumnType;
 import tech.tablesaw.columns.numbers.NumberColumnFormatter;
 
@@ -22,8 +23,8 @@ public abstract class NumberColumn<C extends NumberColumn<C, T>, T extends Numbe
         return Double.compare(f1, f2);
       };
 
-  protected NumberColumn(final ColumnType type, final String name) {
-    super(type, name);
+  protected NumberColumn(final ColumnType type, final String name, AbstractColumnParser<T> parser) {
+    super(type, name, parser);
   }
 
   protected abstract C createCol(final String name, int size);
@@ -52,10 +53,12 @@ public abstract class NumberColumn<C extends NumberColumn<C, T>, T extends Numbe
     return this;
   }
 
+  @Override
   public void setPrintFormatter(final NumberFormat format, final String missingValueString) {
     this.printFormatter = new NumberColumnFormatter(format, missingValueString);
   }
 
+  @Override
   public void setPrintFormatter(final NumberColumnFormatter formatter) {
     this.printFormatter = formatter;
   }
@@ -109,6 +112,7 @@ public abstract class NumberColumn<C extends NumberColumn<C, T>, T extends Numbe
     return column;
   }
 
+  @Override
   public abstract C copy();
 
   /**

--- a/core/src/main/java/tech/tablesaw/api/ShortColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/ShortColumn.java
@@ -27,7 +27,7 @@ public class ShortColumn extends NumberColumn<ShortColumn, Short>
   private final ShortArrayList data;
 
   protected ShortColumn(final String name, ShortArrayList data) {
-    super(ShortColumnType.instance(), name);
+    super(ShortColumnType.instance(), name, ShortColumnType.DEFAULT_PARSER);
     setPrintFormatter(NumberColumnFormatter.ints());
     this.data = data;
   }
@@ -191,6 +191,7 @@ public class ShortColumn extends NumberColumn<ShortColumn, Short>
     return this;
   }
 
+  @Override
   public ShortColumn append(Short val) {
     if (val == null) {
       appendMissing();
@@ -202,12 +203,12 @@ public class ShortColumn extends NumberColumn<ShortColumn, Short>
 
   @Override
   public ShortColumn emptyCopy() {
-    return (ShortColumn) super.emptyCopy();
+    return super.emptyCopy();
   }
 
   @Override
   public ShortColumn emptyCopy(final int rowSize) {
-    return (ShortColumn) super.emptyCopy(rowSize);
+    return super.emptyCopy(rowSize);
   }
 
   @Override
@@ -377,7 +378,7 @@ public class ShortColumn extends NumberColumn<ShortColumn, Short>
   @Override
   public ShortColumn appendCell(final String value) {
     try {
-      return append(ShortColumnType.DEFAULT_PARSER.parseShort(value));
+      return append(parser().parseShort(value));
     } catch (final NumberFormatException e) {
       throw new NumberFormatException(
           "Error adding value to column " + name() + ": " + e.getMessage());

--- a/core/src/main/java/tech/tablesaw/api/StringColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/StringColumn.java
@@ -94,23 +94,23 @@ public class StringColumn extends AbstractStringColumn<StringColumn> {
   }
 
   private StringColumn(String name, Collection<String> strings) {
-    super(StringColumnType.instance(), name);
+    super(StringColumnType.instance(), name, StringColumnType.DEFAULT_PARSER);
     for (String string : strings) {
       append(string);
     }
   }
 
   private StringColumn(String name, DictionaryMap map) {
-    super(StringColumnType.instance(), name);
+    super(StringColumnType.instance(), name, StringColumnType.DEFAULT_PARSER);
     lookupTable = map;
   }
 
   private StringColumn(String name) {
-    super(StringColumnType.instance(), name);
+    super(StringColumnType.instance(), name, StringColumnType.DEFAULT_PARSER);
   }
 
   private StringColumn(String name, String[] strings) {
-    super(StringColumnType.instance(), name);
+    super(StringColumnType.instance(), name, StringColumnType.DEFAULT_PARSER);
     for (String string : strings) {
       append(string);
     }
@@ -158,6 +158,7 @@ public class StringColumn extends AbstractStringColumn<StringColumn> {
    * @return value as String
    * @throws IndexOutOfBoundsException if the given rowIndex is not in the column
    */
+  @Override
   public String get(int rowIndex) {
     return lookupTable.getValueForIndex(rowIndex);
   }
@@ -317,7 +318,7 @@ public class StringColumn extends AbstractStringColumn<StringColumn> {
 
   @Override
   public StringColumn appendCell(String object) {
-    return appendCell(object, StringColumnType.DEFAULT_PARSER);
+    return appendCell(object, parser());
   }
 
   @Override
@@ -372,6 +373,7 @@ public class StringColumn extends AbstractStringColumn<StringColumn> {
     return DoubleColumn.create(this.name(), asDoubleArray());
   }
 
+  @Override
   public StringColumn where(Selection selection) {
     return subset(selection.toArray());
   }
@@ -441,6 +443,7 @@ public class StringColumn extends AbstractStringColumn<StringColumn> {
   }
 
   /** Added for naming consistency with all other columns */
+  @Override
   public StringColumn append(String value) {
     try {
       lookupTable.append(value);

--- a/core/src/main/java/tech/tablesaw/api/TextColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TextColumn.java
@@ -56,7 +56,7 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
   private final Comparator<String> descendingStringComparator = Comparator.reverseOrder();
 
   private TextColumn(String name, Collection<String> strings) {
-    super(TextColumnType.instance(), name);
+    super(TextColumnType.instance(), name, TextColumnType.DEFAULT_PARSER);
     values = new ArrayList<>(strings.size());
     for (String string : strings) {
       append(string);
@@ -64,12 +64,12 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
   }
 
   private TextColumn(String name) {
-    super(TextColumnType.instance(), name);
+    super(TextColumnType.instance(), name, TextColumnType.DEFAULT_PARSER);
     values = new ArrayList<>(DEFAULT_ARRAY_SIZE);
   }
 
   private TextColumn(String name, String[] strings) {
-    super(TextColumnType.instance(), name);
+    super(TextColumnType.instance(), name, TextColumnType.DEFAULT_PARSER);
     values = new ArrayList<>(strings.length);
     for (String string : strings) {
       append(string);
@@ -154,6 +154,7 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
    * @return value as String
    * @throws IndexOutOfBoundsException if the given rowIndex is not in the column
    */
+  @Override
   public String get(int rowIndex) {
     return values.get(rowIndex);
   }
@@ -286,7 +287,7 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
 
   @Override
   public TextColumn appendCell(String object) {
-    append(TextColumnType.DEFAULT_PARSER.parse(object));
+    append(parser().parse(object));
     return this;
   }
 
@@ -317,8 +318,9 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
     return TextColumn.create(name() + " Unique values", strings);
   }
 
+  @Override
   public TextColumn where(Selection selection) {
-    return (TextColumn) subset(selection.toArray());
+    return subset(selection.toArray());
   }
 
   // TODO (lwhite): This could avoid the append and do a list copy
@@ -385,6 +387,7 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
   }
 
   /** Added for naming consistency with all other columns */
+  @Override
   public TextColumn append(String value) {
     values.add(value);
     return this;

--- a/core/src/main/java/tech/tablesaw/api/TimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TimeColumn.java
@@ -66,12 +66,12 @@ public class TimeColumn extends AbstractColumn<TimeColumn, LocalTime>
       };
 
   private TimeColumn(String name, IntArrayList times) {
-    super(TimeColumnType.instance(), name);
+    super(TimeColumnType.instance(), name, TimeColumnType.DEFAULT_PARSER);
     data = times;
   }
 
   private TimeColumn(String name) {
-    super(TimeColumnType.instance(), name);
+    super(TimeColumnType.instance(), name, TimeColumnType.DEFAULT_PARSER);
     data = new IntArrayList(DEFAULT_ARRAY_SIZE);
   }
 
@@ -85,6 +85,12 @@ public class TimeColumn extends AbstractColumn<TimeColumn, LocalTime>
 
   public static TimeColumn create(String name) {
     return new TimeColumn(name);
+  }
+
+  public static TimeColumn create(String name, AbstractColumnParser<LocalTime> parser) {
+    TimeColumn column = new TimeColumn(name);
+    column.setParser(parser);
+    return column;
   }
 
   public static TimeColumn create(String name, Collection<LocalTime> data) {
@@ -156,6 +162,7 @@ public class TimeColumn extends AbstractColumn<TimeColumn, LocalTime>
     return valueIsMissing(getIntInternal(rowNumber));
   }
 
+  @Override
   public int size() {
     return data.size();
   }
@@ -165,6 +172,7 @@ public class TimeColumn extends AbstractColumn<TimeColumn, LocalTime>
     return this;
   }
 
+  @Override
   public TimeColumn append(LocalTime time) {
     int value;
     if (time == null) {
@@ -289,6 +297,7 @@ public class TimeColumn extends AbstractColumn<TimeColumn, LocalTime>
     return PackedLocalTime.asLocalTime(max);
   }
 
+  @Override
   public LocalTime min() {
 
     if (isEmpty()) {
@@ -366,7 +375,7 @@ public class TimeColumn extends AbstractColumn<TimeColumn, LocalTime>
 
   @Override
   public TimeColumn appendCell(String object) {
-    appendInternal(PackedLocalTime.pack(TimeColumnType.DEFAULT_PARSER.parse(object)));
+    appendInternal(PackedLocalTime.pack(parser().parse(object)));
     return this;
   }
 
@@ -384,6 +393,7 @@ public class TimeColumn extends AbstractColumn<TimeColumn, LocalTime>
     return getIntInternal(index);
   }
 
+  @Override
   public LocalTime get(int index) {
     return PackedLocalTime.asLocalTime(getIntInternal(index));
   }
@@ -484,6 +494,7 @@ public class TimeColumn extends AbstractColumn<TimeColumn, LocalTime>
     return this;
   }
 
+  @Override
   public TimeColumn set(int index, LocalTime value) {
     return value == null ? setMissing(index) : set(index, PackedLocalTime.pack(value));
   }

--- a/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
+++ b/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
@@ -31,8 +31,11 @@ public abstract class AbstractColumn<C extends Column<T>, T> implements Column<T
 
   private final ColumnType type;
 
-  public AbstractColumn(ColumnType type, final String name) {
+  private AbstractColumnParser<T> parser;
+
+  public AbstractColumn(ColumnType type, final String name, final AbstractColumnParser<T> parser) {
     this.type = type;
+    setParser(parser);
     setName(name);
   }
 
@@ -45,6 +48,18 @@ public abstract class AbstractColumn<C extends Column<T>, T> implements Column<T
   @SuppressWarnings({"unchecked", "rawtypes"})
   public C setName(final String name) {
     this.name = name.trim();
+    return (C) this;
+  }
+
+  @Override
+  public AbstractColumnParser<T> parser() {
+    return parser;
+  }
+
+  @Override
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public C setParser(final AbstractColumnParser<T> parser) {
+    this.parser = parser;
     return (C) this;
   }
 

--- a/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
+++ b/core/src/main/java/tech/tablesaw/columns/AbstractColumn.java
@@ -14,6 +14,7 @@
 
 package tech.tablesaw.columns;
 
+import com.google.common.base.Preconditions;
 import java.util.Comparator;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -59,6 +60,7 @@ public abstract class AbstractColumn<C extends Column<T>, T> implements Column<T
   @Override
   @SuppressWarnings({"unchecked", "rawtypes"})
   public C setParser(final AbstractColumnParser<T> parser) {
+    Preconditions.checkNotNull(parser);
     this.parser = parser;
     return (C) this;
   }

--- a/core/src/main/java/tech/tablesaw/columns/Column.java
+++ b/core/src/main/java/tech/tablesaw/columns/Column.java
@@ -620,9 +620,9 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
   Column<T> setName(String name);
 
   /**
-   * Sets the parser used by
+   * Sets the parser used by {@link #appendCell()}
    *
-   * @param name The new name MUST be unique for any table containing this column
+   * @param parser a column parser that converts text input to the column data type
    * @return this Column to allow method chaining
    */
   Column<T> setParser(AbstractColumnParser<T> parser);

--- a/core/src/main/java/tech/tablesaw/columns/Column.java
+++ b/core/src/main/java/tech/tablesaw/columns/Column.java
@@ -78,6 +78,13 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
   ColumnType type();
 
   /**
+   * Returns the parser used by {@link #appendCell()}.
+   *
+   * @return {@link AbstractColumnParser}
+   */
+  AbstractColumnParser<T> parser();
+
+  /**
    * Returns a string representation of the value at the given row.
    *
    * @param row The index of the row.
@@ -611,6 +618,14 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
    * @return this Column to allow method chaining
    */
   Column<T> setName(String name);
+
+  /**
+   * Sets the parser used by
+   *
+   * @param name The new name MUST be unique for any table containing this column
+   * @return this Column to allow method chaining
+   */
+  Column<T> setParser(AbstractColumnParser<T> parser);
 
   /**
    * Returns a column containing the rows in this column beginning with start inclusive, and ending

--- a/core/src/main/java/tech/tablesaw/columns/strings/AbstractStringColumn.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/AbstractStringColumn.java
@@ -6,6 +6,7 @@ import java.util.List;
 import tech.tablesaw.api.CategoricalColumn;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.columns.AbstractColumn;
+import tech.tablesaw.columns.AbstractColumnParser;
 import tech.tablesaw.columns.Column;
 
 /** Abstract super class for Text like columns. */
@@ -14,8 +15,8 @@ public abstract class AbstractStringColumn<C extends AbstractColumn<C, String>>
     implements CategoricalColumn<String>, StringFilters, StringMapFunctions, StringReduceUtils {
   private StringColumnFormatter printFormatter = new StringColumnFormatter();
 
-  public AbstractStringColumn(ColumnType type, String name) {
-    super(type, name);
+  public AbstractStringColumn(ColumnType type, String name, AbstractColumnParser<String> parser) {
+    super(type, name, parser);
   }
 
   public void setPrintFormatter(StringColumnFormatter formatter) {

--- a/core/src/test/java/tech/tablesaw/api/BooleanColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/BooleanColumnTest.java
@@ -19,9 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.columns.booleans.BooleanFormatter;
+import tech.tablesaw.columns.booleans.BooleanParser;
 
 /** Tests for BooleanColumn */
 public class BooleanColumnTest {
@@ -152,6 +154,19 @@ public class BooleanColumnTest {
     assertFalse(lastEntry());
     column.appendCell("");
     assertNull(column.get(column.size() - 1));
+  }
+
+  @Test
+  public void testCustomParser() {
+    // Just do enough to ensure the parser is wired up correctly
+    BooleanParser customParser = new BooleanParser(ColumnType.LOCAL_DATE);
+    customParser.setMissingValueStrings(Arrays.asList("not here"));
+    column.setParser(customParser);
+
+    column.appendCell("not here");
+    assertTrue(column.isMissing(column.size() - 1));
+    column.appendCell("true");
+    assertFalse(column.isMissing(column.size() - 1));
   }
 
   @Test

--- a/core/src/test/java/tech/tablesaw/api/DateColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DateColumnTest.java
@@ -1,13 +1,17 @@
 package tech.tablesaw.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.columns.dates.DateColumnType;
+import tech.tablesaw.columns.dates.DateParser;
 
 public class DateColumnTest {
   private DateColumn column1;
@@ -36,6 +40,19 @@ public class DateColumnTest {
     LocalDate date = LocalDate.now();
     column1.append(date);
     assertEquals(5, column1.size());
+  }
+
+  @Test
+  public void testCustomParser() {
+    // Just do enough to ensure the parser is wired up correctly
+    DateParser customParser = new DateParser(ColumnType.LOCAL_DATE);
+    customParser.setMissingValueStrings(Arrays.asList("not here"));
+    column1.setParser(customParser);
+
+    column1.appendCell("not here");
+    assertTrue(column1.isMissing(column1.size() - 1));
+    column1.appendCell("2013-10-23");
+    assertFalse(column1.isMissing(column1.size() - 1));
   }
 
   @Test

--- a/core/src/test/java/tech/tablesaw/api/DateTimeColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DateTimeColumnTest.java
@@ -15,13 +15,17 @@
 package tech.tablesaw.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.tablesaw.columns.datetimes.DateTimeParser;
 import tech.tablesaw.columns.strings.StringColumnType;
 
 public class DateTimeColumnTest {
@@ -53,6 +57,19 @@ public class DateTimeColumnTest {
     column1.appendCell("10/2/2016 8:18:03 AM");
     column1.appendCell("10/12/2016 12:18:03 AM");
     assertEquals(3, column1.size());
+  }
+
+  @Test
+  public void testCustomParser() {
+    // Just do enough to ensure the parser is wired up correctly
+    DateTimeParser customParser = new DateTimeParser(ColumnType.LOCAL_DATE_TIME);
+    customParser.setMissingValueStrings(Arrays.asList("not here"));
+    column1.setParser(customParser);
+
+    column1.appendCell("not here");
+    assertTrue(column1.isMissing(column1.size() - 1));
+    column1.appendCell("1923-10-20T10:15:30");
+    assertFalse(column1.isMissing(column1.size() - 1));
   }
 
   @Test

--- a/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/DoubleColumnTest.java
@@ -15,11 +15,14 @@
 package tech.tablesaw.api;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import tech.tablesaw.columns.numbers.DoubleParser;
 
 public class DoubleColumnTest {
 
@@ -66,5 +69,19 @@ public class DoubleColumnTest {
     DoubleColumn uniq = DoubleColumn.create("test", 5, 4, 3, 2, 1, 5, 4, 3, 2, 1).unique();
     uniq.sortAscending();
     assertArrayEquals(new double[] {1.0, 2.0, 3.0, 4.0, 5.0}, uniq.asDoubleArray());
+  }
+
+  @Test
+  public void testCustomParser() {
+    // Just do enough to ensure the parser is wired up correctly
+    DoubleParser customParser = new DoubleParser(ColumnType.DOUBLE);
+    customParser.setMissingValueStrings(Arrays.asList("not here"));
+    DoubleColumn col = DoubleColumn.create("test", 3.0, 1.0, 2.0, 4.0);
+    col.setParser(customParser);
+
+    col.appendCell("not here");
+    assertTrue(col.isMissing(col.size() - 1));
+    col.appendCell("5.0");
+    assertFalse(col.isMissing(col.size() - 1));
   }
 }

--- a/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/FloatColumnTest.java
@@ -15,9 +15,12 @@
 package tech.tablesaw.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import tech.tablesaw.columns.numbers.FloatParser;
 import tech.tablesaw.selection.Selection;
 
 public class FloatColumnTest {
@@ -62,5 +65,18 @@ public class FloatColumnTest {
     Selection result = floatColumn.isNotIn(4, 40);
     assertEquals(5, result.size());
     assertTrue(floatColumn.where(result).contains(5f));
+  }
+
+  @Test
+  public void testCustomParser() {
+    // Just do enough to ensure the parser is wired up correctly
+    FloatParser customParser = new FloatParser(ColumnType.FLOAT);
+    customParser.setMissingValueStrings(Arrays.asList("not here"));
+    floatColumn.setParser(customParser);
+
+    floatColumn.appendCell("not here");
+    assertTrue(floatColumn.isMissing(floatColumn.size() - 1));
+    floatColumn.appendCell("5.0");
+    assertFalse(floatColumn.isMissing(floatColumn.size() - 1));
   }
 }

--- a/core/src/test/java/tech/tablesaw/api/InstantColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/InstantColumnTest.java
@@ -3,8 +3,11 @@ package tech.tablesaw.api;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.tablesaw.columns.AbstractColumnParser;
 
 class InstantColumnTest {
 
@@ -66,5 +69,36 @@ class InstantColumnTest {
     column1.appendMissing();
 
     assertEquals(3, column1.countUnique());
+  }
+
+  @Test
+  public void testCustomParser() {
+    class CustomParser extends AbstractColumnParser<Instant> {
+
+      private final List<String> VALID_VALUES = Arrays.asList("now");
+
+      public CustomParser() {
+        super(ColumnType.INSTANT);
+      }
+
+      @Override
+      public boolean canParse(String s) {
+        return true;
+      }
+
+      @Override
+      public Instant parse(String s) {
+        return VALID_VALUES.contains(s) ? Instant.now() : null;
+      }
+    }
+
+    InstantColumn column1 = InstantColumn.create("instants");
+    column1.setParser(new CustomParser());
+
+    // Just do enough to ensure the parser is wired up correctly
+    column1.appendCell("not now");
+    assertTrue(column1.isMissing(0));
+    column1.appendCell("now");
+    assertFalse(column1.isMissing(1));
   }
 }

--- a/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/IntColumnTest.java
@@ -2,7 +2,9 @@ package tech.tablesaw.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import tech.tablesaw.columns.numbers.IntParser;
 import tech.tablesaw.selection.Selection;
 
 class IntColumnTest {
@@ -22,5 +24,18 @@ class IntColumnTest {
     Selection result = intColumn.isNotIn(4, 40);
     assertEquals(5, result.size());
     assertTrue(intColumn.where(result).contains(5));
+  }
+
+  @Test
+  public void testCustomParser() {
+    // Just do enough to ensure the parser is wired up correctly
+    IntParser customParser = new IntParser(ColumnType.LONG);
+    customParser.setMissingValueStrings(Arrays.asList("not here"));
+    intColumn.setParser(customParser);
+
+    intColumn.appendCell("not here");
+    assertTrue(intColumn.isMissing(intColumn.size() - 1));
+    intColumn.appendCell("5");
+    assertFalse(intColumn.isMissing(intColumn.size() - 1));
   }
 }

--- a/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/LongColumnTest.java
@@ -2,7 +2,9 @@ package tech.tablesaw.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import tech.tablesaw.columns.numbers.LongParser;
 import tech.tablesaw.selection.Selection;
 
 class LongColumnTest {
@@ -22,5 +24,18 @@ class LongColumnTest {
     Selection result = longColumn.isNotIn(4, 40);
     assertEquals(5, result.size());
     assertTrue(longColumn.where(result).contains(5L));
+  }
+
+  @Test
+  public void testCustomParser() {
+    // Just do enough to ensure the parser is wired up correctly
+    LongParser customParser = new LongParser(ColumnType.LONG);
+    customParser.setMissingValueStrings(Arrays.asList("not here"));
+    longColumn.setParser(customParser);
+
+    longColumn.appendCell("not here");
+    assertTrue(longColumn.isMissing(longColumn.size() - 1));
+    longColumn.appendCell("5");
+    assertFalse(longColumn.isMissing(longColumn.size() - 1));
   }
 }

--- a/core/src/test/java/tech/tablesaw/api/ShortColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/ShortColumnTest.java
@@ -2,7 +2,9 @@ package tech.tablesaw.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import tech.tablesaw.columns.numbers.ShortParser;
 import tech.tablesaw.selection.Selection;
 
 class ShortColumnTest {
@@ -22,5 +24,18 @@ class ShortColumnTest {
     Selection result = shortColumn.isNotIn(4, 40);
     assertEquals(5, result.size());
     assertTrue(shortColumn.where(result).contains((short) 5));
+  }
+
+  @Test
+  public void testCustomParser() {
+    // Just do enough to ensure the parser is wired up correctly
+    ShortParser customParser = new ShortParser(ColumnType.SHORT);
+    customParser.setMissingValueStrings(Arrays.asList("not here"));
+    shortColumn.setParser(customParser);
+
+    shortColumn.appendCell("not here");
+    assertTrue(shortColumn.isMissing(shortColumn.size() - 1));
+    shortColumn.appendCell("5");
+    assertFalse(shortColumn.isMissing(shortColumn.size() - 1));
   }
 }

--- a/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
@@ -82,6 +82,20 @@ class StringColumnTest {
   }
 
   @Test
+  public void testCustomParser() {
+    // Just do enough to ensure the parser is wired up correctly
+    final StringColumn sc = StringColumn.create("sc");
+    StringParser customParser = new StringParser(ColumnType.STRING);
+    customParser.setMissingValueStrings(Arrays.asList("not here"));
+    sc.setParser(customParser);
+
+    sc.appendCell("not here");
+    assertTrue(sc.isMissing(sc.size() - 1));
+    sc.appendCell("*");
+    assertFalse(sc.isMissing(sc.size() - 1));
+  }
+
+  @Test
   void testForNulls() {
     String[] array1 = {"1", "2", "3", "4", null};
     Table table1 = Table.create("table1", StringColumn.create("id", array1));

--- a/core/src/test/java/tech/tablesaw/api/TextColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TextColumnTest.java
@@ -128,6 +128,20 @@ public class TextColumnTest {
   }
 
   @Test
+  public void testCustomParser() {
+    // Just do enough to ensure the parser is wired up correctly
+    final TextColumn sc = TextColumn.create("sc");
+    StringParser customParser = new StringParser(ColumnType.TEXT);
+    customParser.setMissingValueStrings(Arrays.asList("not here"));
+    sc.setParser(customParser);
+
+    sc.appendCell("not here");
+    assertTrue(sc.isMissing(sc.size() - 1));
+    sc.appendCell("*");
+    assertFalse(sc.isMissing(sc.size() - 1));
+  }
+
+  @Test
   public void lead() {
     TextColumn c1 = column.lead(1);
     Table t = Table.create("Test");

--- a/core/src/test/java/tech/tablesaw/api/TimeColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TimeColumnTest.java
@@ -23,11 +23,13 @@ import java.nio.ByteBuffer;
 import java.sql.Time;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.columns.times.TimeColumnType;
+import tech.tablesaw.columns.times.TimeParser;
 import tech.tablesaw.selection.Selection;
 
 public class TimeColumnTest {
@@ -126,6 +128,19 @@ public class TimeColumnTest {
     column1.appendCell("14:00:00");
     column1.appendCell("18:15:30");
     assertEquals(4, column1.size());
+  }
+
+  @Test
+  public void testCustomParser() {
+    // Just do enough to ensure the parser is wired up correctly
+    TimeParser customParser = new TimeParser(ColumnType.LOCAL_TIME);
+    customParser.setMissingValueStrings(Arrays.asList("not here"));
+    column1.setParser(customParser);
+
+    column1.appendCell("not here");
+    assertTrue(column1.isMissing(column1.size() - 1));
+    column1.appendCell("10:15:30");
+    assertFalse(column1.isMissing(column1.size() - 1));
   }
 
   @Test
@@ -414,11 +429,11 @@ public class TimeColumnTest {
 
   @Test
   public void testAppendObjLocalTime() {
-    LocalTime localTime = LocalTime.of(9,10,42);
+    LocalTime localTime = LocalTime.of(9, 10, 42);
     TimeColumn returned = column1.appendObj(localTime);
     assertEquals(column1, returned);
     assertEquals(1, returned.size());
-    assertEquals(LocalTime.of(9,10,42), returned.get(0));
+    assertEquals(LocalTime.of(9, 10, 42), returned.get(0));
   }
 
   @Test
@@ -427,7 +442,7 @@ public class TimeColumnTest {
     TimeColumn returned = column1.appendObj(time);
     assertEquals(column1, returned);
     assertEquals(1, returned.size());
-    assertEquals(LocalTime.of(9,10,42), returned.get(0));
+    assertEquals(LocalTime.of(9, 10, 42), returned.get(0));
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR fixes issue #927 with the following changes:
- This enhancement defines parser() and setParser() methods on the Column interface, and adds a parser argument to the AbstractColumn constructor.
- All column types have been updated to call super with the type-appropriate DEFAULT_PARSER, to preserve functional compatibility with prior releases.
- All column appendCell() methods now parse input using the parser field value, instead of a hardcoded DEFAULT_PARSER.

## Testing

Added unit tests for simple override of parsing strategy for each column type.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

