### PR TITLE
Made shape() return the name of the table, along with the shape

### DIFF
--- a/core/src/main/java/tech/tablesaw/table/Relation.java
+++ b/core/src/main/java/tech/tablesaw/table/Relation.java
@@ -58,7 +58,7 @@ public abstract class Relation implements Iterable<Row> {
   }
 
   public String shape() {
-    return rowCount() + " rows X " + columnCount() + " cols";
+    return name() + ": " + rowCount() + " rows X " + columnCount() + " cols";
   }
 
   public Relation removeColumns(int... columnIndexes) {

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
@@ -753,13 +753,13 @@ public class CsvReaderTest {
   @Test
   public void testEmptyFileHeaderEnabled() throws IOException {
     Table table1 = Table.read().csv(CsvReadOptions.builder("../data/empty_file.csv").header(false));
-    assertEquals("0 rows X 0 cols", table1.shape());
+    assertEquals("empty_file.csv: 0 rows X 0 cols", table1.shape());
   }
 
   @Test
   public void testEmptyFileHeaderDisabled() throws IOException {
     Table table1 = Table.read().csv(CsvReadOptions.builder("../data/empty_file.csv").header(false));
-    assertEquals("0 rows X 0 cols", table1.shape());
+    assertEquals("empty_file.csv: 0 rows X 0 cols", table1.shape());
   }
 
   @Test
@@ -779,7 +779,7 @@ public class CsvReaderTest {
                 CsvReadOptions.builder("../data/10001_columns.csv")
                     .maxNumberOfColumns(10001)
                     .header(false));
-    assertEquals("1 rows X 10001 cols", table1.shape());
+    assertEquals("10001_columns.csv: 1 rows X 10001 cols", table1.shape());
   }
 
   @Test
@@ -791,7 +791,7 @@ public class CsvReaderTest {
                     .maxNumberOfColumns(3)
                     .commentPrefix('#')
                     .header(true));
-    assertEquals("3 rows X 3 cols", table1.shape());
+    assertEquals("with_comments.csv: 3 rows X 3 cols", table1.shape());
   }
 
   @Test

--- a/saw/src/main/java/tech/tablesaw/io/saw/TableMetadata.java
+++ b/saw/src/main/java/tech/tablesaw/io/saw/TableMetadata.java
@@ -95,7 +95,7 @@ public class TableMetadata {
    * the shape() method defined on Relation.
    */
   public String shape() {
-    return getRowCount() + " rows X " + columnCount() + " cols";
+    return getName() + ": " + getRowCount() + " rows X " + columnCount() + " cols";
   }
 
   /** Returns a List of the names of all the columns in this table */

--- a/saw/src/test/java/tech/tablesaw/io/saw/SawStorageTest.java
+++ b/saw/src/test/java/tech/tablesaw/io/saw/SawStorageTest.java
@@ -216,7 +216,7 @@ class SawStorageTest {
   void metadata() throws Exception {
     Table baseball = Table.read().csv("../data/baseball.csv");
     String path = new SawWriter("../testoutput/baseball", baseball).write();
-    assertEquals("1232 rows X 15 cols", new SawReader(path).shape());
+    assertEquals("baseball.csv: 1232 rows X 15 cols", new SawReader(path).shape());
     assertEquals(1232, new SawReader(path).rowCount());
     assertEquals(15, new SawReader(path).columnCount());
     assertEquals(baseball.columnNames(), new SawReader(path).columnNames());


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

What was changed

made shape return:

    baseball.csv: 1232 rows X 15 cols

instead of:

    1232 rows X 15 cols

## Testing

Did you add a unit test? Fixed existing tests.
