### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 
 # for sonarcloud issue tagging
 git:
-  depth: false
+  depth: 3
 
 addons:
   sonarcloud:


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.