### PR TITLE
Removed IOException from write interfaces

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/DataFrameWriter.java
+++ b/core/src/main/java/tech/tablesaw/io/DataFrameWriter.java
@@ -34,27 +34,32 @@ public class DataFrameWriter {
     this.table = table;
   }
 
-  public void toFile(String file) throws IOException {
+  public void toFile(String file) {
     toFile(new File(file));
   }
 
-  public void toFile(File file) throws IOException {
-    String extension = Files.getFileExtension(file.getCanonicalPath());
+  public void toFile(File file) {
+    String extension = null;
+    try {
+      extension = Files.getFileExtension(file.getCanonicalPath());
+    } catch (IOException e) {
+      throw new RuntimeIOException(e);
+    }
     DataWriter<?> dataWriter = registry.getWriterForExtension(extension);
     dataWriter.write(table, new Destination(file));
   }
 
-  public void toStream(OutputStream stream, String extension) throws IOException {
+  public void toStream(OutputStream stream, String extension) {
     DataWriter<?> dataWriter = registry.getWriterForExtension(extension);
     dataWriter.write(table, new Destination(stream));
   }
 
-  public void toWriter(Writer writer, String extension) throws IOException {
+  public void toWriter(Writer writer, String extension) {
     DataWriter<?> dataWriter = registry.getWriterForExtension(extension);
     dataWriter.write(table, new Destination(writer));
   }
 
-  public <T extends WriteOptions> void usingOptions(T options) throws IOException {
+  public <T extends WriteOptions> void usingOptions(T options) {
     DataWriter<T> dataWriter = registry.getWriterForOptions(options);
     dataWriter.write(table, options);
   }
@@ -62,22 +67,18 @@ public class DataFrameWriter {
   public String toString(String extension) {
     StringWriter writer = new StringWriter();
     DataWriter<?> dataWriter = registry.getWriterForExtension(extension);
-    try {
-      dataWriter.write(table, new Destination(writer));
-    } catch (IOException e) {
-      throw new IllegalStateException(e);
-    }
+    dataWriter.write(table, new Destination(writer));
     return writer.toString();
   }
 
   // legacy methods left for backwards compatibility
 
-  public void csv(String file) throws IOException {
+  public void csv(String file) {
     CsvWriteOptions options = CsvWriteOptions.builder(file).build();
     new CsvWriter().write(table, options);
   }
 
-  public void csv(File file) throws IOException {
+  public void csv(File file) {
     CsvWriteOptions options = CsvWriteOptions.builder(file).build();
     new CsvWriter().write(table, options);
   }

--- a/core/src/main/java/tech/tablesaw/io/DataWriter.java
+++ b/core/src/main/java/tech/tablesaw/io/DataWriter.java
@@ -1,11 +1,10 @@
 package tech.tablesaw.io;
 
-import java.io.IOException;
 import tech.tablesaw.api.Table;
 
 public interface DataWriter<O extends WriteOptions> {
 
-  void write(Table table, Destination dest) throws IOException;
+  void write(Table table, Destination dest);
 
-  void write(Table table, O options) throws IOException;
+  void write(Table table, O options);
 }

--- a/core/src/main/java/tech/tablesaw/io/Destination.java
+++ b/core/src/main/java/tech/tablesaw/io/Destination.java
@@ -1,19 +1,18 @@
 package tech.tablesaw.io;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
+import java.io.*;
 
 public class Destination {
 
   protected final OutputStream stream;
   protected final Writer writer;
 
-  public Destination(File file) throws IOException {
-    this.stream = new FileOutputStream(file);
+  public Destination(File file) {
+    try {
+      this.stream = new FileOutputStream(file);
+    } catch (FileNotFoundException e) {
+      throw new RuntimeIOException(e);
+    }
     this.writer = null;
   }
 

--- a/core/src/main/java/tech/tablesaw/io/WriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/WriteOptions.java
@@ -1,7 +1,6 @@
 package tech.tablesaw.io;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 
@@ -42,7 +41,7 @@ public class WriteOptions {
       this.dest = new Destination(dest);
     }
 
-    protected Builder(File dest) throws IOException {
+    protected Builder(File dest) {
       this.dest = new Destination(dest);
       this.autoClose = true;
     }

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvWriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvWriteOptions.java
@@ -1,7 +1,6 @@
 package tech.tablesaw.io.csv;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.nio.file.Paths;
@@ -106,11 +105,11 @@ public class CsvWriteOptions extends WriteOptions {
     return new Builder(dest);
   }
 
-  public static Builder builder(File dest) throws IOException {
+  public static Builder builder(File dest) {
     return new Builder(dest);
   }
 
-  public static Builder builder(String fileName) throws IOException {
+  public static Builder builder(String fileName) {
     return builder(new File(fileName));
   }
 
@@ -129,7 +128,7 @@ public class CsvWriteOptions extends WriteOptions {
     private DateTimeFormatter dateFormatter;
     private Map<String, String> columnNameMap = new HashMap<>();
 
-    protected Builder(String fileName) throws IOException {
+    protected Builder(String fileName) {
       super(Paths.get(fileName).toFile());
     }
 
@@ -137,7 +136,7 @@ public class CsvWriteOptions extends WriteOptions {
       super(dest);
     }
 
-    protected Builder(File file) throws IOException {
+    protected Builder(File file) {
       super(file);
     }
 

--- a/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriteOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriteOptions.java
@@ -3,7 +3,6 @@ package tech.tablesaw.io.fixed;
 import com.univocity.parsers.fixed.FieldAlignment;
 import com.univocity.parsers.fixed.FixedWidthFields;
 import java.io.File;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 import tech.tablesaw.io.Destination;
@@ -146,15 +145,15 @@ public class FixedWidthWriteOptions extends WriteOptions {
     return autoClose;
   }
 
-  public static Builder builder(Destination destination) throws IOException {
+  public static Builder builder(Destination destination) {
     return new Builder(destination);
   }
 
-  public static Builder builder(File file) throws IOException {
+  public static Builder builder(File file) {
     return new Builder(file);
   }
 
-  public static Builder builder(String fileName) throws IOException {
+  public static Builder builder(String fileName) {
     return builder(new File(fileName));
   }
 
@@ -190,11 +189,11 @@ public class FixedWidthWriteOptions extends WriteOptions {
     private char lookupWildcard = '?';
     private char normalizedNewline = '\n';
 
-    protected Builder(Destination destination) throws IOException {
+    protected Builder(Destination destination) {
       super(destination);
     }
 
-    protected Builder(File file) throws IOException {
+    protected Builder(File file) {
       super(file);
     }
 

--- a/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriter.java
+++ b/core/src/main/java/tech/tablesaw/io/fixed/FixedWidthWriter.java
@@ -16,7 +16,6 @@ package tech.tablesaw.io.fixed;
 
 import com.univocity.parsers.fixed.FixedWidthFormat;
 import com.univocity.parsers.fixed.FixedWidthWriterSettings;
-import java.io.IOException;
 import java.io.Writer;
 import javax.annotation.concurrent.Immutable;
 import tech.tablesaw.api.Table;
@@ -159,7 +158,7 @@ public final class FixedWidthWriter implements DataWriter<FixedWidthWriteOptions
   }
 
   @Override
-  public void write(Table table, Destination dest) throws IOException {
+  public void write(Table table, Destination dest) {
     write(table, FixedWidthWriteOptions.builder(dest).build());
   }
 }

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -23,7 +23,6 @@ import static tech.tablesaw.api.ColumnType.DOUBLE;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.io.File;
-import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.time.LocalDate;
@@ -351,7 +350,7 @@ public class TableTest {
   }
 
   @Test
-  void testLast() throws IOException {
+  void testLast() {
     bush = bush.sortOn("date");
     Table t1 = bush.last(3);
     assertEquals(3, t1.rowCount());

--- a/html/src/main/java/tech/tablesaw/io/html/HtmlWriter.java
+++ b/html/src/main/java/tech/tablesaw/io/html/HtmlWriter.java
@@ -23,6 +23,7 @@ import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.io.DataWriter;
 import tech.tablesaw.io.Destination;
+import tech.tablesaw.io.RuntimeIOException;
 import tech.tablesaw.io.WriterRegistry;
 import tech.tablesaw.io.html.HtmlWriteOptions.ElementCreator;
 
@@ -39,7 +40,7 @@ public class HtmlWriter implements DataWriter<HtmlWriteOptions> {
     registry.registerOptions(HtmlWriteOptions.class, INSTANCE);
   }
 
-  public void write(Table table, HtmlWriteOptions options) throws IOException {
+  public void write(Table table, HtmlWriteOptions options) {
     ElementCreator elements = options.elementCreator();
     Element html = elements.create("table");
     html.appendChild(header(table.columns(), elements));
@@ -52,6 +53,8 @@ public class HtmlWriter implements DataWriter<HtmlWriteOptions> {
 
     try (Writer writer = options.destination().createWriter()) {
       writer.write(html.toString());
+    } catch (IOException e) {
+      throw new RuntimeIOException(e);
     }
   }
 
@@ -84,7 +87,7 @@ public class HtmlWriter implements DataWriter<HtmlWriteOptions> {
   }
 
   @Override
-  public void write(Table table, Destination dest) throws IOException {
+  public void write(Table table, Destination dest) {
     write(table, HtmlWriteOptions.builder(dest).build());
   }
 }

--- a/json/src/main/java/tech/tablesaw/io/json/JsonWriter.java
+++ b/json/src/main/java/tech/tablesaw/io/json/JsonWriter.java
@@ -24,6 +24,7 @@ import java.io.Writer;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.DataWriter;
 import tech.tablesaw.io.Destination;
+import tech.tablesaw.io.RuntimeIOException;
 import tech.tablesaw.io.WriterRegistry;
 
 public class JsonWriter implements DataWriter<JsonWriteOptions> {
@@ -41,7 +42,7 @@ public class JsonWriter implements DataWriter<JsonWriteOptions> {
     registry.registerOptions(JsonWriteOptions.class, INSTANCE);
   }
 
-  public void write(Table table, JsonWriteOptions options) throws IOException {
+  public void write(Table table, JsonWriteOptions options) {
     ArrayNode output = mapper.createArrayNode();
     if (options.asObjects()) {
       for (int r = 0; r < table.rowCount(); r++) {
@@ -67,15 +68,16 @@ public class JsonWriter implements DataWriter<JsonWriteOptions> {
         output.add(row);
       }
     }
-
-    String str = mapper.writeValueAsString(output);
     try (Writer writer = options.destination().createWriter()) {
+      String str = mapper.writeValueAsString(output);
       writer.write(str);
+    } catch (IOException e) {
+      throw new RuntimeIOException(e);
     }
   }
 
   @Override
-  public void write(Table table, Destination dest) throws IOException {
+  public void write(Table table, Destination dest) {
     write(table, JsonWriteOptions.builder(dest).build());
   }
 }


### PR DESCRIPTION
IOException is caught and re-thrown as RuntimeIOException(e)

Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

IOException is caught and re-thrown as RuntimeIOException(e)

## Testing

Did you add a unit test? No. 
