### PR TITLE
Standardized names for methods, added missing methods

### DIFF
--- a/core/src/main/java/tech/tablesaw/table/Relation.java
+++ b/core/src/main/java/tech/tablesaw/table/Relation.java
@@ -170,11 +170,38 @@ public abstract class Relation implements Iterable<Row> {
   /**
    * Returns an array of the column types of all columns in the relation, including duplicates as
    * appropriate, and maintaining order
+   *
+   * @deprecated for API name consistency. Use {@link #typeArray()} instead.
    */
+  @Deprecated
   public ColumnType[] columnTypes() {
     ColumnType[] columnTypes = new ColumnType[columnCount()];
     for (int i = 0; i < columnCount(); i++) {
       columnTypes[i] = columns().get(i).type();
+    }
+    return columnTypes;
+  }
+
+  /**
+   * Returns an array of the column types of all columns in the relation, including duplicates as
+   * appropriate, and maintaining order
+   */
+  public ColumnType[] typeArray() {
+    ColumnType[] columnTypes = new ColumnType[columnCount()];
+    for (int i = 0; i < columnCount(); i++) {
+      columnTypes[i] = columns().get(i).type();
+    }
+    return columnTypes;
+  }
+
+  /**
+   * Returns a List of the column types of all columns in the relation, including duplicates as
+   * appropriate, and maintaining order
+   */
+  public List<ColumnType> types() {
+    List<ColumnType> columnTypes = new ArrayList<>(columnCount());
+    for (int i = 0; i < columnCount(); i++) {
+      columnTypes.add(columns().get(i).type());
     }
     return columnTypes;
   }
@@ -190,6 +217,10 @@ public abstract class Relation implements Iterable<Row> {
     return widths;
   }
 
+  /**
+   * Returns a String containing a 'pretty-printed' representation of this table containing at most
+   * 20 rows. The 20 rows are the first and last ten in this table.
+   */
   @Override
   public String toString() {
     return print();
@@ -206,10 +237,18 @@ public abstract class Relation implements Iterable<Row> {
     return new String(baos.toByteArray());
   }
 
+  /**
+   * Returns a String containing a 'pretty-printed' representation of this table containing at most
+   * 20 rows. The 20 rows are the first and last ten in this table.
+   */
   public String print() {
     return print(20);
   }
 
+  /**
+   * Returns the structure of the this relation as a 3-column Table, consisting of Index (an
+   * IntColumn), Column Name (a StringColumn), and Column Type (a StringColumn)
+   */
   public Table structure() {
     Table t = Table.create("Structure of " + name());
 
@@ -313,7 +352,6 @@ public abstract class Relation implements Iterable<Row> {
     for (int i : columnIndices) {
       cols.add(numberColumn(i));
     }
-
     return cols;
   }
 
@@ -323,7 +361,6 @@ public abstract class Relation implements Iterable<Row> {
     for (String name : columnNames) {
       cols.add(numberColumn(name));
     }
-
     return cols;
   }
 
@@ -516,5 +553,10 @@ public abstract class Relation implements Iterable<Row> {
 
   public boolean containsColumn(Column<?> column) {
     return columns().contains(column);
+  }
+
+  public boolean containsColumn(String columnName) {
+    String lowerCase = columnName.toLowerCase();
+    return columnNames().stream().anyMatch(e -> e.toLowerCase().equals(lowerCase));
   }
 }

--- a/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
+++ b/core/src/test/java/tech/tablesaw/aggregate/AggregateFunctionsTest.java
@@ -33,7 +33,6 @@ import static tech.tablesaw.aggregate.AggregateFunctions.percentile95;
 import static tech.tablesaw.aggregate.AggregateFunctions.percentile99;
 import static tech.tablesaw.aggregate.AggregateFunctions.proportionFalse;
 import static tech.tablesaw.aggregate.AggregateFunctions.proportionTrue;
-import static tech.tablesaw.aggregate.AggregateFunctions.standardDeviation;
 import static tech.tablesaw.aggregate.AggregateFunctions.stdDev;
 import static tech.tablesaw.aggregate.AggregateFunctions.sum;
 import static tech.tablesaw.api.QuerySupport.and;
@@ -196,20 +195,33 @@ class AggregateFunctionsTest {
     StringColumn sc = StringColumn.create("group_key", group);
 
     Table table = Table.create(sc, bc);
-    Table summarized = table.summarize("test", proportionTrue, proportionFalse)
-                            .by("group_key");
+    Table summarized = table.summarize("test", proportionTrue, proportionFalse).by("group_key");
 
     assertEquals(2, summarized.rowCount());
-    assertEquals(1, summarized.where(summarized.stringColumn("group_key").isEqualTo("a")).rowCount());
-    assertEquals(1, summarized.where(summarized.stringColumn("group_key").isEqualTo("b")).rowCount());
-    assertEquals(ColumnType.DOUBLE, summarized.where(summarized.stringColumn(0).isEqualTo("a")).column(1).type());
-    assertEquals(ColumnType.DOUBLE, summarized.where(summarized.stringColumn(0).isEqualTo("a")).column(2).type());
-    assertEquals(ColumnType.DOUBLE, summarized.where(summarized.stringColumn(0).isEqualTo("b")).column(1).type());
-    assertEquals(ColumnType.DOUBLE, summarized.where(summarized.stringColumn(0).isEqualTo("b")).column(2).type());
-    assertEquals(0.25, summarized.where(summarized.stringColumn(0).isEqualTo("a")).doubleColumn(1).get(0));
-    assertEquals(0.75, summarized.where(summarized.stringColumn(0).isEqualTo("a")).doubleColumn(2).get(0));
-    assertEquals(0.75, summarized.where(summarized.stringColumn(0).isEqualTo("b")).doubleColumn(1).get(0));
-    assertEquals(0.25, summarized.where(summarized.stringColumn(0).isEqualTo("b")).doubleColumn(2).get(0));
+    assertEquals(
+        1, summarized.where(summarized.stringColumn("group_key").isEqualTo("a")).rowCount());
+    assertEquals(
+        1, summarized.where(summarized.stringColumn("group_key").isEqualTo("b")).rowCount());
+    assertEquals(
+        ColumnType.DOUBLE,
+        summarized.where(summarized.stringColumn(0).isEqualTo("a")).column(1).type());
+    assertEquals(
+        ColumnType.DOUBLE,
+        summarized.where(summarized.stringColumn(0).isEqualTo("a")).column(2).type());
+    assertEquals(
+        ColumnType.DOUBLE,
+        summarized.where(summarized.stringColumn(0).isEqualTo("b")).column(1).type());
+    assertEquals(
+        ColumnType.DOUBLE,
+        summarized.where(summarized.stringColumn(0).isEqualTo("b")).column(2).type());
+    assertEquals(
+        0.25, summarized.where(summarized.stringColumn(0).isEqualTo("a")).doubleColumn(1).get(0));
+    assertEquals(
+        0.75, summarized.where(summarized.stringColumn(0).isEqualTo("a")).doubleColumn(2).get(0));
+    assertEquals(
+        0.75, summarized.where(summarized.stringColumn(0).isEqualTo("b")).doubleColumn(1).get(0));
+    assertEquals(
+        0.25, summarized.where(summarized.stringColumn(0).isEqualTo("b")).doubleColumn(2).get(0));
   }
 
   @Test
@@ -311,7 +323,7 @@ class AggregateFunctionsTest {
     StringColumn stringColumn = StringColumn.create("s", strings);
 
     Table table = Table.create("test", booleanColumn, numberColumn);
-    table.summarize(booleanColumn, numberColumn, countTrue, standardDeviation).by(stringColumn);
+    table.summarize(booleanColumn, numberColumn, countTrue, stdDev).by(stringColumn);
   }
 
   @Test
@@ -327,8 +339,7 @@ class AggregateFunctionsTest {
     StringColumn stringColumn = StringColumn.create("s", strings);
 
     Table table = Table.create("test", booleanColumn, numberColumn, stringColumn);
-    Table summarized =
-        table.summarize(booleanColumn, numberColumn, countTrue, standardDeviation).apply();
+    Table summarized = table.summarize(booleanColumn, numberColumn, countTrue, stdDev).apply();
     assertEquals(1.2909944487358056, summarized.doubleColumn(1).get(0), 0.00001);
   }
 

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -73,6 +73,23 @@ public class TableTest {
   }
 
   @Test
+  void types() throws Exception {
+    Table t = Table.read().csv("../data/bush.csv");
+    List<ColumnType> types = t.types();
+    assertEquals(3, types.size());
+    assertTrue(types.contains(ColumnType.STRING));
+    assertTrue(types.contains(ColumnType.LOCAL_DATE));
+    assertTrue(types.contains(ColumnType.INTEGER));
+  }
+
+  @Test
+  void containsColumn() throws Exception {
+    Table t = Table.read().csv("../data/bush.csv");
+    assertTrue(t.containsColumn("who"));
+    assertTrue(t.containsColumn("date"));
+  }
+
+  @Test
   void reorderColumns() throws Exception {
     Table t = Table.read().csv("../data/bush.csv");
     List<String> names = t.columnNames();
@@ -149,6 +166,60 @@ public class TableTest {
     assertTrue(t.containsColumn(sc2));
     assertFalse(t.containsColumn(sc1));
     assertFalse(t.containsColumn(sc3));
+  }
+
+  @Test
+  void testRejectColumns() {
+    StringColumn sc = StringColumn.create("0");
+    StringColumn sc1 = StringColumn.create("1");
+    StringColumn sc2 = StringColumn.create("2");
+    StringColumn sc3 = StringColumn.create("3");
+    Table t = Table.create("t", sc, sc1, sc2, sc3);
+    Table t2 = t.rejectColumns(1, 3);
+    assertTrue(t.containsColumn(sc));
+    assertTrue(t.containsColumn(sc2));
+    assertTrue(t.containsColumn(sc1));
+    assertTrue(t.containsColumn(sc3));
+    assertTrue(t2.containsColumn(sc.name()));
+    assertTrue(t2.containsColumn(sc2.name()));
+    assertFalse(t2.containsColumn(sc1.name()));
+    assertFalse(t2.containsColumn(sc3.name()));
+  }
+
+  @Test
+  void testRejectColumns3() {
+    StringColumn sc = StringColumn.create("0");
+    StringColumn sc1 = StringColumn.create("1");
+    StringColumn sc2 = StringColumn.create("2");
+    StringColumn sc3 = StringColumn.create("3");
+    Table t = Table.create("t", sc, sc1, sc2, sc3);
+    Table t2 = t.rejectColumns(sc1, sc3);
+    assertTrue(t.containsColumn(sc));
+    assertTrue(t.containsColumn(sc2));
+    assertTrue(t.containsColumn(sc1));
+    assertTrue(t.containsColumn(sc3));
+    assertTrue(t2.containsColumn(sc.name()));
+    assertTrue(t2.containsColumn(sc2.name()));
+    assertFalse(t2.containsColumn(sc1.name()));
+    assertFalse(t2.containsColumn(sc3.name()));
+  }
+
+  @Test
+  void testRejectColumns2() {
+    StringColumn sc = StringColumn.create("0");
+    StringColumn sc1 = StringColumn.create("1");
+    StringColumn sc2 = StringColumn.create("2");
+    StringColumn sc3 = StringColumn.create("3");
+    Table t = Table.create("t", sc, sc1, sc2, sc3);
+    Table t2 = t.rejectColumns("1", "3");
+    assertTrue(t.containsColumn(sc));
+    assertTrue(t.containsColumn(sc2));
+    assertTrue(t.containsColumn(sc1));
+    assertTrue(t.containsColumn(sc3));
+    assertTrue(t2.containsColumn(sc.name()));
+    assertTrue(t2.containsColumn(sc2.name()));
+    assertFalse(t2.containsColumn(sc1.name()));
+    assertFalse(t2.containsColumn(sc3.name()));
   }
 
   @Test
@@ -245,14 +316,14 @@ public class TableTest {
   @Test
   void testSelect1() throws Exception {
     Table t = Table.read().csv("../data/bush.csv");
-    Table t1 = t.select(t.column(1), t.column(2));
+    Table t1 = t.selectColumns(t.column(1), t.column(2));
     assertEquals(2, t1.columnCount());
   }
 
   @Test
   void testSelect2() throws Exception {
     Table t = Table.read().csv("../data/bush.csv");
-    Table t1 = t.select(t.column(0), t.column(1), t.column(2), t.dateColumn(0).year());
+    Table t1 = t.selectColumns(t.column(0), t.column(1), t.column(2), t.dateColumn(0).year());
     assertEquals(4, t1.columnCount());
     assertEquals("date year", t1.column(3).name());
   }
@@ -557,11 +628,13 @@ public class TableTest {
     assertTableColumnSize(table, column, secondColumnSize);
   }
 
+  @Test
   void testAppendNull() {
+    Row r = null;
     assertThrows(
         NullPointerException.class,
         () -> {
-          table.append(null);
+          table.append(r);
         });
   }
 
@@ -781,7 +854,7 @@ public class TableTest {
     StringColumn s3 = StringColumn.create("3", "3", "2", "1");
     IntColumn s4 = IntColumn.create("4", 1, 2, 3);
     Table t = Table.create("t", s3, s2, s1, s4);
-    assertDoesNotThrow(() -> t.where(t.intColumn("4").isIn((int) 1, (int) 2)));
+    assertDoesNotThrow(() -> t.where(t.intColumn("4").isIn(1, 2)));
   }
 
   @Test

--- a/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
+++ b/core/src/test/java/tech/tablesaw/columns/ColumnTest.java
@@ -261,8 +261,7 @@ public class ColumnTest {
     String[] strings = new String[] {"-1.0", "0.0", "1.0"};
     DoubleColumn doubleColumn = DoubleColumn.create("t1", new double[] {-1, 0, 1});
     StringColumn stringColumn1 =
-        (StringColumn)
-            doubleColumn.mapInto(toString, StringColumn.create("T", doubleColumn.size()));
+        doubleColumn.mapInto(toString, StringColumn.create("T", doubleColumn.size()));
     assertContentEquals(stringColumn1, strings);
   }
 
@@ -278,8 +277,7 @@ public class ColumnTest {
               LocalDateTime.of(2018, 9, 2, 21, 42)
             });
     StringColumn stringColumn1 =
-        (StringColumn)
-            dateColumn.mapInto(toSeason, StringColumn.create("Season", dateColumn.size()));
+        dateColumn.mapInto(toSeason, StringColumn.create("Season", dateColumn.size()));
     assertContentEquals(stringColumn1, strings);
   }
 

--- a/core/src/test/java/tech/tablesaw/conversion/smile/SmileConverterTest.java
+++ b/core/src/test/java/tech/tablesaw/conversion/smile/SmileConverterTest.java
@@ -51,7 +51,7 @@ public class SmileConverterTest {
         moneyball.numberColumn("RS").subtract(moneyball.numberColumn("RA")).setName("RD"));
 
     LinearModel winsModel =
-        OLS.fit(Formula.lhs("RD"), moneyball.select("W", "RD").smile().toDataFrame());
+        OLS.fit(Formula.lhs("RD"), moneyball.selectColumns("W", "RD").smile().toDataFrame());
     assertNotNull(winsModel.toString());
   }
 

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
@@ -636,7 +636,7 @@ public class CsvReaderTest {
   }
 
   @Test
-  public void testLoadFromUrlWithColumnTypes() throws IOException {
+  public void testLoadFromUrlWithtypeArray() throws IOException {
     ColumnType[] types = {LOCAL_DATE, DOUBLE, STRING};
     Table table;
     try (InputStream input = new File("../data/bush.csv").toURI().toURL().openStream()) {
@@ -852,8 +852,8 @@ public class CsvReaderTest {
   @Test
   public void testReadCsvWithPercentage1() throws IOException {
     Table table = Table.read().csv(CsvReadOptions.builder("../data/currency_percent.csv"));
-    assertEquals(DoubleColumnType.instance(), table.columnTypes()[1]);
-    assertEquals(DoubleColumnType.instance(), table.columnTypes()[2]);
+    assertEquals(DoubleColumnType.instance(), table.typeArray()[1]);
+    assertEquals(DoubleColumnType.instance(), table.typeArray()[2]);
   }
 
   @Test
@@ -910,7 +910,7 @@ public class CsvReaderTest {
                             .get(columnName)))
             .build();
 
-    ColumnType[] columnTypes = new CsvReader().read(options).columnTypes();
+    ColumnType[] columnTypes = new CsvReader().read(options).typeArray();
 
     ColumnType[] expectedTypes = Arrays.copyOf(bus_types, bus_types.length);
     expectedTypes[0] = STRING; // stop_id
@@ -931,7 +931,7 @@ public class CsvReaderTest {
             .columnTypes(columnName -> STRING)
             .build();
 
-    ColumnType[] columnTypes = new CsvReader().read(options).columnTypes();
+    ColumnType[] columnTypes = new CsvReader().read(options).typeArray();
 
     assertTrue(Arrays.stream(columnTypes).allMatch(columnType -> columnType.equals(STRING)));
   }
@@ -959,7 +959,7 @@ public class CsvReaderTest {
                     FLOAT))
             .build();
 
-    ColumnType[] columnTypes = new CsvReader().read(options).columnTypes();
+    ColumnType[] columnTypes = new CsvReader().read(options).typeArray();
 
     assertArrayEquals(bus_types, columnTypes);
   }
@@ -976,7 +976,7 @@ public class CsvReaderTest {
             .columnTypes(new ColumnType[] {SHORT, STRING, STRING, FLOAT, FLOAT})
             .build();
 
-    ColumnType[] columnTypes = new CsvReader().read(options).columnTypes();
+    ColumnType[] columnTypes = new CsvReader().read(options).typeArray();
 
     assertArrayEquals(bus_types, columnTypes);
   }
@@ -994,7 +994,7 @@ public class CsvReaderTest {
             .columnTypesPartial(ImmutableMap.of("stop_id", SHORT, "stop_name", STRING))
             .build();
 
-    ColumnType[] columnTypes = new CsvReader().read(options).columnTypes();
+    ColumnType[] columnTypes = new CsvReader().read(options).typeArray();
 
     assertArrayEquals(new ColumnType[] {SHORT, STRING}, columnTypes);
   }

--- a/core/src/test/java/tech/tablesaw/io/fixed/FixedWidthReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/fixed/FixedWidthReaderTest.java
@@ -191,7 +191,7 @@ public class FixedWidthReaderTest {
             .columnTypesPartial(ImmutableMap.of("Year", STRING))
             .build();
 
-    ColumnType[] columnTypes = new FixedWidthReader().read(options).columnTypes();
+    ColumnType[] columnTypes = new FixedWidthReader().read(options).typeArray();
 
     ColumnType[] expectedTypes = Arrays.copyOf(car_types, car_types.length);
     car_types[0] = STRING; // Year
@@ -213,7 +213,7 @@ public class FixedWidthReaderTest {
             .columnTypes(columnName -> STRING)
             .build();
 
-    ColumnType[] columnTypes = new FixedWidthReader().read(options).columnTypes();
+    ColumnType[] columnTypes = new FixedWidthReader().read(options).typeArray();
 
     assertTrue(Arrays.stream(columnTypes).allMatch(columnType -> columnType.equals(STRING)));
   }

--- a/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerTest.java
+++ b/core/src/test/java/tech/tablesaw/joining/DataFrameJoinerTest.java
@@ -689,14 +689,14 @@ public class DataFrameJoinerTest {
 
   @Test
   public void innerJoinSingleColumn() {
-    Table joined = SP500.select("Date").joinOn("Date").inner(ONE_YEAR.select("Date"));
+    Table joined = SP500.selectColumns("Date").joinOn("Date").inner(ONE_YEAR.selectColumns("Date"));
     assertEquals(5, joined.rowCount());
     assertEquals(1, joined.columnCount());
   }
 
   @Test
   public void innerJoinSingleColumnOnRight() {
-    Table joined = SP500.joinOn("Date").inner(ONE_YEAR.select("Date"));
+    Table joined = SP500.joinOn("Date").inner(ONE_YEAR.selectColumns("Date"));
     assertEquals(5, joined.rowCount());
     assertEquals(2, joined.columnCount());
   }
@@ -801,7 +801,7 @@ public class DataFrameJoinerTest {
 
   @Test
   public void fullOuterJoinColTwoOnlyJoinKeys() {
-    Table joined = ANIMAL_FEED.joinOn("Animal").fullOuter(ANIMAL_NAMES.select("Animal"));
+    Table joined = ANIMAL_FEED.joinOn("Animal").fullOuter(ANIMAL_NAMES.selectColumns("Animal"));
     assertEquals(2, joined.columnCount());
     assertEquals(8, joined.rowCount());
   }

--- a/core/src/test/java/tech/tablesaw/table/SliceBugTests.java
+++ b/core/src/test/java/tech/tablesaw/table/SliceBugTests.java
@@ -71,7 +71,7 @@ public class SliceBugTests {
 
     Table filteredTable =
         salesTable
-            .select(salesTable.columnNames().toArray(new String[0]))
+            .selectColumns(salesTable.columnNames().toArray(new String[0]))
             .where(
                 salesTable
                     .instantColumn("sale_timestamp")

--- a/docs-src/src/main/java/tech/tablesaw/docs/Tutorial.java
+++ b/docs-src/src/main/java/tech/tablesaw/docs/Tutorial.java
@@ -97,7 +97,7 @@ public class Tutorial implements DocsSourceFile {
                 .isGreaterThan(300) // 300 yards
                 .or(result.doubleColumn("Length").isGreaterThan(10))); // 10 miles
 
-    result = result.select("State", "Date");
+    result = result.selectColumns("State", "Date");
 
     // @@ filtering
     outputWriter.write(result.first(3), "filtering");

--- a/excel/src/test/java/tech/tablesaw/io/xlsx/XlsxReaderTest.java
+++ b/excel/src/test/java/tech/tablesaw/io/xlsx/XlsxReaderTest.java
@@ -203,7 +203,7 @@ public class XlsxReaderTest {
                         ImmutableMap.of("shortcol", DOUBLE, "intcol", LONG, "formulacol", FLOAT))
                     .build());
 
-    ColumnType[] columnTypes = table.columnTypes();
+    ColumnType[] columnTypes = table.typeArray();
 
     assertArrayEquals(
         columnTypes,
@@ -235,7 +235,7 @@ public class XlsxReaderTest {
                     .columnTypes(columName -> STRING)
                     .build());
 
-    ColumnType[] columnTypes = table.columnTypes();
+    ColumnType[] columnTypes = table.typeArray();
 
     assertTrue(Arrays.stream(columnTypes).allMatch(columnType -> columnType.equals(STRING)));
   }

--- a/json/src/test/java/tech/tablesaw/io/json/JsonReaderTest.java
+++ b/json/src/test/java/tech/tablesaw/io/json/JsonReaderTest.java
@@ -38,7 +38,7 @@ public class JsonReaderTest {
     assertEquals(3, table.rowCount());
     assertEquals("Date", table.column(0).name());
     assertEquals("Value", table.column(1).name());
-    assertEquals(ColumnType.LONG, table.columnTypes()[0]);
+    assertEquals(ColumnType.LONG, table.typeArray()[0]);
     assertEquals(1453438800000L, table.column("Date").get(0));
   }
 
@@ -49,7 +49,7 @@ public class JsonReaderTest {
     Table table = Table.read().string(json, "json");
     assertEquals(2, table.columnCount());
     assertEquals(3, table.rowCount());
-    assertEquals(ColumnType.LONG, table.columnTypes()[0]);
+    assertEquals(ColumnType.LONG, table.typeArray()[0]);
   }
 
   @Test
@@ -61,7 +61,7 @@ public class JsonReaderTest {
     assertEquals(3, table.rowCount());
     assertEquals("a", table.column(0).name());
     assertEquals("b.c", table.column(1).name());
-    assertEquals(ColumnType.LONG, table.columnTypes()[0]);
+    assertEquals(ColumnType.LONG, table.typeArray()[0]);
   }
 
   @Test
@@ -76,7 +76,7 @@ public class JsonReaderTest {
             IntColumn.create("C", new int[] {Integer.MIN_VALUE, 123}));
     Table actual = Table.read().string(json, "json");
 
-    assertEquals(ColumnType.INTEGER, actual.columnTypes()[0]);
+    assertEquals(ColumnType.INTEGER, actual.typeArray()[0]);
     assertEquals(expected.column("A").asList(), actual.column("A").asList());
     assertEquals(expected.column("B").asList(), actual.column("B").asList());
     assertEquals(expected.column("C").asList(), actual.column("C").asList());
@@ -93,7 +93,7 @@ public class JsonReaderTest {
                 JsonReadOptions.builderFromString(json)
                     .columnTypesPartial(ImmutableMap.of("Date", INSTANT))
                     .build())
-            .columnTypes();
+            .typeArray();
 
     assertArrayEquals(columnTypes, new ColumnType[] {INSTANT, DOUBLE});
   }
@@ -106,7 +106,7 @@ public class JsonReaderTest {
     ColumnType[] columnTypes =
         new JsonReader()
             .read(JsonReadOptions.builderFromString(json).columnTypes(columnName -> STRING).build())
-            .columnTypes();
+            .typeArray();
 
     assertArrayEquals(columnTypes, new ColumnType[] {STRING, STRING});
   }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Extending select() to support indexed column access. Select is the non-modifying equivalent of retainColumns().
Rename select() to selectColumns() for consistency
Add rejectColumns() to support the non-modifying (i.e., return a new table) exclusion of columns. This is the equivalent of removeColumns().
Add methods to Relation:
- ColumnType[] typeArray()
- List<ColumnType<?> types()
- containsColumn(String columnName);
Deprecated method ColumnType[] columnTypes(), because methods with similar names return Lists not Arrays.
Added method append(Row), and deprecated addRow(Row) so that append() is always the name whether the argument is a table, slice, or row.

## Testing

Did you add a unit test?
Yes, and updated the old ones.