### PR TITLE
Fix empty csv test

### DIFF
--- a/core/src/main/java/tech/tablesaw/io/FileReader.java
+++ b/core/src/main/java/tech/tablesaw/io/FileReader.java
@@ -94,6 +94,12 @@ public abstract class FileReader {
     if (options.header()) {
 
       String[] headerNames = parser.parseNext();
+      
+      if (headerNames == null) {
+        // no header because file is empty
+        // return empty String[]
+        return new String[0];
+      }
 
       // work around issue where Univocity returns null if a column has no header.
       for (int i = 0; i < headerNames.length; i++) {

--- a/core/src/main/java/tech/tablesaw/io/FileReader.java
+++ b/core/src/main/java/tech/tablesaw/io/FileReader.java
@@ -97,8 +97,7 @@ public abstract class FileReader {
       
       if (headerNames == null) {
         // no header because file is empty
-        // return empty String[]
-        return new String[0];
+        return new String[] {};
       }
 
       // work around issue where Univocity returns null if a column has no header.

--- a/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
+++ b/core/src/test/java/tech/tablesaw/io/csv/CsvReaderTest.java
@@ -756,7 +756,7 @@ public class CsvReaderTest {
 
   @Test
   public void testEmptyFileHeaderEnabled() throws IOException {
-    Table table1 = Table.read().csv(CsvReadOptions.builder("../data/empty_file.csv").header(false));
+    Table table1 = Table.read().csv(CsvReadOptions.builder("../data/empty_file.csv").header(true));
     assertEquals("empty_file.csv: 0 rows X 0 cols", table1.shape());
   }
 


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

- Fix `CSVReaderTest.testEmptyFileHeaderEnabled` by enabling header - disabled header tested in `testEmptyFileHeaderDisabled`
- Fix `FileReader.getColumnNames` to not throw NPE when header is enabled and file is empty

## Testing

Fixed one
