### PR TITLE
removed shade plugin from 1.0 branch.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -69,23 +69,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>shaded</shadedClassifierName>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/docs-src/pom.xml
+++ b/docs-src/pom.xml
@@ -39,23 +39,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>shaded</shadedClassifierName>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.github.ryancerf</groupId>
                 <artifactId>choss-maven-plugin</artifactId>
                 <version>v0.02</version>

--- a/excel/pom.xml
+++ b/excel/pom.xml
@@ -58,23 +58,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
-      <plugin>
-           <groupId>org.apache.maven.plugins</groupId>
-           <artifactId>maven-shade-plugin</artifactId>
-           <version>3.1.0</version>
-           <configuration>
-               <shadedArtifactAttached>true</shadedArtifactAttached>
-               <shadedClassifierName>shaded</shadedClassifierName>
-           </configuration>
-           <executions>
-               <execution>
-                   <phase>package</phase>
-                   <goals>
-                       <goal>shade</goal>
-                   </goals>
-               </execution>
-           </executions>
-       </plugin>      
     </plugins>
   </build>
 

--- a/html/pom.xml
+++ b/html/pom.xml
@@ -57,23 +57,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
-      <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-shade-plugin</artifactId>
-         <version>3.1.0</version>
-         <configuration>
-             <shadedArtifactAttached>true</shadedArtifactAttached>
-             <shadedClassifierName>shaded</shadedClassifierName>
-         </configuration>
-         <executions>
-             <execution>
-                 <phase>package</phase>
-                 <goals>
-                     <goal>shade</goal>
-                 </goals>
-             </execution>
-         </executions>
-      </plugin>      
     </plugins>
   </build>
 

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -57,23 +57,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.0</version>
-          <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>shaded</shadedClassifierName>
-          </configuration>
-          <executions>
-              <execution>
-                  <phase>package</phase>
-                  <goals>
-                      <goal>shade</goal>
-                  </goals>
-              </execution>
-          </executions>
-      </plugin>      
     </plugins>
   </build>
 

--- a/jsplot/pom.xml
+++ b/jsplot/pom.xml
@@ -58,31 +58,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>       
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>shaded</shadedClassifierName>
-                    <artifactSet>
-                        <includes>
-                            <include>io.pebbletemplates:pebble</include>
-                            <include>org.unbescape:unbescape</include>
-                            <include>com.coverity.security:coverity-escapers</include>
-                            <include>org.slf4j:slf4j-api</include>
-                        </includes>
-                    </artifactSet>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/saw/pom.xml
+++ b/saw/pom.xml
@@ -57,23 +57,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.0</version>
-          <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>shaded</shadedClassifierName>
-          </configuration>
-          <executions>
-              <execution>
-                  <phase>package</phase>
-                  <goals>
-                      <goal>shade</goal>
-                  </goals>
-              </execution>
-          </executions>
-      </plugin>      
     </plugins>
   </build>
 


### PR DESCRIPTION
Shade breaks module encapsulation and we want to move in the direction of support for Java modules

Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Removed shade plugin references from the 1.0 branch only.

## Testing

Did you add a unit test? No
