### PR TITLE
Allow TextColumn to append StringColumns, and vice-versa

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/StringColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/StringColumn.java
@@ -14,6 +14,9 @@
 
 package tech.tablesaw.api;
 
+import static tech.tablesaw.api.ColumnType.STRING;
+import static tech.tablesaw.api.ColumnType.TEXT;
+
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.IntComparator;
 import java.util.ArrayList;
@@ -391,11 +394,10 @@ public class StringColumn extends AbstractStringColumn<StringColumn> {
 
   @Override
   public StringColumn append(Column<String> column) {
-    Preconditions.checkArgument(column.type() == this.type());
-    StringColumn source = (StringColumn) column;
-    final int size = source.size();
+    Preconditions.checkArgument(column.type() == TEXT || column.type().equals(STRING));
+    final int size = column.size();
     for (int i = 0; i < size; i++) {
-      append(source.getString(i));
+      append(column.getString(i));
     }
     return this;
   }

--- a/core/src/main/java/tech/tablesaw/api/TextColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TextColumn.java
@@ -14,6 +14,9 @@
 
 package tech.tablesaw.api;
 
+import static tech.tablesaw.api.ColumnType.STRING;
+import static tech.tablesaw.api.ColumnType.TEXT;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.IntComparator;
@@ -337,11 +340,10 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
 
   @Override
   public TextColumn append(Column<String> column) {
-    Preconditions.checkArgument(column.type() == this.type());
-    TextColumn source = (TextColumn) column;
-    final int size = source.size();
+    Preconditions.checkArgument(column.type() == TEXT || column.type().equals(STRING));
+    final int size = column.size();
     for (int i = 0; i < size; i++) {
-      append(source.getString(i));
+      append(column.getString(i));
     }
     return this;
   }

--- a/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/StringColumnTest.java
@@ -777,4 +777,20 @@ class StringColumnTest {
     assertEquals("Top Freq.", summary.getUnformatted(3, 0));
     assertEquals("1", summary.getUnformatted(3, 1));
   }
+
+  /** Test that we can append both text and string columns to a string column */
+  @Test
+  void appendTextColumn() {
+    StringColumn col1 = StringColumn.create("col1");
+    col1.append("1");
+    TextColumn col2 = TextColumn.create("col2");
+    col2.append("2");
+    StringColumn col3 = StringColumn.create("col3");
+    col3.append("3");
+    assertEquals(1, col1.size());
+    col1.append(col2);
+    assertEquals(2, col1.size());
+    col1.append(col3);
+    assertEquals(3, col1.size());
+  }
 }

--- a/core/src/test/java/tech/tablesaw/api/TextColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TextColumnTest.java
@@ -562,4 +562,20 @@ public class TextColumnTest {
     assertEquals(3, col1.countUnique());
     assertEquals(3, col1.unique().size());
   }
+
+  /** Test that we can append both text and string columns to a text column */
+  @Test
+  void appendStringColumn() {
+    TextColumn col1 = TextColumn.create("col1");
+    col1.append("1");
+    TextColumn col2 = TextColumn.create("col2");
+    col2.append("2");
+    StringColumn col3 = StringColumn.create("col3");
+    col3.append("3");
+    assertEquals(1, col1.size());
+    col1.append(col2);
+    assertEquals(2, col1.size());
+    col1.append(col3);
+    assertEquals(3, col1.size());
+  }
 }


### PR DESCRIPTION
This is essential due to a design issue where table slices convert string columns to text columns. This prevents the simple appending of some slices to a new table with the same structure as the original

Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Precondition check was broadened to include both types. A cast was removed.

## Testing

Did you add a unit test? Yes. 
