### PR TITLE
fix(table): method 'where' apply 2 times selection function

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -758,10 +758,7 @@ public class Table extends Relation implements Iterable<Row> {
   }
 
   public Table where(Function<Table, Selection> selection) {
-    Table tempTable = where(selection.apply(this));
-    Table newTable = tempTable.emptyCopy(tempTable.rowCount());
-    Rows.copyRowsToTable(selection.apply(this), this, newTable);
-    return newTable;
+    return where(selection.apply(this));
   }
 
   public Table dropWhere(Function<Table, Selection> selection) {


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

fix(table): method 'where' apply 2 times selection function

## Testing

Did you add a unit test?

No
