### PR TITLE
replaced the implementation of Table method dropDuplicateRows() with …

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
@@ -309,6 +309,12 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
 
   /** {@inheritDoc} */
   @Override
+  public int valueHash(int rowNumber) {
+    return getByte(rowNumber);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public String getString(int row) {
     return formatter.format(get(row));
   }

--- a/core/src/main/java/tech/tablesaw/api/ColumnType.java
+++ b/core/src/main/java/tech/tablesaw/api/ColumnType.java
@@ -90,4 +90,14 @@ public interface ColumnType {
     Object o2 = temp.get(temp.size() - 1);
     return o1 == null ? o2 == null : o1.equals(o2);
   }
+
+  /**
+   * Returns true if the value at the specified index in column1 is equal to the value at the
+   * specified index in column 2
+   */
+  default boolean compare(int col1Row, Column<?> col1, int col2Row, Column<?> col2) {
+    Object o1 = col1.get(col1Row);
+    Object o2 = col2.get(col2Row);
+    return o1 == null ? o2 == null : o1.equals(o2);
+  }
 }

--- a/core/src/main/java/tech/tablesaw/api/DateColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateColumn.java
@@ -632,6 +632,12 @@ public class DateColumn extends AbstractColumn<DateColumn, LocalDate>
     return type().byteSize();
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public int valueHash(int rowNumber) {
+    return getIntInternal(rowNumber);
+  }
+
   /**
    * Returns the contents of the cell at rowNumber as a byte[]
    *

--- a/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
@@ -70,6 +70,12 @@ public class DateTimeColumn extends AbstractColumn<DateTimeColumn, LocalDateTime
 
   private DateTimeColumnFormatter printFormatter = new DateTimeColumnFormatter();
 
+  /** {@inheritDoc} */
+  @Override
+  public int valueHash(int rowNumber) {
+    return Long.hashCode(getLongInternal(rowNumber));
+  }
+
   private DateTimeColumn(String name, LongArrayList data) {
     super(DateTimeColumnType.instance(), name, DateTimeColumnType.DEFAULT_PARSER);
     this.data = data;

--- a/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
@@ -275,6 +275,12 @@ public class DoubleColumn extends NumberColumn<DoubleColumn, Double>
 
   /** {@inheritDoc} */
   @Override
+  public int valueHash(int rowNumber) {
+    return Double.hashCode(getDouble(rowNumber));
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public DoubleColumn append(Double val) {
     if (val == null) {
       appendMissing();

--- a/core/src/main/java/tech/tablesaw/api/FloatColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/FloatColumn.java
@@ -33,6 +33,12 @@ public class FloatColumn extends NumberColumn<FloatColumn, Float> {
     return getPrintFormatter().format(value);
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public int valueHash(int rowNumber) {
+    return Float.hashCode(getFloat(rowNumber));
+  }
+
   public static FloatColumn create(String name) {
     return new FloatColumn(name, new FloatArrayList());
   }

--- a/core/src/main/java/tech/tablesaw/api/InstantColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/InstantColumn.java
@@ -65,6 +65,12 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
 
   protected LongArrayList data;
 
+  /** {@inheritDoc} */
+  @Override
+  public int valueHash(int rowNumber) {
+    return Long.hashCode(getLongInternal(rowNumber));
+  }
+
   private final IntComparator comparator =
       (r1, r2) -> {
         long f1 = getPackedDateTime(r1);

--- a/core/src/main/java/tech/tablesaw/api/IntColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/IntColumn.java
@@ -94,6 +94,12 @@ public class IntColumn extends NumberColumn<IntColumn, Integer>
 
   /** {@inheritDoc} */
   @Override
+  public int valueHash(int rowNumber) {
+    return getInt(rowNumber);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public void clear() {
     data.clear();
   }

--- a/core/src/main/java/tech/tablesaw/api/LongColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/LongColumn.java
@@ -30,6 +30,12 @@ public class LongColumn extends NumberColumn<LongColumn, Long> implements Catego
     this.data = data;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public int valueHash(int rowNumber) {
+    return Long.hashCode(getLong(rowNumber));
+  }
+
   public static LongColumn create(final String name) {
     return new LongColumn(name, new LongArrayList());
   }

--- a/core/src/main/java/tech/tablesaw/api/Row.java
+++ b/core/src/main/java/tech/tablesaw/api/Row.java
@@ -4,11 +4,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 import tech.tablesaw.columns.Column;
 import tech.tablesaw.table.TableSlice;
 
@@ -794,13 +790,35 @@ public class Row implements Iterator<Row> {
     return columnMap.get(columnName).type();
   }
 
+  public ColumnType getColumnType(int columnIndex) {
+    return tableSlice.column(columnIndex).type();
+  }
+
+  Column<?> column(int columnIndex) {
+    return tableSlice.column(columnIndex);
+  }
+
+  /** Returns a hash computed on the values in the backing table at this row */
+  public int rowHash() {
+    int[] values = new int[columnCount()];
+    for (int i = 0; i < columnCount(); i++) {
+      Column<?> column = tableSlice.column(i);
+      values[i] = column.valueHash(rowNumber);
+    }
+    int result = 1;
+    for (int hash : values) {
+      result = 31 * result + hash;
+    }
+    return result;
+  }
+
   @Override
   public String toString() {
     Table t = tableSlice.getTable().emptyCopy();
     if (getRowNumber() == -1) {
       return "";
     }
-    t.addRow(this);
+    t.append(this);
     return t.print();
   }
 

--- a/core/src/main/java/tech/tablesaw/api/ShortColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/ShortColumn.java
@@ -35,6 +35,12 @@ public class ShortColumn extends NumberColumn<ShortColumn, Short>
     this.data = data;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public int valueHash(int rowNumber) {
+    return getShort(rowNumber);
+  }
+
   public static ShortColumn create(final String name) {
     return new ShortColumn(name, new ShortArrayList());
   }

--- a/core/src/main/java/tech/tablesaw/api/StringColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/StringColumn.java
@@ -67,6 +67,12 @@ public class StringColumn extends AbstractStringColumn<StringColumn> {
     return this;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public int valueHash(int rowNumber) {
+    return get(rowNumber).hashCode();
+  }
+
   public static StringColumn create(String name) {
     return new StringColumn(name);
   }

--- a/core/src/main/java/tech/tablesaw/api/TextColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TextColumn.java
@@ -58,6 +58,12 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
 
   private final Comparator<String> descendingStringComparator = Comparator.reverseOrder();
 
+  /** {@inheritDoc} */
+  @Override
+  public int valueHash(int rowNumber) {
+    return get(rowNumber).hashCode();
+  }
+
   private TextColumn(String name, Collection<String> strings) {
     super(TextColumnType.instance(), name, TextColumnType.DEFAULT_PARSER);
     values = new ArrayList<>(strings.size());

--- a/core/src/main/java/tech/tablesaw/api/TimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TimeColumn.java
@@ -62,6 +62,12 @@ public class TimeColumn extends AbstractColumn<TimeColumn, LocalTime>
         return Integer.compare(f1, f2);
       };
 
+  /** {@inheritDoc} */
+  @Override
+  public int valueHash(int rowNumber) {
+    return getIntInternal(rowNumber);
+  }
+
   private TimeColumn(String name, IntArrayList times) {
     super(TimeColumnType.instance(), name, TimeColumnType.DEFAULT_PARSER);
     data = times;

--- a/core/src/main/java/tech/tablesaw/columns/Column.java
+++ b/core/src/main/java/tech/tablesaw/columns/Column.java
@@ -638,6 +638,9 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
   /** Appends a missing value appropriate to the column */
   Column<T> appendMissing();
 
+  /** Returns an int suitable as a hash for the value in this column at the given index */
+  int valueHash(int rowNumber);
+
   /** Returns a new column containing the subset referenced by the {@link Selection} */
   Column<T> where(Selection selection);
 

--- a/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
+++ b/core/src/main/java/tech/tablesaw/io/csv/CsvReadOptions.java
@@ -22,10 +22,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.net.URL;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.io.ReadOptions;
@@ -51,6 +48,34 @@ public class CsvReadOptions extends ReadOptions {
     commentPrefix = builder.commentPrefix;
     lineSeparatorDetectionEnabled = builder.lineSeparatorDetectionEnabled;
     sampleSize = builder.sampleSize;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CsvReadOptions that = (CsvReadOptions) o;
+    return lineSeparatorDetectionEnabled == that.lineSeparatorDetectionEnabled
+        && sampleSize == that.sampleSize
+        && Objects.equals(separator, that.separator)
+        && Objects.equals(quoteChar, that.quoteChar)
+        && Objects.equals(escapeChar, that.escapeChar)
+        && Objects.equals(lineEnding, that.lineEnding)
+        && Objects.equals(maxNumberOfColumns, that.maxNumberOfColumns)
+        && Objects.equals(commentPrefix, that.commentPrefix);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        separator,
+        quoteChar,
+        escapeChar,
+        lineEnding,
+        maxNumberOfColumns,
+        commentPrefix,
+        lineSeparatorDetectionEnabled,
+        sampleSize);
   }
 
   public static Builder builder(Source source) {

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -318,6 +318,20 @@ public class TableTest {
   }
 
   @Test
+  void dropDuplicateRows2() {
+    Table t1 =
+        Table.read()
+            .csv(CsvReadOptions.builder(new File("../data/1950-2014_torn.csv")).sample(false));
+    t1 = t1.dropDuplicateRows();
+    Table t2 = t1.copy();
+    int rowCount = t1.rowCount();
+    t1.append(t2);
+    assertEquals(2 * rowCount, t1.rowCount());
+    t1 = t1.dropDuplicateRows();
+    assertEquals(rowCount, t1.rowCount());
+  }
+
+  @Test
   void dropDuplicateRowsWithMissingValue() {
     // Add 4 rows to the table, two of which are duplicates and have missing values.
     int missing = IntColumnType.missingValueIndicator();


### PR DESCRIPTION
…one that uses less memory

Thanks for contributing.

- [x ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

The method dropDuplicateRows was very inefficient in its use of memory. There was, by the end of the method:
- the original table
- a sorted copy of the original
- a copy of the sorted copy, without the duplicates  

Plus, the comparison method to test equality value-by-value used a generic method that auto boxed all the primitive values. 

This was replaced by a method that computes a hash function for the rows which is used to test for equality, eliminating the need for the sorted table copy.  Unfortunately, the auto boxing equality test remains at least for now, however. it is only called when duplicate rows are encountered, rather than for every row in the table.  

## Testing

Did you add a unit test?
yes
