### PR TITLE
Support for not closing the output stream opened by user

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/WriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/WriteOptions.java
@@ -8,6 +8,12 @@ import java.io.Writer;
 public class WriteOptions {
 
   protected final Destination dest;
+
+  /**
+   * This value is not exposed as an actual option. It will determine whether the output stream
+   * automatically closes after the table has been output. The default value is false, and it just
+   * set true for File output.
+   */
   protected final boolean autoClose;
 
   protected WriteOptions(Builder builder) {

--- a/core/src/main/java/tech/tablesaw/io/WriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/WriteOptions.java
@@ -22,7 +22,7 @@ public class WriteOptions {
   public static class Builder {
 
     protected Destination dest;
-    protected boolean autoClose = true;
+    protected boolean autoClose = false;
 
     protected Builder(Destination dest) {
       this.dest = dest;
@@ -30,16 +30,15 @@ public class WriteOptions {
 
     protected Builder(OutputStream dest) {
       this.dest = new Destination(dest);
-      this.autoClose = false;
     }
 
     protected Builder(Writer dest) {
       this.dest = new Destination(dest);
-      this.autoClose = false;
     }
 
     protected Builder(File dest) throws IOException {
       this.dest = new Destination(dest);
+      this.autoClose = true;
     }
   }
 }

--- a/core/src/main/java/tech/tablesaw/io/WriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/WriteOptions.java
@@ -8,9 +8,11 @@ import java.io.Writer;
 public class WriteOptions {
 
   protected final Destination dest;
+  protected final boolean autoClose;
 
   protected WriteOptions(Builder builder) {
     this.dest = builder.dest;
+    this.autoClose = builder.autoClose;
   }
 
   public Destination destination() {
@@ -20,6 +22,7 @@ public class WriteOptions {
   public static class Builder {
 
     protected Destination dest;
+    protected boolean autoClose = true;
 
     protected Builder(Destination dest) {
       this.dest = dest;
@@ -27,10 +30,12 @@ public class WriteOptions {
 
     protected Builder(OutputStream dest) {
       this.dest = new Destination(dest);
+      this.autoClose = false;
     }
 
     protected Builder(Writer dest) {
       this.dest = new Destination(dest);
+      this.autoClose = false;
     }
 
     protected Builder(File dest) throws IOException {

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvWriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvWriteOptions.java
@@ -90,6 +90,10 @@ public class CsvWriteOptions extends WriteOptions {
     return dateFormatter;
   }
 
+  public boolean autoClose() {
+    return autoClose;
+  }
+
   public static Builder builder(Destination dest) {
     return new Builder(dest);
   }

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvWriter.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvWriter.java
@@ -61,7 +61,7 @@ public final class CsvWriter implements DataWriter<CsvWriteOptions> {
     } finally {
       if (csvWriter != null) {
         csvWriter.flush();
-        csvWriter.close();
+        if (options.autoClose()) csvWriter.close();
       }
     }
   }

--- a/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriteOptions.java
@@ -142,6 +142,10 @@ public class FixedWidthWriteOptions extends WriteOptions {
     return normalizedNewline;
   }
 
+  public boolean autoClose() {
+    return autoClose;
+  }
+
   public static Builder builder(Destination destination) throws IOException {
     return new Builder(destination);
   }

--- a/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriter.java
+++ b/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriter.java
@@ -65,7 +65,7 @@ public final class FixedWidthWriter implements DataWriter<FixedWidthWriteOptions
     } finally {
       if (fixedWidthWriter != null) {
         fixedWidthWriter.flush();
-        fixedWidthWriter.close();
+        if (options.autoClose()) fixedWidthWriter.close();
       }
     }
   }

--- a/core/src/test/java/tech/tablesaw/io/DataFrameWriterTest.java
+++ b/core/src/test/java/tech/tablesaw/io/DataFrameWriterTest.java
@@ -83,10 +83,11 @@ public class DataFrameWriterTest {
     // cannot access the status of osw directly, so write again to test whether it close
     try {
       table.write().csv(osw);
+      output = baos.toString();
       assertEquals(
           "v,v2" + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "v,v2"
               + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "",
-          baos.toString());
+          output);
     } catch (Exception e) {
       fail(e);
     }

--- a/core/src/test/java/tech/tablesaw/io/DataFrameWriterTest.java
+++ b/core/src/test/java/tech/tablesaw/io/DataFrameWriterTest.java
@@ -2,9 +2,9 @@ package tech.tablesaw.io;
 
 import static java.lang.Double.NaN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.Table;
@@ -37,5 +37,58 @@ public class DataFrameWriterTest {
     assertEquals(
         "v,v2" + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "",
         output);
+  }
+
+  @Test
+  public void testFileOutputStreamWhetherClose() throws IOException {
+    File file = new File("../testoutput/example.csv");
+    FileOutputStream fos = new FileOutputStream(file);
+    table.write().csv(fos);
+    FileInputStream fis = new FileInputStream(file);
+    byte[] filecontent = new byte[(int) file.length()];
+    fis.read(filecontent);
+    String output = new String(filecontent);
+    assertEquals(
+        "v,v2" + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "",
+        output);
+
+    // cannot access the status of fos, so write again to test whether it close
+    try {
+      table.write().csv(fos);
+      fis = new FileInputStream(file);
+      filecontent = new byte[(int) file.length()];
+      fis.read(filecontent);
+      output = new String(filecontent);
+      assertEquals(
+          "v,v2" + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "v,v2"
+              + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "",
+          output);
+    } catch (Exception e) {
+      fail(e);
+    } finally {
+      file.delete();
+    }
+  }
+
+  @Test
+  public void testOutputStreamWriterWhetherClose() {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    OutputStreamWriter osw = new OutputStreamWriter(baos);
+    table.write().csv(osw);
+    String output = baos.toString();
+    assertEquals(
+        "v,v2" + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "",
+        output);
+
+    // cannot access the status of osw directly, so write again to test whether it close
+    try {
+      table.write().csv(osw);
+      assertEquals(
+          "v,v2" + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "v,v2"
+              + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "",
+          baos.toString());
+    } catch (Exception e) {
+      fail(e);
+    }
   }
 }

--- a/core/src/test/java/tech/tablesaw/io/DataFrameWriterTest.java
+++ b/core/src/test/java/tech/tablesaw/io/DataFrameWriterTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.Table;
@@ -41,13 +44,25 @@ public class DataFrameWriterTest {
 
   @Test
   public void testFileOutputStreamWhetherClose() throws IOException {
-    File file = new File("../testoutput/example.csv");
+    // Create directory if it doesn't exist
+    String DEFAULT_OUTPUT_FOLDER = "../testoutput";
+    Path path = Paths.get(DEFAULT_OUTPUT_FOLDER, "testOutput.csv");
+    try {
+      Files.createDirectories(path.getParent());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    File file = path.toFile();
     FileOutputStream fos = new FileOutputStream(file);
     table.write().csv(fos);
+
+    // Read file content
     FileInputStream fis = new FileInputStream(file);
     byte[] filecontent = new byte[(int) file.length()];
     fis.read(filecontent);
     String output = new String(filecontent);
+
     assertEquals(
         "v,v2" + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "",
         output);
@@ -55,10 +70,12 @@ public class DataFrameWriterTest {
     // cannot access the status of fos, so write again to test whether it close
     try {
       table.write().csv(fos);
+
       fis = new FileInputStream(file);
       filecontent = new byte[(int) file.length()];
       fis.read(filecontent);
       output = new String(filecontent);
+
       assertEquals(
           "v,v2" + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "v,v2"
               + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "",
@@ -76,6 +93,7 @@ public class DataFrameWriterTest {
     OutputStreamWriter osw = new OutputStreamWriter(baos);
     table.write().csv(osw);
     String output = baos.toString();
+
     assertEquals(
         "v,v2" + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "",
         output);
@@ -84,6 +102,7 @@ public class DataFrameWriterTest {
     try {
       table.write().csv(osw);
       output = baos.toString();
+
       assertEquals(
           "v,v2" + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "v,v2"
               + LINE_END + "1.0,1.0" + LINE_END + "2.0,2.0" + LINE_END + "," + LINE_END + "",

--- a/core/src/test/java/tech/tablesaw/io/fixed/FixedWidthWriterTest.java
+++ b/core/src/test/java/tech/tablesaw/io/fixed/FixedWidthWriterTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.univocity.parsers.fixed.FixedWidthFields;
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.Table;
@@ -42,5 +45,141 @@ public class FixedWidthWriterTest {
             + LINE_END
             + "",
         output);
+  }
+
+  @Test
+  public void testFileOutputStreamWhetherClose() throws IOException {
+    // Create directory if it doesn't exist
+    String DEFAULT_OUTPUT_FOLDER = "../testoutput";
+    Path path = Paths.get(DEFAULT_OUTPUT_FOLDER, "testOutput.txt");
+    try {
+      Files.createDirectories(path.getParent());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    File file = path.toFile();
+    FileOutputStream fos = new FileOutputStream(file);
+    FixedWidthFields fwf = new FixedWidthFields(10, 10);
+
+    FixedWidthWriteOptions options =
+        new FixedWidthWriteOptions.Builder(fos)
+            .header(true)
+            .autoConfigurationEnabled(false)
+            .columnSpecs(fwf)
+            .build();
+    FixedWidthWriter writer = new FixedWidthWriter();
+    writer.write(table, options);
+
+    // Read file content
+    FileInputStream fis = new FileInputStream(file);
+    byte[] filecontent = new byte[(int) file.length()];
+    fis.read(filecontent);
+    String output = new String(filecontent);
+
+    assertEquals(
+        "v1________v2________"
+            + LINE_END
+            + "1.0_______1.0_______"
+            + LINE_END
+            + "2.0_______2.0_______"
+            + LINE_END
+            + "____________________"
+            + LINE_END
+            + "",
+        output);
+
+    // cannot access the status of fos, so write again to test whether it close
+    try {
+      writer.write(table, options);
+
+      fis = new FileInputStream(file);
+      filecontent = new byte[(int) file.length()];
+      fis.read(filecontent);
+      output = new String(filecontent);
+
+      assertEquals(
+          "v1________v2________"
+              + LINE_END
+              + "1.0_______1.0_______"
+              + LINE_END
+              + "2.0_______2.0_______"
+              + LINE_END
+              + "____________________"
+              + LINE_END
+              + ""
+              + "v1________v2________"
+              + LINE_END
+              + "1.0_______1.0_______"
+              + LINE_END
+              + "2.0_______2.0_______"
+              + LINE_END
+              + "____________________"
+              + LINE_END
+              + "",
+          output);
+    } catch (Exception e) {
+      fail(e);
+    } finally {
+      file.delete();
+    }
+  }
+
+  @Test
+  public void testOutputStreamWriterWhetherClose() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    OutputStreamWriter osw = new OutputStreamWriter(baos);
+    FixedWidthFields fwf = new FixedWidthFields(10, 10);
+
+    FixedWidthWriteOptions options =
+        new FixedWidthWriteOptions.Builder(osw)
+            .header(true)
+            .columnSpecs(fwf)
+            .autoConfigurationEnabled(false)
+            .build();
+    FixedWidthWriter writer = new FixedWidthWriter();
+    writer.write(table, options);
+
+    String output = baos.toString();
+    assertEquals(
+        "v1________v2________"
+            + LINE_END
+            + "1.0_______1.0_______"
+            + LINE_END
+            + "2.0_______2.0_______"
+            + LINE_END
+            + "____________________"
+            + LINE_END
+            + "",
+        output);
+
+    // cannot access the status of osw directly, so write again to test whether it close
+    try {
+      writer.write(table, options);
+      output = baos.toString();
+
+      assertEquals(
+          "v1________v2________"
+              + LINE_END
+              + "1.0_______1.0_______"
+              + LINE_END
+              + "2.0_______2.0_______"
+              + LINE_END
+              + "____________________"
+              + LINE_END
+              + ""
+              + "v1________v2________"
+              + LINE_END
+              + "1.0_______1.0_______"
+              + LINE_END
+              + "2.0_______2.0_______"
+              + LINE_END
+              + "____________________"
+              + LINE_END
+              + "",
+          output);
+    } catch (Exception e) {
+      fail(e);
+    }
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Add a boolean attribute `autoclose` in `WriteOptions` and `Builder`, whose default value is true. When `Builder` is constructed with OutputStream or Writer, set `autoclose` as false. 

Corresponding issue is #750 

## Testing

Yes. 2 unit tests for testing whether FileOutputStream and OutputStreamWriter close.
