### PR TITLE
Change HashSet to LinkedHashSet for preserving key order in JSON data

### DIFF
--- a/json/src/main/java/tech/tablesaw/io/json/JsonReader.java
+++ b/json/src/main/java/tech/tablesaw/io/json/JsonReader.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.wnameless.json.flattener.JsonFlattener;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -103,7 +103,7 @@ public class JsonReader implements DataReader<JsonReadOptions> {
       throw new RuntimeIOException(e);
     }
 
-    Set<String> colNames = new HashSet<>();
+    Set<String> colNames = new LinkedHashSet<>();
     for (JsonNode row : flattenedJsonObj) {
       Iterator<String> fieldNames = row.fieldNames();
       while (fieldNames.hasNext()) {


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Change HashSet to LinkedHashSet for preserving key order in JSON data

## Testing

I want to read the following JSON, but after reading it and printing the table, the columns were unordered. However, I have made some changes so that the columns are now ordered.
```
    String json =
            "[{\"日期\":\"1991-04-03\",\"开盘\":49,\"收盘\":49,\"最高\":49,\"最低\":49,\"成交量\":1,\"成交额\":5000,\"振幅\":0,\"涨跌幅\":22.5,\"涨跌额\":9,\"换手率\":0},{\"日期\":\"1991-04-04\",\"开盘\":48.76,\"收盘\":48.76,\"最高\":48.76,\"最低\":48.76,\"成交量\":3,\"成交额\":15000,\"振幅\":0,\"涨跌幅\":-0.49,\"涨跌额\":-0.24,\"换手率\":0}]\n";

    JsonReader jsonReader = new JsonReader();
    Table table = jsonReader.read(Source.fromString(json));

    System.out.println(table.print());
```

before:
```
 成交量  |   最低    |   开盘    |   成交额   |   涨跌额   |   最高    |      日期      |  振幅  |   涨跌幅   |   收盘    |  换手率  |
-----------------------------------------------------------------------------------------------------------
   1  |     49  |     49  |   5000  |      9  |     49  |  1991-04-03  |   0  |   22.5  |     49  |    0  |
   3  |  48.76  |  48.76  |  15000  |  -0.24  |  48.76  |  1991-04-04  |   0  |  -0.49  |  48.76  |    0  |
```

after:

```
     日期      |   开盘    |   收盘    |   最高    |   最低    |  成交量  |   成交额   |  振幅  |   涨跌幅   |   涨跌额   |  换手率  |
-----------------------------------------------------------------------------------------------------------
 1991-04-03  |     49  |     49  |     49  |     49  |    1  |   5000  |   0  |   22.5  |      9  |    0  |
 1991-04-04  |  48.76  |  48.76  |  48.76  |  48.76  |    3  |  15000  |   0  |  -0.49  |  -0.24  |    0  |
```



