### PR TITLE
SliceGroup TextColumn handling revision 

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/TextColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TextColumn.java
@@ -383,9 +383,8 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
   /** Returns the contents of the cell at rowNumber as a byte[] */
   @Override
   public byte[] asBytes(int rowNumber) {
-    return new byte[0];
-    // TODO (lwhite): FIX ME:  return
-    // ByteBuffer.allocate(byteSize()).putInt(getInt(rowNumber)).array();
+    String value = get(rowNumber);
+    return value.getBytes();
   }
 
   /** Added for naming consistency with all other columns */

--- a/core/src/main/java/tech/tablesaw/table/SelectionTableSliceGroup.java
+++ b/core/src/main/java/tech/tablesaw/table/SelectionTableSliceGroup.java
@@ -41,7 +41,7 @@ public class SelectionTableSliceGroup extends TableSliceGroup {
 
   private void splitOnSelection(String nameTemplate, List<Selection> selections) {
     for (int i = 0; i < selections.size(); i++) {
-      TableSlice view = new TableSlice(getSourceTable(), selections.get(i), textColumns);
+      TableSlice view = new TableSlice(getSourceTable(), selections.get(i));
       String name = nameTemplate + ": " + i + 1;
       view.setName(name);
       getSlices().add(view);

--- a/core/src/main/java/tech/tablesaw/table/StandardTableSliceGroup.java
+++ b/core/src/main/java/tech/tablesaw/table/StandardTableSliceGroup.java
@@ -93,7 +93,7 @@ public class StandardTableSliceGroup extends TableSliceGroup {
 
     // Add all slices
     for (Entry<ByteArray, Selection> entry : selectionMap.entrySet()) {
-      TableSlice slice = new TableSlice(getSourceTable(), entry.getValue(), textColumns);
+      TableSlice slice = new TableSlice(getSourceTable(), entry.getValue());
       slice.setName(sliceNameMap.get(entry.getKey()));
       addSlice(slice);
     }

--- a/core/src/main/java/tech/tablesaw/table/TableSlice.java
+++ b/core/src/main/java/tech/tablesaw/table/TableSlice.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import tech.tablesaw.aggregate.NumericAggregateFunction;
 import tech.tablesaw.api.NumericColumn;
 import tech.tablesaw.api.Row;
-import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.selection.Selection;
@@ -44,10 +43,6 @@ import tech.tablesaw.sorting.comparators.IntComparatorChain;
 public class TableSlice extends Relation {
 
   private final Table table;
-
-  // the names of any columns that are TextColumns in the original table
-  private List<String> textColumns = new ArrayList<>();
-
   private String name;
   @Nullable private Selection selection;
   @Nullable private int[] sortOrder = null;
@@ -63,33 +58,11 @@ public class TableSlice extends Relation {
   }
 
   /**
-   * Returns a new View constructed from the given table, containing only the rows represented by
-   * the bitmap
-   */
-  public TableSlice(Table table, Selection rowSelection, List<String> textColumns) {
-    this.name = table.name();
-    this.textColumns = textColumns;
-    this.selection = rowSelection;
-    this.table = table;
-  }
-
-  /**
    * Returns a new view constructed from the given table. The view can be sorted independently of
    * the table.
    */
   public TableSlice(Table table) {
     this.name = table.name();
-    this.selection = null;
-    this.table = table;
-  }
-
-  /**
-   * Returns a new view constructed from the given table. The view can be sorted independently of
-   * the table.
-   */
-  public TableSlice(Table table, List<String> textColumns) {
-    this.name = table.name();
-    this.textColumns = textColumns;
     this.selection = null;
     this.table = table;
   }
@@ -207,20 +180,12 @@ public class TableSlice extends Relation {
     return this;
   }
 
-  /**
-   * Returns a Table with the data contained in this slice. If the slice contains string columns
-   * that were TextColumns in the original table, they are converted back to TextColumns here
-   */
   public Table asTable() {
-    Table t = Table.create(this.name());
+    Table table = Table.create(this.name());
     for (Column<?> column : this.columns()) {
-      if (textColumns.contains(column.name())) {
-        t.addColumns(((StringColumn) column).asTextColumn());
-      } else {
-        t.addColumns(column);
-      }
+      table.addColumns(column);
     }
-    return t;
+    return table;
   }
 
   /**

--- a/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
+++ b/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
@@ -29,12 +29,7 @@ import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 
-/**
- * A group of table slices formed by performing splitting operations on an original table
- *
- * <p>NOTE: This can use a tremendous amount of memory on a large table containing many TextColumns.
- * If that is your use case, consider handling this manually instead.
- */
+/** A group of tables formed by performing splitting operations on an original table */
 public class TableSliceGroup implements Iterable<TableSlice> {
 
   // A string that is used internally as a delimiter in creating a column name from all the grouping
@@ -44,8 +39,6 @@ public class TableSliceGroup implements Iterable<TableSlice> {
   // A function that splits the group column name back into the original column names for the
   // grouping columns
   private static final Splitter SPLITTER = Splitter.on(SPLIT_STRING);
-
-  protected List<String> textColumns = new ArrayList<>();
 
   // The list of slices or views over the source table that I contain
   private final List<TableSlice> subTables = new ArrayList<>();
@@ -91,7 +84,6 @@ public class TableSliceGroup implements Iterable<TableSlice> {
     for (int i = 0; i < sourceTable.columnCount(); i++) {
       if (sourceTable.column(i).type().equals(ColumnType.TEXT)) {
         String originalName = sourceTable.column(i).name();
-        textColumns.add(originalName);
         sourceTable.replaceColumn(i, sourceTable.textColumn(i).asStringColumn());
         sourceTable.column(i).setName(originalName);
       }

--- a/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
+++ b/core/src/main/java/tech/tablesaw/table/TableSliceGroup.java
@@ -52,42 +52,8 @@ public class TableSliceGroup implements Iterable<TableSlice> {
    * Returns an instance for calculating a single summary for the given table, with no sub-groupings
    */
   protected TableSliceGroup(Table original) {
-    if (containsAnyTextColumns(original)) {
-      sourceTable = original.copy();
-      replaceTextColumnsWithStringColumns();
-    } else {
-      sourceTable = original;
-    }
+    sourceTable = original;
     splitColumnNames = new String[0];
-  }
-
-  private boolean containsAnyTextColumns(Table original) {
-    for (Column<?> column : original.columns()) {
-      if (column.type().equals(ColumnType.TEXT)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Replace any textColumns in the table with stringColumns. We do this because TextColumns don't
-   * split correctly: The split algorithm uses a byte[] version of the elements to do it's magic,
-   * and text columns have variable sized strings, so variable sized byte arrays. Determining the
-   * correct array size (maybe the largest array size for the array?) would be somewhat fraught
-   * because the size depends on the encoding and the strings do not know they're own encoding. This
-   * would need to be detected using a 3rd party library.
-   *
-   * <p>So replace with the equivalent stringColumn instead.
-   */
-  private void replaceTextColumnsWithStringColumns() {
-    for (int i = 0; i < sourceTable.columnCount(); i++) {
-      if (sourceTable.column(i).type().equals(ColumnType.TEXT)) {
-        String originalName = sourceTable.column(i).name();
-        sourceTable.replaceColumn(i, sourceTable.textColumn(i).asStringColumn());
-        sourceTable.column(i).setName(originalName);
-      }
-    }
   }
 
   /**
@@ -95,12 +61,7 @@ public class TableSliceGroup implements Iterable<TableSlice> {
    * groupColumnNames that appear in the source table
    */
   protected TableSliceGroup(Table sourceTable, String[] groupColumnNames) {
-    if (containsAnyTextColumns(sourceTable)) {
-      this.sourceTable = sourceTable.copy();
-      replaceTextColumnsWithStringColumns();
-    } else {
-      this.sourceTable = sourceTable;
-    }
+    this.sourceTable = sourceTable;
     this.splitColumnNames = groupColumnNames;
   }
 

--- a/core/src/test/java/tech/tablesaw/table/TableSliceGroupTest.java
+++ b/core/src/test/java/tech/tablesaw/table/TableSliceGroupTest.java
@@ -123,12 +123,12 @@ public class TableSliceGroupTest {
     TextColumn whoText = table.stringColumn("who").asTextColumn();
     whoText.setName("who text");
     table.addColumns(whoText);
-    TableSliceGroup group1 =
-        StandardTableSliceGroup.create(table, table.categoricalColumn("who text"));
-    TableSliceGroup group2 = StandardTableSliceGroup.create(table, table.categoricalColumn("who"));
+    TableSliceGroup group1 = StandardTableSliceGroup.create(table, table.textColumn("who text"));
+    TableSliceGroup group2 = StandardTableSliceGroup.create(table, table.stringColumn("who"));
+
     Table aggregated1 = group1.aggregate("approval", exaggerate);
     Table aggregated2 = group2.aggregate("approval", exaggerate);
-    assertEquals(aggregated1.rowCount(), aggregated2.rowCount());
+    assertEquals(aggregated2.rowCount(), aggregated1.rowCount());
   }
 
   @Test

--- a/core/src/test/java/tech/tablesaw/table/TableSliceTest.java
+++ b/core/src/test/java/tech/tablesaw/table/TableSliceTest.java
@@ -8,13 +8,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tech.tablesaw.aggregate.AggregateFunctions.sum;
-import static tech.tablesaw.api.ColumnType.TEXT;
 
 import com.google.common.collect.Streams;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.tablesaw.api.*;
+import tech.tablesaw.api.IntColumn;
+import tech.tablesaw.api.Row;
+import tech.tablesaw.api.StringColumn;
+import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.selection.Selection;
 import tech.tablesaw.sorting.Sort;
@@ -313,16 +315,5 @@ public class TableSliceTest {
     for (TableSlice slice : sliceGroup.getSlices()) {
       assertNotNull(slice.structure());
     }
-  }
-
-  /** Test that we can append both text and string columns to a string column */
-  @Test
-  void asTableWithTextColumn() {
-    Table sourceCopy = source.copy();
-    sourceCopy.replaceColumn("who", sourceCopy.stringColumn("who").asTextColumn());
-    TableSliceGroup group = sourceCopy.splitOn("who");
-    TableSlice slice = group.get(0);
-    Table t = slice.asTable();
-    assertEquals(t.column("who").type(), TEXT);
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

avoids copying of text columns to stringColumns to use the original slice approach. In the new approach the bytes produced by each row in the text column are used. 

## Testing

Did you add a unit test?  No. There is already a test
