### PR TITLE
Name to lowercase in renameDuplicateColumnHeaders

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/FileReader.java
+++ b/core/src/main/java/tech/tablesaw/io/FileReader.java
@@ -134,10 +134,10 @@ public abstract class FileReader {
       String name = headerNames[i];
       Integer count = nameCounter.get(name.toLowerCase());
       if (count == null) {
-        nameCounter.put(name, 1);
+        nameCounter.put(name.toLowerCase(), 1);
       } else {
         count++;
-        nameCounter.put(name, count);
+        nameCounter.put(name.toLowerCase(), count);
         headerNames[i] = name + "-" + count;
       }
     }

--- a/core/src/main/java/tech/tablesaw/io/FileReader.java
+++ b/core/src/main/java/tech/tablesaw/io/FileReader.java
@@ -132,7 +132,7 @@ public abstract class FileReader {
     Map<String, Integer> nameCounter = new HashMap<>();
     for (int i = 0; i < headerNames.length; i++) {
       String name = headerNames[i];
-      Integer count = nameCounter.get(name);
+      Integer count = nameCounter.get(name.toLowerCase());
       if (count == null) {
         nameCounter.put(name, 1);
       } else {


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

renameDuplicateColumnHeaders when allowDuplicateColumnNames is true is case sensitive which causes validateColumn(final Column<?> newColumn) to fail and throw IllegalArgumentException. 

What was changed

Used toLowerCase while using HashMap.
Also thought of using treeMap, but get() in treeMap has timecomplexity of O(log(n))

Did you add a unit test?
No