### PR TITLE
replace parallelQuickSort with mergeSort to fix issue #957.

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -656,7 +656,7 @@ public class Table extends Relation implements Iterable<Row> {
     Table newTable = emptyCopy(rowCount());
 
     int[] newRows = rows();
-    IntArrays.parallelQuickSort(newRows, rowComparator);
+    IntArrays.mergeSort(newRows, rowComparator);
 
     Rows.copyRowsToTable(newRows, this, newTable);
     return newTable;


### PR DESCRIPTION
Parallel quick sort fails because Table Row is not thread safe.

Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

One line change replacing one FastUtil sort algorithm with another

## Testing

Did you add a unit test? No. 
