### PR TITLE
Fix drop duplicate rows

### DIFF
--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -340,12 +340,10 @@ public class TableTest {
 
   @Test
   void testDropDuplicateRows3() {
-    Table testTable =
-        Table.create("test")
-            .addColumns(
-                IntColumn.create("part_id", new int[] {1, 1, 1, 2, 2, 2}),
-                StringColumn.create(
-                    "nsequence", new String[] {"N40", "N50", "N60", "N40", "N50", "N60"}));
+    Table testTable = Table.create("test").addColumns(
+        IntColumn.create("part_id", new int[] {1, 1, 1, 2, 2, 2}),
+        StringColumn.create(
+            "nsequence", new String[] {"N40", "N50", "N60", "N40", "N50", "N60"}));
     Table testUnique = testTable.selectColumns("part_id", "nsequence").dropDuplicateRows();
     assertEquals(testTable.rowCount(), testUnique.rowCount());
   }

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -22,6 +22,9 @@ import static tech.tablesaw.api.ColumnType.DOUBLE;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.io.File;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -970,5 +973,20 @@ public class TableTest {
         IndexOutOfBoundsException.class,
         () -> Table.compareRows(lastRowNumber, missingValues, differentTable),
         "Row outside range does not throw exception");
+  }
+
+  @Test
+  void testDropDuplicateWithHashCollision() throws Exception {
+    Table testTable =
+        Table.read()
+            .usingOptions(
+                CsvReadOptions.builder(new File("../data/missing_values.csv"))
+                    .missingValueIndicator("-"));
+    Row row0 = testTable.row(0);
+    Int2ObjectMap<IntArrayList> uniqueHashes = new Int2ObjectOpenHashMap<>();
+    IntArrayList value = new IntArrayList(new int[] {1, 0});
+    uniqueHashes.put(row0.hashCode(), value);
+    boolean isDuplicate = testTable.isDuplicate(row0, uniqueHashes);
+    assertTrue(isDuplicate, "Duplicate row not found");
   }
 }

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -976,7 +976,7 @@ public class TableTest {
   }
 
   @Test
-  void testDropDuplicateWithHashCollision() throws Exception {
+  void testDropDuplicateWithHashCollision() {
     Table testTable =
         Table.read()
             .usingOptions(

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -977,11 +977,9 @@ public class TableTest {
 
   @Test
   void testDropDuplicateWithHashCollision() {
-    Table testTable =
-        Table.read()
-            .usingOptions(
-                CsvReadOptions.builder(new File("../data/missing_values.csv"))
-                    .missingValueIndicator("-"));
+    Table testTable = Table.read().usingOptions(CsvReadOptions
+      .builder(new File("../data/missing_values.csv"))
+      .missingValueIndicator("-"));
     Row row0 = testTable.row(0);
     Int2ObjectMap<IntArrayList> uniqueHashes = new Int2ObjectOpenHashMap<>();
     IntArrayList value = new IntArrayList(new int[] {1, 0});

--- a/core/src/test/java/tech/tablesaw/api/TableTest.java
+++ b/core/src/test/java/tech/tablesaw/api/TableTest.java
@@ -336,6 +336,18 @@ public class TableTest {
   }
 
   @Test
+  void testDropDuplicateRows3() {
+    Table testTable =
+        Table.create("test")
+            .addColumns(
+                IntColumn.create("part_id", new int[] {1, 1, 1, 2, 2, 2}),
+                StringColumn.create(
+                    "nsequence", new String[] {"N40", "N50", "N60", "N40", "N50", "N60"}));
+    Table testUnique = testTable.selectColumns("part_id", "nsequence").dropDuplicateRows();
+    assertEquals(testTable.rowCount(), testUnique.rowCount());
+  }
+
+  @Test
   void dropDuplicateRowsWithMissingValue() {
     // Add 4 rows to the table, two of which are duplicates and have missing values.
     int missing = IntColumnType.missingValueIndicator();


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Fixed issue with `Table.dropDuplicateRows` described in #1296 by reverting to using a custom map instead of a set of rows.

## Testing

Reported use case implemented as unit test. Added back testing of hash collision.
