### PR TITLE
eliminated the auto boxing of table values and row numbers

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
@@ -315,6 +315,12 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
 
   /** {@inheritDoc} */
   @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return getByte(rowNumber1) == getByte(rowNumber2);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public String getString(int row) {
     return formatter.format(get(row));
   }

--- a/core/src/main/java/tech/tablesaw/api/DateColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateColumn.java
@@ -638,6 +638,12 @@ public class DateColumn extends AbstractColumn<DateColumn, LocalDate>
     return getIntInternal(rowNumber);
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return getIntInternal(rowNumber1) == getIntInternal(rowNumber2);
+  }
+
   /**
    * Returns the contents of the cell at rowNumber as a byte[]
    *

--- a/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DateTimeColumn.java
@@ -76,6 +76,12 @@ public class DateTimeColumn extends AbstractColumn<DateTimeColumn, LocalDateTime
     return Long.hashCode(getLongInternal(rowNumber));
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return getLongInternal(rowNumber1) == getLongInternal(rowNumber2);
+  }
+
   private DateTimeColumn(String name, LongArrayList data) {
     super(DateTimeColumnType.instance(), name, DateTimeColumnType.DEFAULT_PARSER);
     this.data = data;

--- a/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/DoubleColumn.java
@@ -281,6 +281,12 @@ public class DoubleColumn extends NumberColumn<DoubleColumn, Double>
 
   /** {@inheritDoc} */
   @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return getDouble(rowNumber1) == getDouble(rowNumber2);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public DoubleColumn append(Double val) {
     if (val == null) {
       appendMissing();

--- a/core/src/main/java/tech/tablesaw/api/FloatColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/FloatColumn.java
@@ -39,6 +39,12 @@ public class FloatColumn extends NumberColumn<FloatColumn, Float> {
     return Float.hashCode(getFloat(rowNumber));
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return getFloat(rowNumber1) == getFloat(rowNumber2);
+  }
+
   public static FloatColumn create(String name) {
     return new FloatColumn(name, new FloatArrayList());
   }

--- a/core/src/main/java/tech/tablesaw/api/InstantColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/InstantColumn.java
@@ -71,6 +71,12 @@ public class InstantColumn extends AbstractColumn<InstantColumn, Instant>
     return Long.hashCode(getLongInternal(rowNumber));
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return getLongInternal(rowNumber1) == getLongInternal(rowNumber2);
+  }
+
   private final IntComparator comparator =
       (r1, r2) -> {
         long f1 = getPackedDateTime(r1);

--- a/core/src/main/java/tech/tablesaw/api/IntColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/IntColumn.java
@@ -100,6 +100,12 @@ public class IntColumn extends NumberColumn<IntColumn, Integer>
 
   /** {@inheritDoc} */
   @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return getInt(rowNumber1) == getInt(rowNumber2);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public void clear() {
     data.clear();
   }

--- a/core/src/main/java/tech/tablesaw/api/LongColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/LongColumn.java
@@ -36,6 +36,12 @@ public class LongColumn extends NumberColumn<LongColumn, Long> implements Catego
     return Long.hashCode(getLong(rowNumber));
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return getLong(rowNumber1) == getLong(rowNumber2);
+  }
+
   public static LongColumn create(final String name) {
     return new LongColumn(name, new LongArrayList());
   }

--- a/core/src/main/java/tech/tablesaw/api/ShortColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/ShortColumn.java
@@ -41,6 +41,12 @@ public class ShortColumn extends NumberColumn<ShortColumn, Short>
     return getShort(rowNumber);
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return getShort(rowNumber1) == getShort(rowNumber2);
+  }
+
   public static ShortColumn create(final String name) {
     return new ShortColumn(name, new ShortArrayList());
   }

--- a/core/src/main/java/tech/tablesaw/api/StringColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/StringColumn.java
@@ -15,8 +15,7 @@
 package tech.tablesaw.api;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.tablesaw.api.ColumnType.STRING;
-import static tech.tablesaw.api.ColumnType.TEXT;
+import static tech.tablesaw.api.ColumnType.*;
 
 import it.unimi.dsi.fastutil.ints.IntComparator;
 import java.util.ArrayList;
