### PR TITLE
Add displayLogo option to jsplot Config

### DIFF
--- a/jsplot/src/main/java/tech/tablesaw/plotly/components/Config.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/components/Config.java
@@ -7,10 +7,12 @@ public class Config extends Component {
 
   private final Boolean displayModeBar;
   private final Boolean responsive;
+  private final Boolean displayLogo;
 
   private Config(Builder builder) {
     this.displayModeBar = builder.displayModeBar;
     this.responsive = builder.responsive;
+    this.displayLogo = builder.displayLogo;
   }
 
   public static Builder builder() {
@@ -32,6 +34,7 @@ public class Config extends Component {
     Map<String, Object> context = new HashMap<>();
     context.put("displayModeBar", displayModeBar);
     context.put("responsive", responsive);
+    context.put("displaylogo", displayLogo);
     return context;
   }
 
@@ -39,6 +42,7 @@ public class Config extends Component {
 
     Boolean displayModeBar;
     Boolean responsive;
+    Boolean displayLogo;
 
     private Builder() {}
 
@@ -49,6 +53,11 @@ public class Config extends Component {
 
     public Builder responsive(boolean responsive) {
       this.responsive = responsive;
+      return this;
+    }
+
+    public Builder displayLogo(boolean displayLogo) {
+      this.displayLogo = displayLogo;
       return this;
     }
 

--- a/jsplot/src/test/java/tech/tablesaw/plotly/components/ConfigTest.java
+++ b/jsplot/src/test/java/tech/tablesaw/plotly/components/ConfigTest.java
@@ -37,5 +37,17 @@ public class ConfigTest {
       Config config = Config.builder().build();
       assertFalse(config.asJavascript().contains("responsive"));
     }
+    {
+      Config config = Config.builder().displayLogo(true).build();
+      assertTrue(config.asJavascript().contains("\"displaylogo\" : true"));
+    }
+    {
+      Config config = Config.builder().displayLogo(false).build();
+      assertTrue(config.asJavascript().contains("\"displaylogo\" : false"));
+    }
+    {
+      Config config = Config.builder().build();
+      assertFalse(config.asJavascript().contains("displaylogo"));
+    }
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Added a `displayLogo` `Config` option to show or hide plot.ly logo in jsplot plots.

## Testing

Added asserts in `ConfigTest` for the new `displayLogo` option.
