### PR TITLE
Assign the value to FixedWidthWriterSettings.fieldLengths

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriteOptions.java
@@ -217,7 +217,7 @@ public class FixedWidthWriteOptions extends WriteOptions {
       return this;
     }
 
-    public FixedWidthWriteOptions.Builder header(FixedWidthFields columnSpecs) {
+    public FixedWidthWriteOptions.Builder columnSpecs(FixedWidthFields columnSpecs) {
       this.columnSpecs = columnSpecs;
       return this;
     }

--- a/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriter.java
+++ b/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriter.java
@@ -97,6 +97,9 @@ public final class FixedWidthWriter implements DataWriter<FixedWidthWriteOptions
 
   protected FixedWidthWriterSettings fixedWidthWriterSettings(FixedWidthWriteOptions options) {
     FixedWidthWriterSettings settings = new FixedWidthWriterSettings();
+    if (options.columnSpecs() != null) {
+      settings = new FixedWidthWriterSettings(options.columnSpecs());
+    }
 
     if (options.autoConfigurationEnabled()) {
       settings.setAutoConfigurationEnabled(options.autoConfigurationEnabled());

--- a/core/src/test/java/tech/tablesaw/io/fixed/FixedWidthWriterTest.java
+++ b/core/src/test/java/tech/tablesaw/io/fixed/FixedWidthWriterTest.java
@@ -1,0 +1,46 @@
+package tech.tablesaw.io.fixed;
+
+import static java.lang.Double.NaN;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.univocity.parsers.fixed.FixedWidthFields;
+import java.io.*;
+import org.junit.jupiter.api.Test;
+import tech.tablesaw.api.DoubleColumn;
+import tech.tablesaw.api.Table;
+
+public class FixedWidthWriterTest {
+  private static final String LINE_END = System.lineSeparator();
+
+  private double[] v1 = {1, 2, NaN};
+  private double[] v2 = {1, 2, NaN};
+  private Table table =
+      Table.create("t", DoubleColumn.create("v1", v1), DoubleColumn.create("v2", v2));
+
+  @Test
+  public void testOutputInFixedWidthFormat() {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    FixedWidthFields fwf = new FixedWidthFields(10, 10);
+    FixedWidthWriteOptions options =
+        new FixedWidthWriteOptions.Builder(baos)
+            .header(true)
+            .columnSpecs(fwf)
+            .autoConfigurationEnabled(false)
+            .build();
+    FixedWidthWriter writer = new FixedWidthWriter();
+    writer.write(table, options);
+
+    String output = baos.toString();
+    assertEquals(
+        "v1________v2________"
+            + LINE_END
+            + "1.0_______1.0_______"
+            + LINE_END
+            + "2.0_______2.0_______"
+            + LINE_END
+            + "____________________"
+            + LINE_END
+            + "",
+        output);
+  }
+}


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Construct `FixedWidthWriterSettings` with `FixedWidthFields.columnSpecs` to assign it to `FixedWidthWriterSettings.fieldLengths`    
The corresponding issue is #942.

## Testing

Yes.