### PR TITLE
Fix issue 812

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/FileReader.java
+++ b/core/src/main/java/tech/tablesaw/io/FileReader.java
@@ -7,14 +7,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 import com.univocity.parsers.common.AbstractParser;
 import java.io.Reader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Random;
+import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tech.tablesaw.api.ColumnType;
@@ -231,7 +224,9 @@ public abstract class FileReader {
         continue;
       }
       if (nextLine.length < types.length) {
-        if (nextLine.length == 1 && Strings.isNullOrEmpty(nextLine[0])) {
+        if (options.autoFillMissingColumn()) {
+          nextLine = Arrays.copyOf(nextLine, types.length);
+        } else if (nextLine.length == 1 && Strings.isNullOrEmpty(nextLine[0])) {
           logger.error("Warning: Invalid file. Row " + rowNumber + " is empty. Continuing.");
           continue;
         } else {

--- a/core/src/main/java/tech/tablesaw/io/ReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/ReadOptions.java
@@ -49,6 +49,7 @@ public class ReadOptions {
 
   public static final boolean DEFAULT_IGNORE_ZERO_DECIMAL = true;
   public static final boolean DEFAULT_SKIP_ROWS_WITH_INVALID_COLUMN_COUNT = false;
+  public static final boolean DEFAULT_AUTO_FILL_MISSING_COLUMN = false;
 
   private static final List<ColumnType> DEFAULT_TYPES =
       Lists.newArrayList(
@@ -88,6 +89,7 @@ public class ReadOptions {
   protected final boolean ignoreZeroDecimal;
   protected final boolean allowDuplicateColumnNames;
   protected final boolean skipRowsWithInvalidColumnCount;
+  protected final boolean autoFillMissingColumn;
 
   protected final DateTimeFormatter dateFormatter;
   protected final DateTimeFormatter dateTimeFormatter;
@@ -111,6 +113,7 @@ public class ReadOptions {
     maxCharsPerColumn = builder.maxCharsPerColumn;
     ignoreZeroDecimal = builder.ignoreZeroDecimal;
     skipRowsWithInvalidColumnCount = builder.skipRowsWithInvalidColumnCount;
+    autoFillMissingColumn = builder.autoFillMissingColumn;
 
     dateFormatter = builder.dateFormatter;
     timeFormatter = builder.timeFormatter;
@@ -174,6 +177,10 @@ public class ReadOptions {
     return skipRowsWithInvalidColumnCount;
   }
 
+  public boolean autoFillMissingColumn() {
+    return autoFillMissingColumn;
+  }
+
   public DateTimeFormatter dateTimeFormatter() {
     if (dateTimeFormatter != null) {
       return dateTimeFormatter;
@@ -228,6 +235,7 @@ public class ReadOptions {
     protected int maxCharsPerColumn = 4096;
     protected boolean ignoreZeroDecimal = DEFAULT_IGNORE_ZERO_DECIMAL;
     protected boolean skipRowsWithInvalidColumnCount = DEFAULT_SKIP_ROWS_WITH_INVALID_COLUMN_COUNT;
+    protected boolean autoFillMissingColumn = DEFAULT_AUTO_FILL_MISSING_COLUMN;
     private boolean allowDuplicateColumnNames = false;
     protected ColumnType[] columnTypes;
     protected Map<String, ColumnType> columnTypeMap = new HashMap<>();
@@ -331,9 +339,18 @@ public class ReadOptions {
       return this;
     }
 
-    /** Skip the rows with invalid column count in data values. Defaluts to {@code false}. */
+    /** Skip the rows with invalid column count in data values. Defaults to {@code false}. */
     public Builder skipRowsWithInvalidColumnCount(boolean skipRowsWithInvalidColumnCount) {
       this.skipRowsWithInvalidColumnCount = skipRowsWithInvalidColumnCount;
+      return this;
+    }
+
+    /**
+     * Auto fill the missing column when import file with columns of different sizes. Defaults to
+     * {@code false}.
+     */
+    public Builder autoFillMissingColumn(boolean autoFillMissingColumn) {
+      this.autoFillMissingColumn = autoFillMissingColumn;
       return this;
     }
 

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
@@ -379,5 +379,11 @@ public class CsvReadOptions extends ReadOptions {
       super.skipRowsWithInvalidColumnCount(skipRowsWithInvalidColumnCount);
       return this;
     }
+
+    @Override
+    public Builder autoFillMissingColumn(boolean autoFillMissingColumn) {
+      super.autoFillMissingColumn(autoFillMissingColumn);
+      return this;
+    }
   }
 }

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
@@ -858,7 +858,7 @@ public class CsvReaderTest {
   }
 
   @Test
-  public void skipRowsWithInvalidColumnCountWithoutHeader() throws IOException {
+  public void skipRowsWithInvalidColumnCountWithoutHeader() {
     assertThrows(
         AddCellToColumnException.class,
         () -> {
@@ -869,6 +869,28 @@ public class CsvReaderTest {
                       .skipRowsWithInvalidColumnCount(true)
                       .build());
         });
+  }
+
+  @Test
+  public void testAutoFillMissingColumn() throws IOException {
+    Table table =
+        Table.read()
+            .csv(
+                CsvReadOptions.builder("../data/short_row.csv")
+                    .autoFillMissingColumn(true)
+                    .build());
+    assertEquals(3, table.rowCount());
+  }
+
+  @Test
+  public void testAutoFillMissingColumn2() throws IOException {
+    Table table =
+        Table.read()
+            .csv(
+                CsvReadOptions.builder("../data/short_row2.csv")
+                    .autoFillMissingColumn(true)
+                    .build());
+    assertEquals(4, table.rowCount());
   }
 
   @Test

--- a/data/short_row2.csv
+++ b/data/short_row2.csv
@@ -1,0 +1,5 @@
+Products,Sales,Market_Share
+a,5500,3
+b,12200
+,
+c,60000,33


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Fix [issue #812](https://github.com/jtablesaw/tablesaw/issues/812)
Add an Read Option `autoFillMissingColumn`. Allow the reader to fill the missing column with the Missing Value when import file with columns of different sizes automatically.   
This option only allow to fill the last missing column of each row with `null`.

## Testing

Add two tests for testing this option.
