### PR TITLE
Take prefix/suffix TickSettings into account and add format option

### DIFF
--- a/jsplot/src/main/java/tech/tablesaw/plotly/components/TickSettings.java
+++ b/jsplot/src/main/java/tech/tablesaw/plotly/components/TickSettings.java
@@ -51,7 +51,7 @@ public class TickSettings {
 
   /** Controls the display of prefixes, suffixes, and exponents on ticks */
   public enum DisplayRules {
-    ALL("outside"),
+    ALL("all"),
     FIRST("first"),
     LAST("last"),
     NONE("none");
@@ -132,6 +132,7 @@ public class TickSettings {
   private final int angle;
   private final String prefix;
   private final String suffix;
+  private final String format;
   private final boolean autoMargin;
   private final DisplayRules showPrefix;
   private final DisplayRules showSuffix;
@@ -167,6 +168,7 @@ public class TickSettings {
     angle = builder.angle;
     prefix = builder.prefix;
     suffix = builder.suffix;
+    format = builder.format;
     mirror = builder.mirror;
     separateThousands = builder.separateThousands;
   }
@@ -204,6 +206,7 @@ public class TickSettings {
     context.put("suffix", suffix);
     context.put("showPrefix", showPrefix);
     context.put("showSuffix", showSuffix);
+    context.put("format", format);
     context.put("angle", angle);
     context.put("autoMargin", autoMargin);
     context.put("tickMode", tickMode);
@@ -239,6 +242,7 @@ public class TickSettings {
     private boolean autoMargin = true;
     private DisplayRules showPrefix = ALL;
     private DisplayRules showSuffix = ALL;
+    private String format;
     private Mirror mirror;
     private boolean separateThousands;
 
@@ -396,6 +400,11 @@ public class TickSettings {
 
     public TickSettings.TickSettingsBuilder suffix(String suffix) {
       this.suffix = suffix;
+      return this;
+    }
+
+    public TickSettings.TickSettingsBuilder format(String format) {
+      this.format = format;
       return this;
     }
 

--- a/jsplot/src/main/resources/axis_template.html
+++ b/jsplot/src/main/resources/axis_template.html
@@ -28,6 +28,21 @@
 {% if tick0 is not null %}
     tick0: '{{tick0}}',
 {% endif %}
+{% if showPrefix is not null %}
+    showtickprefix: '{{showPrefix}}',
+{% endif %}
+{% if showSuffix is not null %}
+    showticksuffix: '{{showSuffix}}',
+{% endif %}
+{% if prefix is not null %}
+    tickprefix: '{{prefix}}',
+{% endif %}
+{% if suffix is not null %}
+    ticksuffix: '{{suffix}}',
+{% endif %}
+{% if format is not null %}
+    tickformat: '{{format}}',
+{% endif %}
 {% if showExponent is not null %}
     showExponent: '{{showExponent}}',
 {% endif %}


### PR DESCRIPTION
Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

In tablesaw-jsplot, `AxisSettings.{prefix|suffix|showPrefix|showSuffix}` were not used in `axis_template.html`, making them useless.
I updated the template to use these options, and also added a `format` option matching plotly's `tickformat`.
I also fixed the value for `DisplayRules.ALL` from 'outside' to 'all'

## Testing

No new unit tests
