### PR TITLE
fix(sec): upgrade pebble to 3.1.4

### DIFF
--- a/jsplot/pom.xml
+++ b/jsplot/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>io.pebbletemplates</groupId>
             <artifactId>pebble</artifactId>
-            <version>3.1.2</version>
+            <version>3.1.4</version>
         </dependency>
         <dependency>
             <groupId>tech.tablesaw</groupId>


### PR DESCRIPTION
Upgrade pebble 3.1.2 to 3.1.4 for vulnerability fix:
         - [CVE-2019-19899](https://www.oscs1024.com/hd/MPS-2019-16801)