@@ -71,6 +70,12 @@ public class StringColumn extends AbstractStringColumn<StringColumn> {
   @Override
   public int valueHash(int rowNumber) {
     return get(rowNumber).hashCode();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return getDictionary().getKeyAtIndex(rowNumber1) == getDictionary().getKeyAtIndex(rowNumber2);
   }
 
   public static StringColumn create(String name) {

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -25,9 +25,7 @@ import com.google.common.collect.*;
 import com.google.common.primitives.Ints;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntArrays;
-import it.unimi.dsi.fastutil.ints.IntComparator;
+import it.unimi.dsi.fastutil.ints.*;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -559,13 +557,8 @@ public class Table extends Relation implements Iterable<Row> {
     }
     boolean result;
     for (int columnIndex = 0; columnIndex < row1.columnCount(); columnIndex++) {
-      ColumnType columnType = row1.getColumnType(columnIndex);
-      result =
-          columnType.compare(
-              row1.getRowNumber(),
-              row1.column(columnIndex),
-              row2.getRowNumber(),
-              row2.column(columnIndex));
+      Column<?> c = column(columnIndex);
+      result = c.equals(row1.getRowNumber(), row2.getRowNumber());
       if (!result) {
         return false;
       }
@@ -940,7 +933,8 @@ public class Table extends Relation implements Iterable<Row> {
   public Table dropDuplicateRows() {
 
     Table temp = emptyCopy();
-    ListMultimap<Integer, Integer> uniqueHashes = ArrayListMultimap.create();
+    Int2ObjectMap<IntArrayList> uniqueHashes = new Int2ObjectOpenHashMap<>();
+    // ListMultimap<Integer, Integer> uniqueHashes = ArrayListMultimap.create();
     for (Row row : this) {
       if (!isDuplicate(row, uniqueHashes)) {
         temp.append(row);
@@ -959,22 +953,24 @@ public class Table extends Relation implements Iterable<Row> {
    *     list, so that there are exemplars for both
    * @return true if the row's values exactly match a row that was previously seen
    */
-  private boolean isDuplicate(Row row, ListMultimap<Integer, Integer> uniqueHashes) {
-    Integer hash = row.rowHash();
+  private boolean isDuplicate(Row row, Int2ObjectMap<IntArrayList> uniqueHashes) {
+    int hash = row.rowHash();
     if (!uniqueHashes.containsKey(hash)) {
-      uniqueHashes.put(hash, row.getRowNumber());
+      IntArrayList rowNumbers = new IntArrayList();
+      rowNumbers.add(row.getRowNumber());
+      uniqueHashes.put(hash, rowNumbers);
       return false;
     }
 
     // the hashmap contains the hash, make sure the actual row values match
-    List<Integer> matchingKeys = uniqueHashes.get(hash);
+    IntArrayList matchingKeys = uniqueHashes.get(hash);
 
-    for (Integer key : matchingKeys) {
+    for (int key : matchingKeys) {
       Row oldRow = this.row(key);
       if (duplicateRows(row, oldRow)) {
         return true;
       } else {
-        uniqueHashes.put(hash, row.getRowNumber());
+        uniqueHashes.get(hash).add(row.getRowNumber());
         return false;
       }
     }

--- a/core/src/main/java/tech/tablesaw/api/TextColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TextColumn.java
@@ -64,6 +64,12 @@ public class TextColumn extends AbstractStringColumn<TextColumn> {
     return get(rowNumber).hashCode();
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return get(rowNumber1).equals(get(rowNumber2));
+  }
+
   private TextColumn(String name, Collection<String> strings) {
     super(TextColumnType.instance(), name, TextColumnType.DEFAULT_PARSER);
     values = new ArrayList<>(strings.size());

--- a/core/src/main/java/tech/tablesaw/api/TimeColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/TimeColumn.java
@@ -68,6 +68,12 @@ public class TimeColumn extends AbstractColumn<TimeColumn, LocalTime>
     return getIntInternal(rowNumber);
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(int rowNumber1, int rowNumber2) {
+    return getIntInternal(rowNumber1) == getIntInternal(rowNumber2);
+  }
+
   private TimeColumn(String name, IntArrayList times) {
     super(TimeColumnType.instance(), name, TimeColumnType.DEFAULT_PARSER);
     data = times;

--- a/core/src/main/java/tech/tablesaw/columns/Column.java
+++ b/core/src/main/java/tech/tablesaw/columns/Column.java
@@ -641,6 +641,9 @@ public interface Column<T> extends Iterable<T>, Comparator<T> {
   /** Returns an int suitable as a hash for the value in this column at the given index */
   int valueHash(int rowNumber);
 
+  /** Returns true if the value in this column at rowNumber1 is equal to the value at rowNumber2 */
+  boolean equals(int rowNumber1, int rowNumber2);
+
   /** Returns a new column containing the subset referenced by the {@link Selection} */
   Column<T> where(Selection selection);
 

--- a/core/src/main/java/tech/tablesaw/columns/strings/ByteDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/ByteDictionaryMap.java
@@ -65,6 +65,12 @@ public class ByteDictionaryMap implements DictionaryMap {
   // the map with counts
   private Byte2IntOpenHashMap keyToCount = new Byte2IntOpenHashMap();
 
+  /** {@inheritDoc} */
+  @Override
+  public int getKeyAtIndex(int rowNumber) {
+    return values.getByte(rowNumber);
+  }
+
   public ByteDictionaryMap() {
     valueToKey.defaultReturnValue(DEFAULT_RETURN_VALUE);
     keyToCount.defaultReturnValue(0);

--- a/core/src/main/java/tech/tablesaw/columns/strings/DictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/DictionaryMap.java
@@ -21,6 +21,9 @@ public interface DictionaryMap {
 
   void sortAscending();
 
+  /** Returns the int that represents the string at rowNumber */
+  int getKeyAtIndex(int rowNumber);
+
   String getValueForKey(int key);
 
   int size();

--- a/core/src/main/java/tech/tablesaw/columns/strings/IntDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/IntDictionaryMap.java
@@ -160,6 +160,12 @@ public class IntDictionaryMap implements DictionaryMap {
     this.values = new IntArrayList(elements);
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public int getKeyAtIndex(int rowNumber) {
+    return values.getInt(rowNumber);
+  }
+
   @Override
   public String getValueForKey(int key) {
     return keyToValue.get(key);

--- a/core/src/main/java/tech/tablesaw/columns/strings/ShortDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/ShortDictionaryMap.java
@@ -64,6 +64,12 @@ public class ShortDictionaryMap implements DictionaryMap {
 
   private Short2IntOpenHashMap keyToCount = new Short2IntOpenHashMap();
 
+  /** {@inheritDoc} */
+  @Override
+  public int getKeyAtIndex(int rowNumber) {
+    return values.getShort(rowNumber);
+  }
+
   /** Returns a new DictionaryMap that is a deep copy of the original */
   ShortDictionaryMap(ByteDictionaryMap original) throws NoKeysAvailableException {
     valueToKey.defaultReturnValue(DEFAULT_RETURN_VALUE);


### PR DESCRIPTION
Thanks for contributing.

- [ ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

added method to Column Interface for comparing values from two different rows for equality, used it to avoid auto-boxing

used fastutil classes to make a multi map so we don't auto-box row indexes and hash codes.

## Testing

Did you add a unit test? No.
