### PR TITLE
Simplify adding new column to table

### DIFF
--- a/core/src/main/java/tech/tablesaw/analytic/AnalyticQueryEngine.java
+++ b/core/src/main/java/tech/tablesaw/analytic/AnalyticQueryEngine.java
@@ -29,6 +29,7 @@ final class AnalyticQueryEngine {
     this.rowComparator = sort.isPresent() ? SortUtils.getChain(query.getTable(), sort.get()) : null;
   }
 
+  /** Returns a new AnalyticQueryEngine to execute the given query */
   public static AnalyticQueryEngine create(AnalyticQuery query) {
     return new AnalyticQueryEngine(query);
   }

--- a/core/src/main/java/tech/tablesaw/analytic/FunctionMetaData.java
+++ b/core/src/main/java/tech/tablesaw/analytic/FunctionMetaData.java
@@ -4,9 +4,13 @@ import tech.tablesaw.api.ColumnType;
 
 /** Base class for an Analytic Function. */
 interface FunctionMetaData {
+
+  /** Returns the name of the function */
   String functionName();
 
+  /** Returns the type of column that will hold the return values of the function */
   ColumnType returnType();
 
+  /** Returns true if the function can be applied to data of the given {@link ColumnType} */
   boolean isCompatibleColumn(ColumnType type);
 }

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -280,14 +280,23 @@ public class TableTest {
   }
 
   @Test
+  void appendSmallerColumnToEmptyTable() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          table.doubleColumn("f1").append(23).append(42);
+          table.addColumns(StringColumn.create("test", 1));
+        });
+  }
+
+  @Test
   void testCountBy() {
     assertEquals(3, bush.countBy("who", "date").columnCount());
   }
 
   @Test
   void appendEmptyColumnToPopulatedTable() {
-    assertThrows(
-        IllegalArgumentException.class,
+    assertDoesNotThrow(
         () -> {
           table.doubleColumn("f1").append(23);
           table.addColumns(StringColumn.create("test"));


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Automatically fill empty columns to match the size of the table they are added to. Columns that are not empty must continue to match the size of the table when added as adding a 24 row column to a 23 row table is most likely a bug

## Testing

Did you add a unit test? Yes. 
