### PR TITLE
#982 Fix for undesirable use of TextColumns as String Columns when slices are converted back to tables.

### DIFF
--- a/core/src/main/java/tech/tablesaw/table/SelectionTableSliceGroup.java
+++ b/core/src/main/java/tech/tablesaw/table/SelectionTableSliceGroup.java
@@ -41,7 +41,7 @@ public class SelectionTableSliceGroup extends TableSliceGroup {
 
   private void splitOnSelection(String nameTemplate, List<Selection> selections) {
     for (int i = 0; i < selections.size(); i++) {
-      TableSlice view = new TableSlice(getSourceTable(), selections.get(i));
+      TableSlice view = new TableSlice(getSourceTable(), selections.get(i), textColumns);
       String name = nameTemplate + ": " + i + 1;
       view.setName(name);
       getSlices().add(view);

--- a/core/src/main/java/tech/tablesaw/table/StandardTableSliceGroup.java
+++ b/core/src/main/java/tech/tablesaw/table/StandardTableSliceGroup.java
@@ -93,7 +93,7 @@ public class StandardTableSliceGroup extends TableSliceGroup {
 
     // Add all slices
     for (Entry<ByteArray, Selection> entry : selectionMap.entrySet()) {
-      TableSlice slice = new TableSlice(getSourceTable(), entry.getValue());
+      TableSlice slice = new TableSlice(getSourceTable(), entry.getValue(), textColumns);
       slice.setName(sliceNameMap.get(entry.getKey()));
       addSlice(slice);
     }

--- a/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
+++ b/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
@@ -29,7 +29,12 @@ import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 
-/** A group of tables formed by performing splitting operations on an original table */
+/**
+ * A group of table slices formed by performing splitting operations on an original table
+ *
+ * <p>NOTE: This can use a tremendous amount of memory on a large table containing many TextColumns.
+ * If that is your use case, consider handling this manually instead.
+ */
 public class TableSliceGroup implements Iterable<TableSlice> {
 
   // A string that is used internally as a delimiter in creating a column name from all the grouping
@@ -242,10 +247,6 @@ public class TableSliceGroup implements Iterable<TableSlice> {
 
   /**
    * Returns a list of Tables created by reifying my list of slices (views) over the original table
-   *
-   * <p>NOTE: This can use a tremendous amount of memory on a large table containing many
-   * TextColumns. If that is your use case, consider looping over TableSlices and converting each to
-   * a table independently.
    */
   public List<Table> asTableList() {
     List<Table> tableList = new ArrayList<>();

--- a/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
+++ b/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
@@ -40,6 +40,8 @@ public class TableSliceGroup implements Iterable<TableSlice> {
   // grouping columns
   private static final Splitter SPLITTER = Splitter.on(SPLIT_STRING);
 
+  protected List<String> textColumns = new ArrayList<>();
+
   // The list of slices or views over the source table that I contain
   private final List<TableSlice> subTables = new ArrayList<>();
 
@@ -84,6 +86,7 @@ public class TableSliceGroup implements Iterable<TableSlice> {
     for (int i = 0; i < sourceTable.columnCount(); i++) {
       if (sourceTable.column(i).type().equals(ColumnType.TEXT)) {
         String originalName = sourceTable.column(i).name();
+        textColumns.add(originalName);
         sourceTable.replaceColumn(i, sourceTable.textColumn(i).asStringColumn());
         sourceTable.column(i).setName(originalName);
       }
@@ -239,6 +242,10 @@ public class TableSliceGroup implements Iterable<TableSlice> {
 
   /**
    * Returns a list of Tables created by reifying my list of slices (views) over the original table
+   *
+   * <p>NOTE: This can use a tremendous amount of memory on a large table containing many
+   * TextColumns. If that is your use case, consider looping over TableSlices and converting each to
+   * a table independently.
    */
   public List<Table> asTableList() {
     List<Table> tableList = new ArrayList<>();

--- a/core/src/test/java/tech/tablesaw/table/TableSliceTest.java
+++ b/core/src/test/java/tech/tablesaw/table/TableSliceTest.java
@@ -8,15 +8,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tech.tablesaw.aggregate.AggregateFunctions.sum;
+import static tech.tablesaw.api.ColumnType.TEXT;
 
 import com.google.common.collect.Streams;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.tablesaw.api.IntColumn;
-import tech.tablesaw.api.Row;
-import tech.tablesaw.api.StringColumn;
-import tech.tablesaw.api.Table;
+import tech.tablesaw.api.*;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.selection.Selection;
 import tech.tablesaw.sorting.Sort;
@@ -315,5 +313,16 @@ public class TableSliceTest {
     for (TableSlice slice : sliceGroup.getSlices()) {
       assertNotNull(slice.structure());
     }
+  }
+
+  /** Test that we can append both text and string columns to a string column */
+  @Test
+  void asTableWithTextColumn() {
+    Table sourceCopy = source.copy();
+    sourceCopy.replaceColumn("who", sourceCopy.stringColumn("who").asTextColumn());
+    TableSliceGroup group = sourceCopy.splitOn("who");
+    TableSlice slice = group.get(0);
+    Table t = slice.asTable();
+    assertEquals(t.column("who").type(), TEXT);
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

StandardTableSliceGroups create tableSlices that can be reconverted to Tables with structures matching the original 

## Testing

Did you add a unit test? Yes
