### PR TITLE
Add support for violin plot

### DIFF
--- a/jsplot/src/main/java/tech/tablesaw/plotly/api/ViolinPlot.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/api/ViolinPlot.java
@@ -1,0 +1,23 @@
+package tech.tablesaw.plotly.api;
+
+import tech.tablesaw.api.Table;
+import tech.tablesaw.plotly.components.Figure;
+import tech.tablesaw.plotly.components.Layout;
+import tech.tablesaw.plotly.traces.BoxTrace;
+import tech.tablesaw.plotly.traces.ViolinTrace;
+
+public class ViolinPlot {
+
+    private static final int HEIGHT = 600;
+    private static final int WIDTH = 800;
+
+    public static Figure create(
+            String title, Table table, String groupingColumn, String numericColumn) {
+        Layout layout = Layout.builder().title(title).height(HEIGHT).width(WIDTH).build();
+
+        ViolinTrace trace =
+                ViolinTrace.builder(table.categoricalColumn(groupingColumn), table.nCol(numericColumn))
+                        .build();
+        return new Figure(layout, trace);
+    }
+}

--- a/jsplot/src/main/java/tech/tablesaw/plotly/api/ViolinPlot.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/api/ViolinPlot.java
@@ -12,11 +12,12 @@ public class ViolinPlot {
     private static final int WIDTH = 800;
 
     public static Figure create(
-            String title, Table table, String groupingColumn, String numericColumn) {
+            String title, Table table, String groupingColumn, String numericColumn, boolean showBoxPlot, boolean showMeanLine) {
         Layout layout = Layout.builder().title(title).height(HEIGHT).width(WIDTH).build();
-
         ViolinTrace trace =
                 ViolinTrace.builder(table.categoricalColumn(groupingColumn), table.nCol(numericColumn))
+                        .boxPlot(showBoxPlot)
+                        .meanLine(showMeanLine)
                         .build();
         return new Figure(layout, trace);
     }

--- a/jsplot/src/main/java/tech/tablesaw/plotly/traces/ViolinTrace.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/traces/ViolinTrace.java
@@ -1,0 +1,112 @@
+package tech.tablesaw.plotly.traces;
+
+import static tech.tablesaw.plotly.Utils.dataAsString;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.util.Map;
+import tech.tablesaw.api.CategoricalColumn;
+import tech.tablesaw.api.NumericColumn;
+
+public class ViolinTrace extends AbstractTrace {
+
+    private final Object[] x;
+    private final double[] y;
+
+    private ViolinTrace(ViolinBuilder builder) {
+        super(builder);
+        this.x = builder.x;
+        this.y = builder.y;
+    }
+
+    public static ViolinBuilder builder(Object[] x, double[] y) {
+        return new ViolinBuilder(x, y);
+    }
+
+    public static ViolinBuilder builder(CategoricalColumn<?> x, NumericColumn<? extends Number> y) {
+        return new ViolinBuilder(x, y);
+    }
+
+    public static ViolinBuilder builder(double[] x, double[] y) {
+        Double[] xObjs = new Double[x.length];
+        for (int i = 0; i < x.length; i++) {
+            xObjs[i] = x[i];
+        }
+        return new ViolinBuilder(xObjs, y);
+    }
+
+    @Override
+    public String asJavascript(int i) {
+        Writer writer = new StringWriter();
+        PebbleTemplate compiledTemplate;
+
+        try {
+            compiledTemplate = engine.getTemplate("trace_template.html");
+            compiledTemplate.evaluate(writer, getContext(i));
+        } catch (PebbleException e) {
+            throw new IllegalStateException(e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return writer.toString();
+    }
+
+    private Map<String, Object> getContext(int i) {
+
+        Map<String, Object> context = super.getContext();
+        context.put("variableName", "trace" + i);
+        context.put("y", dataAsString(y));
+        context.put("x", dataAsString(x));
+        context.put("box", "{visible: true}");
+//        context.put("meanLine", "{visible: true}");
+        return context;
+    }
+
+    public static class ViolinBuilder extends TraceBuilder {
+
+        private static final String type = "violin";
+        private final Object[] x;
+        private final double[] y;
+
+        ViolinBuilder(Object[] x, double[] y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public ViolinBuilder name(String name) {
+            super.name(name);
+            return this;
+        }
+
+        ViolinBuilder(CategoricalColumn<?> x, NumericColumn<? extends Number> y) {
+            this.x = columnToStringArray(x);
+            this.y = y.asDoubleArray();
+        }
+
+        public ViolinTrace build() {
+            return new ViolinTrace(this);
+        }
+
+        @Override
+        public ViolinBuilder xAxis(String xAxis) {
+            super.xAxis(xAxis);
+            return this;
+        }
+
+        @Override
+        public ViolinBuilder yAxis(String yAxis) {
+            super.yAxis(yAxis);
+            return this;
+        }
+
+        @Override
+        protected String getType() {
+            return type;
+        }
+    }
+}

--- a/jsplot/src/main/java/tech/tablesaw/plotly/traces/ViolinTrace.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/traces/ViolinTrace.java
@@ -16,11 +16,15 @@ public class ViolinTrace extends AbstractTrace {
 
     private final Object[] x;
     private final double[] y;
+    private final boolean showBoxPlot;
+    private final boolean showMeanLine;
 
     private ViolinTrace(ViolinBuilder builder) {
         super(builder);
         this.x = builder.x;
         this.y = builder.y;
+        this.showMeanLine = builder.showMeanLine;
+        this.showBoxPlot = builder.showBoxPlot;
     }
 
     public static ViolinBuilder builder(Object[] x, double[] y) {
@@ -61,8 +65,12 @@ public class ViolinTrace extends AbstractTrace {
         context.put("variableName", "trace" + i);
         context.put("y", dataAsString(y));
         context.put("x", dataAsString(x));
-        context.put("box", "{visible: true}");
-//        context.put("meanLine", "{visible: true}");
+        if (showBoxPlot){
+            context.put("box", "{visible: true}");
+        }
+        if (showMeanLine){
+            context.put("meanLine", "{visible: true}");
+        }
         return context;
     }
 
@@ -71,6 +79,8 @@ public class ViolinTrace extends AbstractTrace {
         private static final String type = "violin";
         private final Object[] x;
         private final double[] y;
+        private boolean showBoxPlot;
+        private boolean showMeanLine;
 
         ViolinBuilder(Object[] x, double[] y) {
             this.x = x;
@@ -86,6 +96,16 @@ public class ViolinTrace extends AbstractTrace {
         ViolinBuilder(CategoricalColumn<?> x, NumericColumn<? extends Number> y) {
             this.x = columnToStringArray(x);
             this.y = y.asDoubleArray();
+        }
+
+        public ViolinBuilder boxPlot(boolean show) {
+            this.showBoxPlot = show;
+            return this;
+        }
+
+        public ViolinBuilder meanLine(boolean show) {
+            this.showMeanLine = show;
+            return this;
         }
 
         public ViolinTrace build() {

--- a/jsplot/src/main/resources/trace_template.html
+++ b/jsplot/src/main/resources/trace_template.html
@@ -86,4 +86,10 @@ fillcolor: '{{fillColor}}',
 {% endif %}
 type: '{{type}}',
 name: '{{name}}',
+{% if box is not null %}
+box: {{box}},
+{% endif %}
+{% if meanLine is not null %}
+meanline: {{meanLine}},
+{% endif %}
 };

--- a/jsplot/src/test/java/tech/tablesaw/plotly/ViolinTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/plotly/ViolinTest.java
@@ -1,0 +1,49 @@
+package tech.tablesaw.plotly;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import tech.tablesaw.plotly.components.Figure;
+import tech.tablesaw.plotly.traces.ViolinTrace;
+
+@Disabled
+class ViolinTest {
+
+    private final Object[] x = {
+            "sheep",
+            "cows",
+            "fish",
+            "tree sloths",
+            "sheep",
+            "cows",
+            "fish",
+            "tree sloths",
+            "sheep",
+            "cows",
+            "fish",
+            "tree sloths"
+    };
+    private final double[] y = {1, 4, 9, 16, 3, 6, 8, 8, 2, 4, 7, 11};
+
+    @Test
+    void testAsJavascript() {
+        ViolinTrace trace = ViolinTrace.builder(x, y).build();
+        assertNotNull(trace.asJavascript(1));
+    }
+
+    @Test
+    void show() {
+        ViolinTrace trace = ViolinTrace.builder(x, y).build();
+        Figure figure = new Figure(trace);
+        assertNotNull(figure);
+        Plot.show(figure, "target");
+    }
+
+    /** Test ensures that the name() method returns a ViolinTraceBuilder as expected. */
+    @Test
+    void name() {
+        ViolinTrace trace = ViolinTrace.builder(x, y).name("my name").build();
+        assertNotNull(trace);
+    }
+}

--- a/jsplot/src/test/java/tech/tablesaw/plotly/ViolinTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/plotly/ViolinTest.java
@@ -27,14 +27,22 @@ class ViolinTest {
     private final double[] y = {1, 4, 9, 16, 3, 6, 8, 8, 2, 4, 7, 11};
 
     @Test
-    void testAsJavascript() {
-        ViolinTrace trace = ViolinTrace.builder(x, y).build();
+    void testAsJavascriptWithBoxPlot() {
+        ViolinTrace trace = ViolinTrace.builder(x, y).boxPlot(true).build();
         assertNotNull(trace.asJavascript(1));
     }
 
     @Test
-    void show() {
-        ViolinTrace trace = ViolinTrace.builder(x, y).build();
+    void showWithMeanLine() {
+        ViolinTrace trace = ViolinTrace.builder(x, y).meanLine(true).build();
+        Figure figure = new Figure(trace);
+        assertNotNull(figure);
+        Plot.show(figure, "target");
+    }
+
+    @Test
+    void showWithBoxPlot() {
+        ViolinTrace trace = ViolinTrace.builder(x, y).boxPlot(true).build();
         Figure figure = new Figure(trace);
         assertNotNull(figure);
         Plot.show(figure, "target");


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
This is the fix for issue #509  

Two files are added: `ViolinPlot.java` and `ViolinTrace.java`. Also I modified the file `trace_template.html` so that violin plot can draw the inner box plot at the same time. Also, considering that the mean line of violin plot is also frequently used, it is also added into the `trace_template.html` but I comment the code (`context.put("meanLine", "{visible: true}")`) that draw the mean line in `ViolinTrace.java` because it doesn't perform well together with inner box plot. You can changed the code and style according to your preference.

## Testing

Test is developed following the style of other plot tests.
