### PR TITLE
Avoid read(URL) throwing NPE for invalid URLs

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/DataFrameReader.java
+++ b/core/src/main/java/tech/tablesaw/io/DataFrameReader.java
@@ -56,14 +56,13 @@ public class DataFrameReader {
    * mime-type Use {@link #usingOptions(ReadOptions) usingOptions} to use non-default options
    */
   public Table url(URL url) {
-    URLConnection connection = null;
     try {
-      connection = url.openConnection();
+      URLConnection connection = url.openConnection();
+      String contentType = connection.getContentType();
+      return url(url, getCharset(contentType), getMimeType(contentType));
     } catch (IOException e) {
-      e.printStackTrace();
+        throw new RuntimeIOException(e);
     }
-    String contentType = connection.getContentType();
-    return url(url, getCharset(contentType), getMimeType(contentType));
   }
 
   private Table url(URL url, Charset charset, String mimeType) {
@@ -87,11 +86,13 @@ public class DataFrameReader {
   }
 
   private String getMimeType(String contentType) {
+    if(contentType == null) return null;
     String[] pair = contentType.split(";");
     return pair[0].trim();
   }
 
   private Charset getCharset(String contentType) {
+    if(contentType == null) return Charset.defaultCharset();
     String[] pair = contentType.split(";");
     return pair.length == 1
         ? Charset.defaultCharset()

--- a/core/src/test/java/tech/tablesaw/io/DataFrameReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/DataFrameReaderTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -80,5 +81,17 @@ class DataFrameReaderTest {
         thrown
             .getMessage()
             .contains("No reader registered for mime-type application/octet-stream"));
+  }
+  
+  @Test
+  void readInvalidURL() throws MalformedURLException {
+      final URL url = new URL("ftp://not-a-host/data.csv");
+      assertThrows(RuntimeIOException.class, () -> Table.read().url(url));
+  }
+
+  @Test
+  void readInvalidURLNoExtension() throws MalformedURLException {
+      final URL url = new URL("ftp://not-a-host/data/csv");
+      assertThrows(IllegalArgumentException.class, () -> Table.read().url(url));
   }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

If `DataFrameReader.read(URL)` is called with an invalid URL a NPE is thrown. Code refactored to throw either RuntimeIOException (when the URL has a known file extension) or IllegalArgumentException if not.

## Testing

Yes
