### PR TITLE
Update Layout.java

### DIFF
--- a/jsplot/src/main/java/tech/tablesaw/plotly/components/Layout.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/components/Layout.java
@@ -21,7 +21,7 @@ public class Layout {
   private static final String DEFAULT_DECIMAL_SEPARATOR = ".";
   private static final String DEFAULT_THOUSANDS_SEPARATOR = ",";
   private static final boolean DEFAULT_AUTO_SIZE = false;
-  private static final HoverMode DEFAULT_HOVER_MODE = HoverMode.FALSE;
+  private static final HoverMode DEFAULT_HOVER_MODE = HoverMode.CLOSEST;
   private static final DragMode DEFAULT_DRAG_MODE = DragMode.ZOOM;
   private static final int DEFAULT_HOVER_DISTANCE = 20;
   private static final BarMode DEFAULT_BAR_MODE = BarMode.GROUP;


### PR DESCRIPTION
The default value for overmode in plotly is not FALSE but CLOSEST.
The actual behavior prevent us from using FALSE hovermode

Thanks for contributing.

- [ ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

What was changed

## Testing

Did you add a unit test?
