### PR TITLE
Upgrading json-flattener version to latest 0.16.4 version

### DIFF
--- a/json/pom.xml
+++ b/json/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>com.github.wnameless.json</groupId>
       <artifactId>json-flattener</artifactId>
-      <version>0.8.1</version>
+      <version>0.16.4</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Upgraded `json-flattener` dependency to latest version 0.16.4 to remove the critical vulnerability in 0.8.1 version from `commons-text` version 1.8.0

## Testing

Did you add a unit test? No since this is dependency upgrade so no new unit test case is required.
