### PR TITLE
Correct BooleanColumn documentation

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
+++ b/core/src/main/java/tech/tablesaw/api/BooleanColumn.java
@@ -133,7 +133,7 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
   }
 
   /**
-   * Returns a new Boolean column of the given size. All elements are false
+   * Returns a new Boolean column of the given size.
    *
    * @param name The column name
    * @param initialSize The column size
@@ -422,7 +422,7 @@ public class BooleanColumn extends AbstractColumn<BooleanColumn, Boolean>
     return (double) countTrue() / (size() - countMissing());
   }
 
-  /** Returns the proportion of non-missing row elements that contain true */
+  /** Returns the proportion of non-missing row elements that contain false */
   public double proportionFalse() {
     return 1.0 - proportionTrue();
   }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

- Correct the documentation for the `create` method that takes a name and an initial size.  (This closes #1186.)
- Change "true" to "false" in the documentation for `proportionFalse()`.  
