### PR TITLE
Make table.removeColumns() return Table rather than Relation

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -917,6 +917,16 @@ public class Table extends Relation implements Iterable<Row> {
     return this;
   }
 
+  @Override
+  public Table removeColumns(String... columns) {
+    return (Table) super.removeColumns(columns);
+  }
+
+  @Override
+  public Table removeColumns(int... columnIndexes) {
+    return (Table) super.removeColumns(columnIndexes);
+  }
+
   /**
    * Appends an empty row and returns a Row object indexed to the newly added row so values can be
    * set.


### PR DESCRIPTION
This removes an important inconsistency in the API


- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

What was changed

## Testing

Did you add a unit test? Not needed. This is thoroughly tested.
