### PR TITLE
bugfix: determine columnType using precision

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
+++ b/core/src/main/java/tech/tablesaw/io/jdbc/SqlResultSetReader.java
@@ -170,11 +170,11 @@ public class SqlResultSetReader {
           }
         }
       } else { // s is not zero, so a decimal value is expected. First try float, then double
-        if (scale <= 7) {
+        if (precision <= 6) {
           type = ColumnType.FLOAT;
-        } else if (scale <= 16) {
+        } else if (precision <= 15) {
           type = ColumnType.DOUBLE;
-        }
+        } 
       }
     }
     return type;


### PR DESCRIPTION
using precision instead of scale to determin columnType is float or double.
e.g. current logic will treat 432246582.082388 (scale=6, precision =15) as float, instead, it should be double

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)