### PR TITLE
Support for multiple grouped / aggregated columns in pivoting

### DIFF
--- a/core/src/main/java/tech/tablesaw/aggregate/PivotTable.java
+++ b/core/src/main/java/tech/tablesaw/aggregate/PivotTable.java
@@ -3,10 +3,15 @@ package tech.tablesaw.aggregate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.LinkedList;
 import java.util.Map;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
 import tech.tablesaw.api.CategoricalColumn;
 import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.NumericColumn;
+import tech.tablesaw.columns.Column;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.table.TableSlice;
 import tech.tablesaw.table.TableSliceGroup;
@@ -36,66 +41,123 @@ public class PivotTable {
    *     subgroups
    * @return A new, pivoted table
    */
+  
+
   public static Table pivot(
       Table table,
-      CategoricalColumn<?> column1,
-      CategoricalColumn<?> column2,
-      NumericColumn<?> values,
+      CategoricalColumn<?> groupingColumn,
+      CategoricalColumn<?> pivotColumn,
+      NumericColumn<?> aggregatedColumns,
       AggregateFunction<?, ?> aggregateFunction) {
 
-    TableSliceGroup tsg = table.splitOn(column1);
+      return pivot(table, List.of(groupingColumn), pivotColumn, List.of(aggregatedColumns), aggregateFunction);
+  }
+      
+      
+  public static Table pivot(
+      Table table,
+      List<CategoricalColumn<?>> groupingColumns,
+      CategoricalColumn<?> pivotColumn,
+      List<NumericColumn<?>> aggregatedColumns,
+      AggregateFunction<?, ?> aggregateFunction) {
 
-    Table pivotTable = Table.create("Pivot: " + column1.name() + " x " + column2.name());
-    pivotTable.addColumns(column1.type().create(column1.name()));
+    boolean multiAggregated = aggregatedColumns.size() > 1;
 
-    List<String> valueColumnNames = getValueColumnNames(table, column2);
+    TableSliceGroup tsg = table.splitOn(groupingColumns.toArray(CategoricalColumn[]::new));
 
-    for (String colName : valueColumnNames) {
-      pivotTable.addColumns(DoubleColumn.create(colName));
+    List<String> groupingColumnNames = groupingColumns.stream().map(_c -> _c.name()).collect(Collectors.toList());
+
+    Table pivotTable = Table.create("Pivot: " + String.join(",", groupingColumnNames)  + " x " + pivotColumn.name());
+
+    pivotTable.addColumns(groupingColumns.stream().map(_c -> _c.type().create(_c.name())).toArray(Column[]::new));
+
+    List<String> valueColumnNames = getValueColumnNames(table, pivotColumn);
+
+    if(multiAggregated){
+      for (String colName : valueColumnNames) 
+        for(NumericColumn<?> aggColumn : aggregatedColumns) {
+        pivotTable.addColumns(DoubleColumn.create(colName + "." + aggColumn.name()));
+      }
     }
-
-    int valueIndex = table.columnIndex(column2);
-    int keyIndex = table.columnIndex(column1);
-
-    String key;
-
-    for (TableSlice slice : tsg.getSlices()) {
-      key = String.valueOf(slice.get(0, keyIndex));
-      pivotTable.column(0).appendCell(key);
-
-      Map<String, Double> valueMap =
-          getValueMap(column1, column2, values, valueIndex, slice, aggregateFunction);
-
-      for (String columnName : valueColumnNames) {
-        Double aDouble = valueMap.get(columnName);
-        NumericColumn<?> pivotValueColumn = pivotTable.numberColumn(columnName);
-        if (aDouble == null) {
-          pivotValueColumn.appendMissing();
-        } else {
-          pivotValueColumn.appendObj(aDouble);
-        }
+    else{
+      for (String colName : valueColumnNames) {
+        pivotTable.addColumns(DoubleColumn.create(colName));
       }
     }
 
+    for (TableSlice slice : tsg.getSlices()) {
+
+      for (int i = 0; i < groupingColumns.size(); i++) {
+        String key = String.valueOf(slice.get(0, table.columnIndex(groupingColumns.get(i))));
+        pivotTable.column(i).appendCell(key);
+      }
+
+      Map<String, Double> valueMap =
+          getValueMap(groupingColumns, pivotColumn, aggregatedColumns, slice, aggregateFunction);
+
+      for (String columnName : valueColumnNames) {
+          for (NumericColumn<?> aggregatedColumn: aggregatedColumns) {
+            
+            String appendedColumnName;
+
+            if(multiAggregated){
+              appendedColumnName = columnName + "." + aggregatedColumn.name();
+            } else {
+              appendedColumnName = columnName;
+            }
+            
+            NumericColumn<?> pivotValueColumn = pivotTable.numberColumn(appendedColumnName);
+            
+            Double aDouble = valueMap.get(appendedColumnName);
+
+            if (aDouble == null) {
+              pivotValueColumn.appendMissing();
+            } else {
+              pivotValueColumn.appendObj(aDouble);
+            }
+          }
+        }  
+
+    }
+    
     return pivotTable;
   }
 
   private static Map<String, Double> getValueMap(
-      CategoricalColumn<?> column1,
-      CategoricalColumn<?> column2,
-      NumericColumn<?> values,
-      int valueIndex,
+      List<CategoricalColumn<?>> groupingColumns,
+      CategoricalColumn<?> pivotColumn,
+      List<NumericColumn<?>> aggregatedColumns,
       TableSlice slice,
       AggregateFunction<?, ?> function) {
 
     Table temp = slice.asTable();
-    Table summary = temp.summarize(values.name(), function).by(column1.name(), column2.name());
+    List<CategoricalColumn<?>> allKeyColumns = new LinkedList<>(groupingColumns);
+    allKeyColumns.add(pivotColumn);
+
+    List<String> aggregatedColumnNames = aggregatedColumns.stream().map(NumericColumn::name).collect(Collectors.toList());
+
+    Table summary = temp.summarize(aggregatedColumnNames, function).by(allKeyColumns.stream().map(CategoricalColumn::name).toArray(String[]::new));
 
     Map<String, Double> valueMap = new HashMap<>();
-    NumericColumn<?> nc = summary.numberColumn(summary.columnCount() - 1);
-    for (int i = 0; i < summary.rowCount(); i++) {
-      valueMap.put(String.valueOf(summary.get(i, 1)), nc.getDouble(i));
+
+    
+    if(aggregatedColumns.size() == 1){
+
+      NumericColumn<?> nc = summary.numberColumn(summary.columnCount() - 1);
+      for (int i = 0; i < summary.rowCount(); i++) {
+        valueMap.put(String.valueOf(summary.get(i, groupingColumns.size())), nc.getDouble(i));
+      }
+
     }
+    else{
+      for (int i = 0; i < summary.rowCount(); i++) {
+        for (int k = 0; k < aggregatedColumns.size(); k++) {
+          NumericColumn<?> nc = summary.numberColumn(groupingColumns.size() + k + 1);
+          valueMap.put(String.valueOf(summary.get(i, groupingColumns.size())) + "." + aggregatedColumns.get(k).name(), nc.getDouble(i));
+        }
+      }
+    }
+
     return valueMap;
   }
 

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -864,19 +864,41 @@ public class Table extends Relation implements Iterable<Row> {
     return newTable;
   }
 
-  /**
+
+  public Table pivot(
+    List<CategoricalColumn<?>> groupingColumn,
+    CategoricalColumn<?> pivotColumn,
+    List<NumericColumn<?>> aggregatedColumn,
+    AggregateFunction<?, ?> aggregateFunction) {
+    return PivotTable.pivot(this, groupingColumn, pivotColumn, aggregatedColumn, aggregateFunction);
+  }
+
+  public Table pivot(
+      List<String> groupingColumnNames,
+      String pivotColumnName,
+      List<String> aggregatedColumnNames,
+      AggregateFunction<?, ?> aggregateFunction) {
+        return pivot(
+            groupingColumnNames.stream().map(this::categoricalColumn).collect(Collectors.toList()),
+            categoricalColumn(pivotColumnName),
+            aggregatedColumnNames.stream().map(this::numberColumn).collect(Collectors.toList()),
+            aggregateFunction);
+  }
+
+    /**
    * Returns a pivot on this table, where: The first column contains unique values from the index
    * column1 There are n additional columns, one for each unique value in column2 The values in each
    * of the cells in these new columns are the result of applying the given AggregateFunction to the
    * data in column3, grouped by the values of column1 and column2
    */
   public Table pivot(
-      CategoricalColumn<?> column1,
-      CategoricalColumn<?> column2,
-      NumericColumn<?> column3,
+      CategoricalColumn<?> groupingColumn,
+      CategoricalColumn<?> pivotColumn,
+      NumericColumn<?> aggregatedColumn,
       AggregateFunction<?, ?> aggregateFunction) {
-    return PivotTable.pivot(this, column1, column2, column3, aggregateFunction);
+    return PivotTable.pivot(this, groupingColumn, pivotColumn, aggregatedColumn, aggregateFunction);
   }
+
 
   /**
    * Returns a pivot on this table, where: The first column contains unique values from the index
@@ -885,14 +907,14 @@ public class Table extends Relation implements Iterable<Row> {
    * data in column3, grouped by the values of column1 and column2
    */
   public Table pivot(
-      String column1Name,
-      String column2Name,
-      String column3Name,
+      String groupingColumnName,
+      String pivotColumnName,
+      String aggregatedColumnName,
       AggregateFunction<?, ?> aggregateFunction) {
     return pivot(
-        categoricalColumn(column1Name),
-        categoricalColumn(column2Name),
-        numberColumn(column3Name),
+        categoricalColumn(groupingColumnName),
+        categoricalColumn(pivotColumnName),
+        numberColumn(pivotColumnName),
         aggregateFunction);
   }
 

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -865,14 +865,44 @@ public class Table extends Relation implements Iterable<Row> {
   }
 
 
+  /**
+   * Returns a new column, where the first n columns are the groupingColumns. There are then p additional
+   * columns, which is the product of each unique value in the pivot column and aggregatedColumn. The 
+   * values in each of the cells in these new columns are the result of applying the given AggregateFunction 
+   * to the data in each of aggregatedColumn, grouped by the values of groupingColumn and pivotColumn.
+   * 
+   * If more than one aggregatedColumn is provided then each is appended to each unique value of the pivot
+   * column in the format "{PivotColumnValue}.{AggregatedColumnName}
+   * 
+   * @param groupingColumn
+   * @param pivotColumn
+   * @param aggregatedColumn
+   * @param aggregateFunction
+   * @return
+   */
   public Table pivot(
-    List<CategoricalColumn<?>> groupingColumn,
+    List<CategoricalColumn<?>> groupingColumns,
     CategoricalColumn<?> pivotColumn,
-    List<NumericColumn<?>> aggregatedColumn,
+    List<NumericColumn<?>> aggregatedColumns,
     AggregateFunction<?, ?> aggregateFunction) {
-    return PivotTable.pivot(this, groupingColumn, pivotColumn, aggregatedColumn, aggregateFunction);
+    return PivotTable.pivot(this, groupingColumns, pivotColumn, aggregatedColumns, aggregateFunction);
   }
 
+  /**
+   * Returns a new column, where the first n columns are the groupingColumns. There are then p additional
+   * columns, which is the product of each unique value in the pivot column and aggregatedColumn. The 
+   * values in each of the cells in these new columns are the result of applying the given AggregateFunction 
+   * to the data in each of aggregatedColumn, grouped by the values of groupingColumn and pivotColumn.
+   * 
+   * If more than one aggregatedColumn is provided then each is appended to each unique value of the pivot
+   * column in the format "{PivotColumnValue}.{AggregatedColumnName}
+   * 
+   * @param groupingColumnNames
+   * @param pivotColumnName
+   * @param aggregatedColumnNames
+   * @param aggregateFunction
+   * @return
+   */
   public Table pivot(
       List<String> groupingColumnNames,
       String pivotColumnName,
@@ -887,9 +917,9 @@ public class Table extends Relation implements Iterable<Row> {
 
     /**
    * Returns a pivot on this table, where: The first column contains unique values from the index
-   * column1 There are n additional columns, one for each unique value in column2 The values in each
-   * of the cells in these new columns are the result of applying the given AggregateFunction to the
-   * data in column3, grouped by the values of column1 and column2
+   * groupingColumn There are n additional columns, one for each unique value in the pivotColumn. The 
+   * values in each of the cells in these new columns are the result of applying the given AggregateFunction 
+   * to the data in the aggregatedColumn, grouped by the values of groupingColumn and pivotColumn
    */
   public Table pivot(
       CategoricalColumn<?> groupingColumn,
@@ -902,9 +932,9 @@ public class Table extends Relation implements Iterable<Row> {
 
   /**
    * Returns a pivot on this table, where: The first column contains unique values from the index
-   * column1 There are n additional columns, one for each unique value in column2 The values in each
-   * of the cells in these new columns are the result of applying the given AggregateFunction to the
-   * data in column3, grouped by the values of column1 and column2
+   * groupingColumn There are n additional columns, one for each unique value in the pivotColumn The 
+   * values in each of the cells in these new columns are the result of applying the given AggregateFunction 
+   * to the data in the aggregatedColumn, grouped by the values of groupingColumn and pivotColumn
    */
   public Table pivot(
       String groupingColumnName,

--- a/core/src/test/java/tech/tablesaw/aggregate/PivotTableTest.java
+++ b/core/src/test/java/tech/tablesaw/aggregate/PivotTableTest.java
@@ -6,11 +6,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.csv.CsvReadOptions;
+import java.util.List;
 
 public class PivotTableTest {
 
+  /**
+   * Illustrate usage of pivot function with a single grouping, pivot and aggregated columns
+   * @throws Exception
+   */
   @Test
-  public void pivot() throws Exception {
+  public void pivotSingle() throws Exception {
     Table t =
         Table.read()
             .csv(CsvReadOptions.builder("../data/bush.csv").missingValueIndicator(":").build());
@@ -30,4 +35,72 @@ public class PivotTableTest {
     assertTrue(pivot.columnNames().contains("2004"));
     assertEquals(6, pivot.rowCount());
   }
+  
+
+  @Test
+  public void pivotMultipleGroupAndAggregate() throws Exception {
+    Table t =
+        Table.read()
+            .csv(CsvReadOptions.builder("../data/baseball.csv").build());
+
+    Table pivot =
+        t.pivot(
+            List.of("Team","League"),
+            "Year",
+            List.of("RS","RA","W"),
+            AggregateFunctions.mean);
+
+    assertTrue(pivot.columnNames().contains("Team"));
+    assertTrue(pivot.columnNames().contains("League"));
+    assertTrue(pivot.columnNames().contains("2001.RS"));
+    assertTrue(pivot.columnNames().contains("2001.RA"));
+    assertTrue(pivot.columnNames().contains("2001.W"));
+    assertEquals(143, pivot.columnCount());
+    assertEquals(40, pivot.rowCount());
+  }
+
+  @Test
+  public void pivotMultipleGroup() throws Exception {
+    Table t =
+        Table.read()
+            .csv(CsvReadOptions.builder("../data/baseball.csv").build());
+
+    Table pivot =
+        t.pivot(
+            List.of("Team","League"),
+            "Year",
+            List.of("RS"),
+            AggregateFunctions.mean);
+
+    assertTrue(pivot.columnNames().contains("Team"));
+    assertTrue(pivot.columnNames().contains("League"));
+    assertTrue(pivot.columnNames().contains("2001"));
+    assertTrue(pivot.columnNames().contains("2002"));
+    assertTrue(pivot.columnNames().contains("2003"));
+    assertEquals(49, pivot.columnCount());
+    assertEquals(40, pivot.rowCount());
+  }
+
+  @Test
+  public void pivotMultipleAggregate() throws Exception {
+    Table t =
+        Table.read()
+            .csv(CsvReadOptions.builder("../data/baseball.csv").build());
+
+    Table pivot =
+        t.pivot(
+            List.of("League"),
+            "Year",
+            List.of("RS","RA","W"),
+            AggregateFunctions.mean);
+
+    assertTrue(!pivot.columnNames().contains("Team"));
+    assertTrue(pivot.columnNames().contains("League"));
+    assertTrue(pivot.columnNames().contains("2001.RS"));
+    assertTrue(pivot.columnNames().contains("2001.RA"));
+    assertTrue(pivot.columnNames().contains("2001.W"));
+    assertEquals(142, pivot.columnCount());
+    assertEquals(2, pivot.rowCount());
+  }
+
 }


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

 - Added support for multiple grouping / aggregation columns via the pivot method. kept the old method contract as is but now delegates to shared logic
 - renamed column1/column2/column3 to groupedColumn/pivotColumn/aggregatedColumn to make it more
   obvious what the meaning of each argument is
- not entirely sure the approach of concatenating the pivot value with aggregated column name ie "2012.Score" is the best, open to suggestions here.

Note: first time contributing to a project on github so let me know if i've done something wrong

## Testing

yes added tests for 3 use cases 1) both multiple grouping and aggregation columns 2) multiple grouping and single aggregation 3) single grouping and 
