### PR TITLE
fix axis_template.html: add comma to range

### DIFF
--- a/jsplot/src/main/resources/axis_template.html
+++ b/jsplot/src/main/resources/axis_template.html
@@ -85,7 +85,7 @@
     type: '{{type}}',
 {% endif %}
 {% if range is not null %}
-    range: {{range | raw}}
+    range: {{range | raw}},
 {% endif %}
 {% if visible is not null %}
     visible: {{visible}},


### PR DESCRIPTION
Thanks for contributing.

- [ ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

What was changed:

fix axis_template.html: add comma to range
reference issue post: https://github.com/jtablesaw/tablesaw/issues/1192

summary: comma is not added to the body such that any html jsplot output using the range field fails to render, fix is just to add comma

## Testing

Did you add a unit test? No, it is not necessary
