### PR TITLE
Fix not reading when the entire row is 0 (jtablesaw#1147)

### DIFF
--- a/excel/src/main/java/tech/tablesaw/io/xlsx/XlsxReader.java
+++ b/excel/src/main/java/tech/tablesaw/io/xlsx/XlsxReader.java
@@ -147,7 +147,7 @@ public class XlsxReader implements DataReader<XlsxReadOptions> {
       case NUMERIC:
         if (DateUtil.isCellDateFormatted(cell)
             ? cell.getDateCellValue() != null
-            : cell.getNumericCellValue() != 0) {
+            : cell.getNumericCellValue() != 0 || cell.getCellType() == NUMERIC) {
           return false;
         }
         break;


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

The underlying Apache library reads a blank cell as a 0. Therefore, when the value in a cell is 0, the previous logic cannot distinguish between a blank cell and a 0, which leads to ruling out the entire row where all cells are 0.

## Testing

No new tests added.
